### PR TITLE
tegra-flashtools-native: make compatible with python 3.9

### DIFF
--- a/recipes-bsp/tegra-binaries/files/0009-Update-tegraflash_internal.py-for-Python-3.9.patch
+++ b/recipes-bsp/tegra-binaries/files/0009-Update-tegraflash_internal.py-for-Python-3.9.patch
@@ -1,0 +1,67 @@
+From 9e6881a09e5a0fb1e78bad182942bed9cb54939b Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kurt.kiefer@arthrex.com>
+Date: Wed, 4 Nov 2020 21:58:48 -0800
+Subject: [PATCH] Update tegraflash_internal.py for Python 3.9
+
+---
+ bootloader/tegraflash_internal.py | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/bootloader/tegraflash_internal.py b/bootloader/tegraflash_internal.py
+index e377695..c5bd6bb 100755
+--- a/bootloader/tegraflash_internal.py
++++ b/bootloader/tegraflash_internal.py
+@@ -804,7 +804,7 @@ def tegraflash_t19x_encrypt_and_sign(cfg_file):
+              list_text = "signed_file"
+          else:
+              list_text = "encrypt_file"
+-         for file_nodes in xml_tree.getiterator('file'):
++         for file_nodes in xml_tree.iter('file'):
+              file_name = file_nodes.get('name')
+              file_type = file_nodes.get('type')
+              magic_id = tegraflash_get_magicid(file_type)
+@@ -1149,7 +1149,7 @@ def tegraflash_encrypt_and_copy_signed_binaries(xml_file, output_dir):
+     else:
+         list_text = "encrypt_file"
+ 
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         file_name = file_nodes.get('name')
+         file_type = file_nodes.get('type')
+         signed_file = file_nodes.find(mode).get(list_text)
+@@ -1184,7 +1184,7 @@ def tegraflash_copy_signed_binaries(xml_file, output_dir):
+         else:
+             list_text = "encrypt_file"
+ 
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         file_name = file_nodes.get('name')
+         signed_file = file_nodes.find(mode).get(list_text)
+         shutil.copyfile(signed_file, output_dir + "/" + os.path.basename(signed_file))
+@@ -1908,7 +1908,7 @@ def tegraflash_oem_encrypt_and_sign_file(in_file, header , magic_id):
+         sig_file = "hash"
+ 
+     signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+ 
+@@ -1990,7 +1990,7 @@ def tegraflash_t21x_sign_file(magicid, in_file):
+     #signed_file = filename
+ 
+    # signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+     if mode == "pkc":
+@@ -2106,7 +2106,7 @@ def tegraflas_oem_sign_file(in_file, magic_id):
+                 sig_file = "hash"
+ 
+     signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+ 

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.4.4.bb
@@ -17,6 +17,7 @@ SRC_URI += "\
            file://0005-Convert-rollback_parser.py-to-Python3.patch \
            file://0006-Update-tegraflash_internal.py-for-Python3.patch \
            file://0007-Update-check-functions-in-BUP_generator.py-for-Pytho.patch \
+           file://0009-Update-tegraflash_internal.py-for-Python-3.9.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"

--- a/recipes-bsp/tegra-binaries/tegra210-flashtools-native_32.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra210-flashtools-native_32.4.4.bb
@@ -21,6 +21,7 @@ SRC_URI += "${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${PV}_aarch64.tbz2;name=l4t
            file://0006-Update-tegraflash_internal.py-for-Python3.patch \
            file://0007-Update-check-functions-in-BUP_generator.py-for-Pytho.patch \
            file://0008-Skip-qspi-sd-specific-entries-for-eMMC-Nano-BUP-payl.patch \
+           file://0009-Update-tegraflash_internal.py-for-Python-3.9.patch \
            "
 
 S = "${WORKDIR}/Linux_for_Tegra"


### PR DESCRIPTION
The tegraflash-internal.py script was using a function removed in python 3.9. Update patching for the script to use the new version of this function.

If preferred, I can roll this patch into the 0006 patch which does similar work.