### PR TITLE
tegra-helper-scripts: fix generation of rcm_2 files for tegra194

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -318,6 +318,7 @@ if [ -n "$keyfile" ]; then
     bctfilename=`echo $sdramcfg_files | cut -d, -f1`
     bctfile1name=`echo $sdramcfg_files | cut -d, -f2`
     SOSARGS="--applet mb1_t194_prod.bin "
+    NV_ARGS="--soft_fuses tegra194-mb1-soft-fuses-l4t.cfg "
     BCTARGS="$bctargs"
     . "$here/odmsign.func"
     (odmsign_ext) || exit 1


### PR DESCRIPTION
When running the odmsign_ext function for Xavier, NV_ARGS
must be set for the soft fuses configuration in order to generate
the rcm_2 files used during flashing.

Signed-off-by: Matt Madison <matt@madison.systems>