### PR TITLE
Jetson Nano 2GB Devkit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Boards supported:
 * Jetson AGX Xavier development kit
 * Jetson Nano development kit
 * Jetson Nano eMMC module with rev B01 carrier board
+* Jetson Nanon 2GB development kit
 * Jetson Xavier NX Development Kit
 * Jetson Xavier NX eMMC module in dev kit or Nano carrier board
 

--- a/conf/machine/jetson-nano-2gb-devkit.conf
+++ b/conf/machine/jetson-nano-2gb-devkit.conf
@@ -1,0 +1,38 @@
+#@TYPE: Machine
+#@NAME: Nvidia Jetson Nano 2GB Dev Kit
+#@DESCRIPTION: Nvidia Jetson Nano 2GB development kit
+
+KERNEL_ARGS ?= "console=ttyS0,115200 console=tty0 fbcon=map:0 net.ifnames=0"
+KERNEL_ROOTSPEC ?= "root=/dev/mmcblk0p${distro_bootpart} rw rootwait"
+IMAGE_ROOTFS_ALIGNMENT ?= "1024"
+
+NVPMODEL ?= "nvpmodel_t210_jetson-nano"
+
+TEGRA_BOARDID ?= "3448"
+TEGRA_FAB ?= "400"
+TEGRA_BOARDSKU ?= "0003"
+TEGRA_BUPGEN_SPECS ?= "fab=400"
+
+require conf/machine/include/tegra210.inc
+
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtl8821cu"
+
+KERNEL_DEVICETREE ?= "_ddot_/_ddot_/_ddot_/_ddot_/nvidia/platform/t210/batuu/kernel-dts/tegra210-p3448-0003-p3542-0000.dtb"
+
+UBOOT_MACHINE = "p3541-0000_defconfig"
+
+EMMC_SIZE ?= ""
+EMMC_DEVSECT_SIZE ?= "512"
+BOOTPART_SIZE ?= ""
+BOOTPART_LIMIT ?= "10485760"
+ROOTFSPART_SIZE ?= "15032385536"
+ODMDATA ?= "0x94000"
+EMMC_BCT ?= "P3448_A00_lpddr4_204Mhz_P987.cfg"
+NVIDIA_BOARD ?= "t210ref"
+NVIDIA_PRODUCT ?= "p3541-0000"
+NVIDIA_BOARD_CFG ?= ""
+PARTITION_LAYOUT_TEMPLATE ?= "flash_l4t_t210_spi_sd_p3448.xml"
+TEGRA_SPIFLASH_BOOT ?= "1"
+TEGRAFLASH_SDCARD_SIZE ?= "16G"
+OTABOOTDEV ?= "/dev/mtdblock0"
+OTAGPTDEV ?= "/dev/mtdblock0"

--- a/recipes-bsp/u-boot/u-boot-tegra_2020.07.bb
+++ b/recipes-bsp/u-boot/u-boot-tegra_2020.07.bb
@@ -8,7 +8,7 @@ DEPENDS += "bc-native dtc-native ${SOC_FAMILY}-flashtools-native"
 SRC_REPO ?= "github.com/OE4T/u-boot-tegra.git;protocol=https"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
 SRCBRANCH ?= "patches-v2020.07"
-SRCREV = "d4f697d93304ae7efeecaf1c84bcd7b996b1aad0"
+SRCREV = "5a8a51f2f4338c6f161ae695c8571fe30fdd7b54"
 
 PV .= "+g${SRCPV}"
 


### PR DESCRIPTION
* Add a machine configuration file
* U-Boot SRCREV update with a patch from NV's downstream U-Boot repo modified for the v2020.07 code base
