### PR TITLE
Support csv file reference removal globs - dunfell-l4t-r32.4.3

### DIFF
--- a/classes/container-runtime-csv.bbclass
+++ b/classes/container-runtime-csv.bbclass
@@ -1,4 +1,5 @@
 CONTAINER_CSV_FILES ??= "${libdir}/*.so*"
+CONTAINER_CSV_EXCLUDE_FILES ??= ""
 CONTAINER_CSV_BASENAME ??= "${PN}"
 CONTAINER_CSV_PKGNAME ?= "${CONTAINER_CSV_BASENAME}-container-csv"
 CONTAINER_CSV_EXTRA ??= ""
@@ -23,6 +24,19 @@ python populate_container_csv() {
             entries.update([entry[2:] for entry in globbed])
         else:
             entries.update([csvglob[2:]])
+    excludeglobs = (d.getVar('CONTAINER_CSV_EXCLUDE_FILES') or '').split()
+    for csvglob in excludeglobs:
+        if os.path.isabs(csvglob):
+            csvglob = '.' + csvglob
+        if not csvglob.startswith('./'):
+            csvglob = './' + csvglob
+        globbed = glob.glob(csvglob)
+        if globbed and globbed != [ csvglob ]:
+            for entry in globbed:
+                entries.discard(entry[2:])
+        else:
+            for entry in globbed:
+                entries.discard(csvglob[2:])
     csvlines = (d.getVar('CONTAINER_CSV_EXTRA') or '').split('\n')
     for entry in entries:
         if os.path.isdir(entry):

--- a/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
+++ b/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
@@ -11,6 +11,9 @@ RRECOMMENDS_libv4l += "${TEGRA_PLUGINS}"
 inherit container-runtime-csv
 CONTAINER_CSV_BASENAME = "libv4l"
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/ov* ${libdir}/libv4l/*.so ${libdir}/libv4l/plugins/*.so"
+# These files aren't in nvidia host-files-for-container.d/l4t.csv and conflict with attempts
+# to install v4l-utils inside the container (Invalid cross-device link)
+CONTAINER_CSV_EXCLUDE_FILES = "${libdir}/libv4l2rds*"
 RDEPENDS_libv4l_append_tegra = " ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', '${CONTAINER_CSV_PKGNAME}', '', d)}"
 RDEPENDS_${PN}_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', '${CONTAINER_CSV_PKGNAME}', '', d)}"
 PACKAGE_ARCH_tegra = "${TEGRA_PKGARCH}"


### PR DESCRIPTION
This commit has already been merged in the `master` branch. I have cherry-picked the commit of @dwalkes to include it in the `dunfell-l4t-r32.4.3` branch as well.


The list of files in the csf for v4l-utils does not match the list
in /etc/nvidia-container-runtime/host-files-for-container.d/l4t.csv
on a Jetpack 4.4 based stock NVIDIA image.  This is problematic
for the libv4l2rds libraries when attempting to install v4l-utils
in a container.  The install works fine if the container is running
on an NVIDIA image, but when running on OE4T you see an error
message:
```
unable to make backup link of './usr/lib/aarch64-linux-gnu/libv4l2rds.so.0.0.0' before installing new version: Invalid cross-device link
```

To avoid this, add support for removing container runtime files
in the container-runtime-csv class using a glob pattern, and
use this pattern to avoid placing libv4l2rds in the container
runtime.