### PR TITLE
Update u-boot SRCREV to include allow equal sign as key value separation patch

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
+++ b/recipes-bsp/u-boot/u-boot-tegra-common-2016.07.inc
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://Licenses/README;md5=a2c678cfd4a4d97135585cad908541c6"
 UBOOT_TEGRA_REPO ?= "github.com/madisongh/u-boot-tegra.git"
 SRCBRANCH ?= "patches-l4t-r32.2-v2016.07"
 SRC_URI = "git://${UBOOT_TEGRA_REPO};branch=${SRCBRANCH}"
-SRCREV = "8e576d30001dc06552b017fab22e00fe7145b8da"
+SRCREV = "cf370d093462a432ebc08c08946a1973dcbcffeb"
 PV .= "+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Signed-off-by: Arnstein Kleven <arnsteinkleven@gmail.com>