### PR TITLE
zeus-l4t-r32.3.1: Fix nvv4l2h265enc getting capabilities for device

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
@@ -38,7 +38,7 @@ do_install() {
     ln -sf libnvid_mapper.so.1.0.0 ${D}${libdir}/libnvid_mapper.so.1
     ln -sf libnvid_mapper.so.1.0.0 ${D}${libdir}/libnvid_mapper.so
     rm -f ${D}${libdir}/libdrm* ${D}${libdir}/libnvphsd* ${D}${libdir}/libnvgov*
-    rm -f ${D}${libdir}/libv4l2.so* ${D}${libdir}/libv4lconvert.so*
+    rm -f ${D}${libdir}/libv4l2.so* ${D}${libdir}/libv4lconvert.so* ${D}${libdir}/libnvv4l2.so ${D}${libdir}/libnvv4lconvert.so
     # argus and scf libraries hard-coded to use this path
     #install -d ${D}/usr/lib/aarch64-linux-gnu/tegra-egl
     #ln -sf ${libdir}/libEGL_nvidia.so.0 ${D}/usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0


### PR DESCRIPTION
Fix #463 [Zeus: nvv4l2h265enc: Error getting capabilities for device '/dev/nvhost-msenc']

Backport:
```
    tegra-libraries: don't install libnvv4l2, libnvv4lconvert
    
    These are not directly linked against by anything, and don't
    appear to provide any functionality that isn't provided by
    the open-source libv4l2 libraries, so just remove them.

    Signed-off-by: Matt Madison <matt@madison.systems>
```

This is needed on zeus to work properly with the gstreamer nvv4l2 plugin.