### PR TITLE
zeus-l4t-r32.3.1: Fix gst_buffer_resize_range: assertion 'bufmax >= bufoffs + offset + size' failed

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
@@ -1,0 +1,28 @@
+From 5649d9265fbdceb97d560c0fdf392264a97ceb9d Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Thu, 25 Jun 2020 16:46:23 -0400
+Subject: [PATCH 1/3] v4l2videoenc: Fix negotiation caps leak
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2videoenc.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/gstv4l2videoenc.c b/gstv4l2videoenc.c
+index 22700e0..3889b6a 100644
+--- a/gstv4l2videoenc.c
++++ b/gstv4l2videoenc.c
+@@ -888,6 +888,9 @@ gst_v4l2_video_enc_negotiate (GstVideoEncoder * encoder)
+     if (gst_caps_foreach (allowed_caps, negotiate_profile_and_level, &ctx)) {
+       goto no_profile_level;
+     }
++
++    gst_caps_unref (allowed_caps);
++    allowed_caps = NULL;
+   }
+ 
+ #ifndef USE_V4L2_TARGET_NV
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
@@ -1,0 +1,31 @@
+From a3961db8a37fb55440075b8eb2f14dd2d67d043a Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Fri, 26 Jun 2020 09:53:13 -0400
+Subject: [PATCH 2/3] v4l2allocator: Fix data offset / bytesused size
+ validation
+
+The check was too strict causing spurious warning. Now check for <= so that 0
+sized buffer do not cause a warning.
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2allocator.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gstv4l2allocator.c b/gstv4l2allocator.c
+index e66da49..9dd071b 100644
+--- a/gstv4l2allocator.c
++++ b/gstv4l2allocator.c
+@@ -1483,7 +1483,7 @@ gst_v4l2_allocator_dqbuf (GstV4l2Allocator * allocator,
+ 
+       offset = group->planes[i].data_offset;
+ 
+-      if (group->planes[i].bytesused > group->planes[i].data_offset) {
++      if (group->planes[i].bytesused >= group->planes[i].data_offset) {
+         size = group->planes[i].bytesused - group->planes[i].data_offset;
+       } else {
+         GST_WARNING_OBJECT (allocator, "V4L2 provided buffer has bytesused %"
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.3.1/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
@@ -1,0 +1,40 @@
+From fb987d2657da10b886550f5d0dbf6e535ff5a95e Mon Sep 17 00:00:00 2001
+From: Nicolas Dufresne <nicolas.dufresne@collabora.com>
+Date: Fri, 26 Jun 2020 11:05:25 -0400
+Subject: [PATCH 3/3] v4l2bufferpool: Avoid set_flushing warning
+
+The gst_buffer_pool_set_flushing() warns when that function is called
+on an inactive pool. Avoid the warning by checking the state, this is
+similar to what we do in gst_v4l2_object_unlock().
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2bufferpool.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gstv4l2bufferpool.c b/gstv4l2bufferpool.c
+index f7d5638..cc60067 100644
+--- a/gstv4l2bufferpool.c
++++ b/gstv4l2bufferpool.c
+@@ -1241,7 +1241,7 @@ gst_v4l2_buffer_pool_flush_start (GstBufferPool * bpool)
+   g_cond_broadcast (&pool->empty_cond);
+   GST_OBJECT_UNLOCK (pool);
+ 
+-  if (pool->other_pool)
++  if (pool->other_pool && gst_buffer_pool_is_active (pool->other_pool))
+     gst_buffer_pool_set_flushing (pool->other_pool, TRUE);
+ }
+ 
+@@ -1252,7 +1252,7 @@ gst_v4l2_buffer_pool_flush_stop (GstBufferPool * bpool)
+ 
+   GST_DEBUG_OBJECT (pool, "stop flushing");
+ 
+-  if (pool->other_pool)
++  if (pool->other_pool && gst_buffer_pool_is_active (pool->other_pool))
+     gst_buffer_pool_set_flushing (pool->other_pool, FALSE);
+ 
+ #ifndef USE_V4L2_TARGET_NV
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.3.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.3.1.bb
@@ -12,6 +12,10 @@ TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/public/gst-nvvideo4linux2_src.tbz
 require recipes-bsp/tegra-sources/tegra-sources-32.3.1.inc
 
 SRC_URI += "file://build-fixups.patch"
+# https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649
+SRC_URI += "file://0001-v4l2videoenc-Fix-negotiation-caps-leak.patch"
+SRC_URI += "file://0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch"
+SRC_URI += "file://0003-v4l2bufferpool-Avoid-set_flushing-warning.patch"
 
 DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries"
 


### PR DESCRIPTION
Backport: https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649

- v4l2videoenc: Fix negotiation caps leak
  https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/dbdbcfe7ff1b329e9ce23e5a3be6e860dc7aacec?merge_request_iid=649
- v4l2allocator: Fix data offset / bytesused size validation
  https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/0344c50eafa5a1b1bc203808d8950e3b07e563e8?merge_request_iid=649
- v4l2bufferpool: Avoid set_flushing warning
  https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/commit/b8f1f2195ec7ef5f930a4b0bf66ce484ca21d5fa?merge_request_iid=649

This is intended to fix:

(gst-launch-1.0:4621): GStreamer-CRITICAL **: 15:51:27.489: gst_buffer_resize_range: assertion 'bufmax >= bufoffs + offset + size' failed

Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>