### PR TITLE
WIP: Fix gst_buffer_resize_range: assertion 'bufmax >= bufoffs + offset + size' failed

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
@@ -1,0 +1,28 @@
+From 5649d9265fbdceb97d560c0fdf392264a97ceb9d Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Thu, 25 Jun 2020 16:46:23 -0400
+Subject: [PATCH 1/3] v4l2videoenc: Fix negotiation caps leak
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2videoenc.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gstv4l2videoenc.c b/gstv4l2videoenc.c
+index 22700e0..3889b6a 100644
+--- a/gstv4l2videoenc.c
++++ b/gstv4l2videoenc.c
+@@ -888,6 +888,9 @@ gst_v4l2_video_enc_negotiate (GstVideoEncoder * encoder)
+     if (gst_caps_foreach (allowed_caps, negotiate_profile_and_level, &ctx)) {
+       goto no_profile_level;
+     }
++
++    gst_caps_unref (allowed_caps);
++    allowed_caps = NULL;
+   }
+ 
+ #ifndef USE_V4L2_TARGET_NV
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
@@ -1,0 +1,31 @@
+From a3961db8a37fb55440075b8eb2f14dd2d67d043a Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Fri, 26 Jun 2020 09:53:13 -0400
+Subject: [PATCH 2/3] v4l2allocator: Fix data offset / bytesused size
+ validation
+
+The check was too strict causing spurious warning. Now check for <= so that 0
+sized buffer do not cause a warning.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2allocator.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gstv4l2allocator.c b/gstv4l2allocator.c
+index e66da49..9dd071b 100644
+--- a/gstv4l2allocator.c
++++ b/gstv4l2allocator.c
+@@ -1483,7 +1483,7 @@ gst_v4l2_allocator_dqbuf (GstV4l2Allocator * allocator,
+ 
+       offset = group->planes[i].data_offset;
+ 
+-      if (group->planes[i].bytesused > group->planes[i].data_offset) {
++      if (group->planes[i].bytesused >= group->planes[i].data_offset) {
+         size = group->planes[i].bytesused - group->planes[i].data_offset;
+       } else {
+         GST_WARNING_OBJECT (allocator, "V4L2 provided buffer has bytesused %"
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
@@ -1,0 +1,40 @@
+From fb987d2657da10b886550f5d0dbf6e535ff5a95e Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Fri, 26 Jun 2020 11:05:25 -0400
+Subject: [PATCH 3/3] v4l2bufferpool: Avoid set_flushing warning
+
+The gst_buffer_pool_set_flushing() warns when that function is called
+on an inactive pool. Avoid the warning by checking the state, this is
+similar to what we do in gst_v4l2_object_unlock().
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2bufferpool.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gstv4l2bufferpool.c b/gstv4l2bufferpool.c
+index f7d5638..cc60067 100644
+--- a/gstv4l2bufferpool.c
++++ b/gstv4l2bufferpool.c
+@@ -1241,7 +1241,7 @@ gst_v4l2_buffer_pool_flush_start (GstBufferPool * bpool)
+   g_cond_broadcast (&pool->empty_cond);
+   GST_OBJECT_UNLOCK (pool);
+ 
+-  if (pool->other_pool)
++  if (pool->other_pool && gst_buffer_pool_is_active (pool->other_pool))
+     gst_buffer_pool_set_flushing (pool->other_pool, TRUE);
+ }
+ 
+@@ -1252,7 +1252,7 @@ gst_v4l2_buffer_pool_flush_stop (GstBufferPool * bpool)
+ 
+   GST_DEBUG_OBJECT (pool, "stop flushing");
+ 
+-  if (pool->other_pool)
++  if (pool->other_pool && gst_buffer_pool_is_active (pool->other_pool))
+     gst_buffer_pool_set_flushing (pool->other_pool, FALSE);
+ 
+ #ifndef USE_V4L2_TARGET_NV
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.4.3.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.4.3.bb
@@ -11,6 +11,10 @@ TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/public/gst-nvvideo4linux2_src.tbz
 require recipes-bsp/tegra-sources/tegra-sources-32.4.3.inc
 
 SRC_URI += "file://build-fixups.patch"
+# https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649
+SRC_URI += "file://0001-v4l2videoenc-Fix-negotiation-caps-leak.patch"
+SRC_URI += "file://0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch"
+SRC_URI += "file://0003-v4l2bufferpool-Avoid-set_flushing-warning.patch"
 
 DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0/0001-bufferpool-only-resize-in-reset-when-maxsize-is-larger.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0/0001-bufferpool-only-resize-in-reset-when-maxsize-is-larger.patch
@@ -1,0 +1,46 @@
+From a1b41b2b2493069365a8274c6a544e6799a5a8df Mon Sep 17 00:00:00 2001
+From: Matthew Waters <matthew@centricular.com>
+Date: Mon, 20 Jul 2020 17:08:32 +1000
+Subject: [PATCH] gst/bufferpool: only resize in reset when maxsize is larger
+
+Only resize the buffer if the maxsize is larger then the configued pool
+size.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/570>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gst/gstbufferpool.c | 18 +++++++++++++++---
+ 1 file changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/gst/gstbufferpool.c b/gst/gstbufferpool.c
+index 8ae868cf2c7..a8167d017d6 100644
+--- a/gst/gstbufferpool.c
++++ b/gst/gstbufferpool.c
+@@ -1223,9 +1223,21 @@ default_reset_buffer (GstBufferPool * pool, GstBuffer * buffer)
+ 
+   /* if the memory is intact reset the size to the full size */
+   if (!GST_BUFFER_FLAG_IS_SET (buffer, GST_BUFFER_FLAG_TAG_MEMORY)) {
+-    gsize offset;
+-    gst_buffer_get_sizes (buffer, &offset, NULL);
+-    gst_buffer_resize (buffer, -offset, pool->priv->size);
++    gsize offset, maxsize;
++    gst_buffer_get_sizes (buffer, &offset, &maxsize);
++    /* check if we can resize to at least the pool configured size.  If not,
++     * then this will fail internally in gst_buffer_resize().
++     * default_release_buffer() will drop the buffer from the pool if the
++     * sizes don't match */
++    if (maxsize >= pool->priv->size) {
++      gst_buffer_resize (buffer, -offset, pool->priv->size);
++    } else {
++      GST_WARNING_OBJECT (pool, "Buffer %p without the memory tag has "
++          "maxsize (%" G_GSIZE_FORMAT ") that is smaller than the "
++          "configured buffer pool size (%u). The buffer will be not be "
++          "reused. This is most likely a bug in this GstBufferPool subclass",
++          buffer, maxsize, pool->priv->size);
++    }
+   }
+ 
+   /* remove all metadata without the POOLED flag */
+-- 
+GitLab
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0_1.16.3.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0_1.16.3.bbappend
@@ -1,0 +1,5 @@
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/gstreamer1.0:"
+
+# https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/570
+SRC_URI += "file://0001-bufferpool-only-resize-in-reset-when-maxsize-is-larger.patch"


### PR DESCRIPTION
This MR will fix a critical warning that spams the stderr:

`(gst-launch-1.0:4621): GStreamer-CRITICAL **: 15:51:27.489: gst_buffer_resize_range: assertion 'bufmax >= bufoffs + offset + size' failed
`

More information can be found there:
https://forums.developer.nvidia.com/t/gstreamer-udp-decoding-pipeline-in-jetson-tx2/128755/15

This basicaly backport two MR:
_gstreamer: gst/bufferpool: only resize in reset when maxsize is larger_
https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/570
_gst-plugins-good: v4l2: Various minor fixes_
https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649/commits

It compile and remove the warning on branch `dunfell-l4t-r32.4.3` using gstreamer 1.16.3

I have marked it as WIP because it needs more testing. For now I tested it with:
`
gst-launch-1.0 videotestsrc ! nvvidconv ! nvv4l2h265enc ! fakesink
`
