### PR TITLE
tegra-helper-scripts: fix secureboot support in tegra210 and tegra194 helpers

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -117,10 +117,14 @@ if [ -z "$CHIPREV" ]; then
 	echo "ERR: chip ID mismatch for Xavier" >&2
 	exit 1
     fi
-    if [ "${chipid:2:1}" != "8" ]; then
-	echo "ERR: non-production chip found" >&2
-	exit 1
-    fi
+    case "${chipid:2:1}" in
+	8|9|d)
+	    ;;
+	*)
+	    echo "ERR: non-production chip found" >&2
+	    exit 1
+	    ;;
+    esac
     CHIPREV="${chipid:5:1}"
     skipuid="--skipuid"
 fi


### PR DESCRIPTION
For tegra210:

* Pass --key argument where needed
* Fix the --bct argument for secured devices
* Handle direct flashing, BUP, and SDcard generation

When signing occurs during a build, only direct flashing is
supported; no separate SDcard generation.  Since NVIDIA
doesn't actually support secure boot on the SDcard-equipped
Nano dev kits, this shouldn't have much of an impact.

For tegra194:
* Fix recognition of secured devices. 

Note, however, that when flashing secured devices without pre-signed binaries (i.e., using `-u` and possibly `-v` to specify the signing keys), one must follow the instructions in the L4T documentation and manually set `BOARDID`, `FAB`, `BOARDSKU` and `BOARDREV` in the environment when running the `doflash.sh` script, which will bypass the BR_CID check anyway.  The underlying flashing tools do not appear to support querying the EEPROM of a secured device for retrieving those values.

Signed-off-by: Matt Madison <matt@madison.systems>