### PR TITLE
Fix CUDA include directories

### DIFF
--- a/classes/cuda.bbclass
+++ b/classes/cuda.bbclass
@@ -59,8 +59,9 @@ cmake_do_generate_toolchain_file_append_cuda() {
     cat >> ${WORKDIR}/toolchain.cmake <<EOF
 set(CMAKE_CUDA_TOOLKIT_ROOT_DIR "${STAGING_DIR_NATIVE}/usr/local/cuda-${CUDA_VERSION}" CACHE PATH "" FORCE)
 set(CMAKE_CUDA_TOOLKIT_TARGET_DIR "${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}" CACHE PATH "" FORCE)
-set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "${CMAKE_CUDA_TOOLKIT_ROOT_DIR}/include ${CMAKE_CUDA_TOOLKIT_TARGET_DIR}/include" CACHE PATH "" FORCE)
 EOF
+
+echo 'set(CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES "${CMAKE_CUDA_TOOLKIT_ROOT_DIR}/include;${CMAKE_CUDA_TOOLKIT_TARGET_DIR}/include" CACHE PATH "" FORCE)' >> ${WORKDIR}/toolchain.cmake
 }
 
 meson_cuda_cross_config() {


### PR DESCRIPTION
The variable `CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES` is not correctly initialized in the generated `${WORKDIR}/toolchain.cmake`. 

The `CMAKE_CUDA_TOOLKIT_ROOT_DIR` and `CMAKE_CUDA_TOOLKIT_TARGET_DIR` variables are evaluated when the toolchain file is generated from `cuda.bbclass`, which are undefined at that time and the incude dirs become `/include /include`.

Also, no list separator was used, this results in an include path of `-I<root_dir> <target_dir>` instead of `-I<root_dir> -I<target_dir>`.