### PR TITLE
cuda-nvgraph: add DEPENDS setting

### DIFF
--- a/recipes-devtools/cuda/cuda-nvgraph_10.2.89-1.bb
+++ b/recipes-devtools/cuda/cuda-nvgraph_10.2.89-1.bb
@@ -1,3 +1,4 @@
+DEPENDS = "cuda-curand cuda-cusolver"
 
 require cuda-shared-binaries-${PV}.inc
 


### PR DESCRIPTION
Analysis of libnvgraph shows that libcurand and libcusolver
are NEEDED by it, so add cuda-curand and cuda-cusolver to
its build-time dependencies so the packaging code can locate
those libraries and set the runtime depenencies appropriately.

Signed-off-by: Matt Madison <matt@madison.systems>

Fixes #472