### PR TITLE
libnvidia-container-tools: fix generation of compiled-in build info

### DIFF
--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.9.0/0004-Fix-build.h-generation-for-cross-builds.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.9.0/0004-Fix-build.h-generation-for-cross-builds.patch
@@ -1,0 +1,40 @@
+From 59ce7ceb66f3276874bf706b7cfd368af62a7e1b Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 27 Sep 2020 05:35:52 -0700
+Subject: [PATCH] Fix build.h generation for cross builds
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ Makefile     | 4 ++++
+ mk/common.mk | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index a574800..cd44c73 100644
+--- a/Makefile
++++ b/Makefile
+@@ -177,7 +177,11 @@ DEPENDENCIES   := $(BIN_OBJS:%.o=%.d) $(LIB_OBJS:%.lo=%.d)
+ $(BUILD_DEFS):
+ 	@printf '#define BUILD_DATE     "%s"\n' '$(strip $(DATE))' >$(BUILD_DEFS)
+ 	@printf '#define BUILD_COMPILER "%s " __VERSION__\n' '$(notdir $(COMPILER))' >>$(BUILD_DEFS)
++ifeq ($(EXCLUDE_BUILD_FLAGS),)
+ 	@printf '#define BUILD_FLAGS    "%s"\n' '$(strip $(CPPFLAGS) $(CFLAGS) $(LDFLAGS))' >>$(BUILD_DEFS)
++else
++	@printf '#define BUILD_FLAGS    ""\n' >>$(BUILD_DEFS)
++endif
+ 	@printf '#define BUILD_REVISION "%s"\n' '$(strip $(REVISION))' >>$(BUILD_DEFS)
+ 	@printf '#define BUILD_PLATFORM "%s"\n' '$(strip $(PLATFORM))' >>$(BUILD_DEFS)
+ 
+diff --git a/mk/common.mk b/mk/common.mk
+index 09987a3..5a03988 100644
+--- a/mk/common.mk
++++ b/mk/common.mk
+@@ -22,7 +22,7 @@ UID      := $(shell id -u)
+ GID      := $(shell id -g)
+ DATE     := $(shell date -u --iso-8601=minutes)
+ REVISION := $(shell git rev-parse HEAD)
+-COMPILER := $(realpath $(shell which $(CC)))
++COMPILER := $(realpath $(shell which $(firstword $(CC))))
+ PLATFORM ?= $(shell uname -m)
+ JETSON   ?= $(shell test -f /etc/nv_tegra_release && echo "TRUE")
+ 

--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
@@ -36,6 +36,7 @@ SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia;branch
            file://0001-Makefile-Fix-RCP-flags-and-change-path-definitions-s.patch \
            file://0002-common.mk-Set-JETSON-variable-if-not-set-before.patch \
            file://0003-Fix-mapping-of-library-paths-for-jetson-mounts.patch \
+           file://0004-Fix-build.h-generation-for-cross-builds.patch \
            "
 
 SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
@@ -49,11 +50,19 @@ SRCREV_modprobe = "d97c08af5061f1516fb2e3a26508936f69d6d71d"
 S = "${WORKDIR}/git"
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[seccomp] = " WITH_SECCOMP=yes , WITH_SECCOMP=no ,libseccomp"
+PACKAGECONFIG[seccomp] = "WITH_SECCOMP=yes,WITH_SECCOMP=no,libseccomp"
+
+def build_date(d):
+    import datetime
+    epoch = d.getVar('SOURCE_DATE_EPOCH')
+    if epoch:
+        dt = datetime.datetime.fromtimestamp(int(epoch), tz=datetime.timezone.utc)
+        return 'DATE=' + dt.isoformat(timespec='minutes')
+    return ''
 
 # We need to link with libelf, otherwise we need to
 # include bmake-native which does not exist at the moment.
-EXTRA_OEMAKE_append = " WITH_LIBELF=yes JETSON=TRUE ${PACKAGECONFIG_CONFARGS}"
+EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
 
 CFLAGS_prepend = " -I=/usr/include/tirpc "
 


### PR DESCRIPTION
Patch the makefile and update the recipe to alter how the compiled-in
build information is generated.  This should fix failures on certain
build hosts and better support reproducible builds.

Fixes #429 

Signed-off-by: Matt Madison <matt@madison.systems>