### PR TITLE
Dunfell backports

### DIFF
--- a/classes/container-runtime-csv.bbclass
+++ b/classes/container-runtime-csv.bbclass
@@ -1,4 +1,5 @@
 CONTAINER_CSV_FILES ??= "${libdir}/*.so*"
+CONTAINER_CSV_EXCLUDE_FILES ??= ""
 CONTAINER_CSV_BASENAME ??= "${PN}"
 CONTAINER_CSV_PKGNAME ?= "${CONTAINER_CSV_BASENAME}-container-csv"
 CONTAINER_CSV_EXTRA ??= ""
@@ -23,6 +24,19 @@ python populate_container_csv() {
             entries.update([entry[2:] for entry in globbed])
         else:
             entries.update([csvglob[2:]])
+    excludeglobs = (d.getVar('CONTAINER_CSV_EXCLUDE_FILES') or '').split()
+    for csvglob in excludeglobs:
+        if os.path.isabs(csvglob):
+            csvglob = '.' + csvglob
+        if not csvglob.startswith('./'):
+            csvglob = './' + csvglob
+        globbed = glob.glob(csvglob)
+        if globbed and globbed != [ csvglob ]:
+            for entry in globbed:
+                entries.discard(entry[2:])
+        else:
+            for entry in globbed:
+                entries.discard(csvglob[2:])
     csvlines = (d.getVar('CONTAINER_CSV_EXTRA') or '').split('\n')
     for entry in entries:
         if os.path.isdir(entry):

--- a/classes/cuda.bbclass
+++ b/classes/cuda.bbclass
@@ -48,5 +48,4 @@ EOF
 
 PACKAGE_ARCH_cuda = "${SOC_FAMILY_PKGARCH}"
 RDEPENDS_${PN}_append_tegra = " tegra-libraries"
-RRECOMMENDS_${PN}_append_tegra = " kernel-module-nvgpu"
 

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -321,6 +321,9 @@ create_tegraflash_pkg_tegra210() {
         cp -R ${STAGING_BINDIR_NATIVE}/tegra210-flash/* .
         tegraflash_generate_bupgen_script
     fi
+    if [ -e ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ]; then
+        cp ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ./odmfuse_pkc.xml
+    fi
     tegraflash_custom_pre
     cp "${IMAGE_TEGRAFLASH_ROOTFS}" ./${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE}
     tegraflash_create_flash_config "${WORKDIR}/tegraflash" ${LNXFILE}
@@ -331,6 +334,13 @@ create_tegraflash_pkg_tegra210() {
 MACHINE=${MACHINE} ./tegra210-flash-helper.sh -B ${TEGRA_BLBLOCKSIZE} flash.xml.in ${DTBFILE} ${MACHINE}.cfg ${ODMDATA} "$boardcfg" ${LNXFILE} ${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE} "\$@"
 END
     chmod +x doflash.sh
+    if [ -e ./odmfuse_pkc.xml ]; then
+        cat > burnfuses.sh <<END
+#!/bin/sh
+MACHINE=${MACHINE} ./tegra210-flash-helper.sh -B ${TEGRA_BLBLOCKSIZE} -c "blowfuses odmfuse_pkc.xml" flash.xml.in ${DTBFILE} ${MACHINE}.cfg ${ODMDATA} "$boardcfg" ${LNXFILE} ${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE} "\$@"
+END
+        chmod +x burnfuses.sh
+    fi
     if [ "${TEGRA_SPIFLASH_BOOT}" = "1" ]; then
         rm -f dosdcard.sh
         cat > dosdcard.sh <<END
@@ -458,6 +468,9 @@ create_tegraflash_pkg_tegra194() {
         mv ./rollback_parser.py ./rollback/
         tegraflash_generate_bupgen_script
     fi
+    if [ -e ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ]; then
+        cp ${STAGING_DATADIR}/tegraflash/odmfuse_pkc_${MACHINE}.xml ./odmfuse_pkc.xml
+    fi
     tegraflash_custom_pre
     mksparse -v --fillpattern=0 "${IMAGE_TEGRAFLASH_ROOTFS}" ${IMAGE_BASENAME}.img
     tegraflash_create_flash_config "${WORKDIR}/tegraflash" ${LNXFILE}
@@ -467,6 +480,13 @@ create_tegraflash_pkg_tegra194() {
 MACHINE=${MACHINE} ./tegra194-flash-helper.sh flash.xml.in ${DTBFILE} ${MACHINE}.cfg,${MACHINE}-override.cfg ${ODMDATA} ${LNXFILE} ${IMAGE_BASENAME}.img "\$@"
 END
     chmod +x doflash.sh
+    if [ -e ./odmfuse_pkc.xml ]; then
+        cat > burnfuses.sh <<END
+#!/bin/sh
+MACHINE=${MACHINE} ./tegra194-flash-helper.sh -c "burnfuses odmfuse_pkc.xml" flash.xml.in ${DTBFILE} ${MACHINE}.cfg,${MACHINE}-override.cfg ${ODMDATA} ${LNXFILE} ${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE} "\$@"
+END
+        chmod +x burnfuses.sh
+    fi
     tegraflash_custom_post
     tegraflash_custom_sign_pkg
     tegraflash_finalize_pkg

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -418,7 +418,7 @@ END
     if [ -e ./odmfuse_pkc.xml ]; then
         cat > burnfuses.sh <<END
 #!/bin/sh
-MACHINE=${MACHINE} ./tegra186-flash-helper.sh --burnfuses flash.xml.in ${DTBFILE} ${MACHINE}.cfg ${ODMDATA} ${LNXFILE} ${IMAGE_BASENAME}.img "\$@"
+MACHINE=${MACHINE} ./tegra186-flash-helper.sh -c "burnfuses odmfuse_pkc.xml" flash.xml.in ${DTBFILE} ${MACHINE}.cfg ${ODMDATA} ${LNXFILE} ${IMAGE_BASENAME}.img "\$@"
 END
 	chmod +x burnfuses.sh
     fi

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -28,7 +28,6 @@ IMAGE_CLASSES += "image_types_tegra"
 IMAGE_FSTYPES ?= "tegraflash"
 
 MACHINE_HWCODECS = "gstreamer1.0-omx-tegra gstreamer1.0-plugins-nvvideo4linux2"
-LICENSE_FLAGS_WHITELIST_append = " commercial_gstreamer1.0-omx-tegra"
 
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 XSERVER = "xserver-xorg xf86-input-evdev xserver-xorg-video-nvidia xserver-xorg-module-libwfb"

--- a/contrib/conf/layer.conf
+++ b/contrib/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += " \
 
 BBFILE_COLLECTIONS += "tegra-contrib"
 BBFILE_PATTERN_tegra-contrib = "^${LAYERDIR}/"
-BBFILE_PRIORITY_tegra-contrib = "6"
+BBFILE_PRIORITY_tegra-contrib = "4"
 
 LAYERVERSION_tegra-contrib = "1"
 

--- a/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
+++ b/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
@@ -11,6 +11,9 @@ RRECOMMENDS_libv4l += "${TEGRA_PLUGINS}"
 inherit container-runtime-csv
 CONTAINER_CSV_BASENAME = "libv4l"
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/ov* ${libdir}/libv4l/*.so ${libdir}/libv4l/plugins/*.so"
+# These files aren't in nvidia host-files-for-container.d/l4t.csv and conflict with attempts
+# to install v4l-utils inside the container (Invalid cross-device link)
+CONTAINER_CSV_EXCLUDE_FILES = "${libdir}/libv4l2rds*"
 RDEPENDS_libv4l_append_tegra = " ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', '${CONTAINER_CSV_PKGNAME}', '', d)}"
 RDEPENDS_${PN}_remove = " ${@bb.utils.contains('DISTRO_FEATURES', 'virtualization', '${CONTAINER_CSV_PKGNAME}', '', d)}"
 PACKAGE_ARCH_tegra = "${TEGRA_PKGARCH}"

--- a/external/openembedded-layer/recipes-support/eigen/libeigen_3.3.7.bbappend
+++ b/external/openembedded-layer/recipes-support/eigen/libeigen_3.3.7.bbappend
@@ -1,0 +1,3 @@
+SRC_URI = "git://gitlab.com/libeigen/eigen.git;protocol=https;nobranch=1"
+SRCREV = "21ae2afd4edaa1b69782c67a54182d34efe43f9c"
+S = "${WORKDIR}/git"

--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.9.0/0004-Fix-build.h-generation-for-cross-builds.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.9.0/0004-Fix-build.h-generation-for-cross-builds.patch
@@ -1,0 +1,40 @@
+From 59ce7ceb66f3276874bf706b7cfd368af62a7e1b Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 27 Sep 2020 05:35:52 -0700
+Subject: [PATCH] Fix build.h generation for cross builds
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ Makefile     | 4 ++++
+ mk/common.mk | 2 +-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index a574800..cd44c73 100644
+--- a/Makefile
++++ b/Makefile
+@@ -177,7 +177,11 @@ DEPENDENCIES   := $(BIN_OBJS:%.o=%.d) $(LIB_OBJS:%.lo=%.d)
+ $(BUILD_DEFS):
+ 	@printf '#define BUILD_DATE     "%s"\n' '$(strip $(DATE))' >$(BUILD_DEFS)
+ 	@printf '#define BUILD_COMPILER "%s " __VERSION__\n' '$(notdir $(COMPILER))' >>$(BUILD_DEFS)
++ifeq ($(EXCLUDE_BUILD_FLAGS),)
+ 	@printf '#define BUILD_FLAGS    "%s"\n' '$(strip $(CPPFLAGS) $(CFLAGS) $(LDFLAGS))' >>$(BUILD_DEFS)
++else
++	@printf '#define BUILD_FLAGS    ""\n' >>$(BUILD_DEFS)
++endif
+ 	@printf '#define BUILD_REVISION "%s"\n' '$(strip $(REVISION))' >>$(BUILD_DEFS)
+ 	@printf '#define BUILD_PLATFORM "%s"\n' '$(strip $(PLATFORM))' >>$(BUILD_DEFS)
+ 
+diff --git a/mk/common.mk b/mk/common.mk
+index 09987a3..5a03988 100644
+--- a/mk/common.mk
++++ b/mk/common.mk
+@@ -22,7 +22,7 @@ UID      := $(shell id -u)
+ GID      := $(shell id -g)
+ DATE     := $(shell date -u --iso-8601=minutes)
+ REVISION := $(shell git rev-parse HEAD)
+-COMPILER := $(realpath $(shell which $(CC)))
++COMPILER := $(realpath $(shell which $(firstword $(CC))))
+ PLATFORM ?= $(shell uname -m)
+ JETSON   ?= $(shell test -f /etc/nv_tegra_release && echo "TRUE")
+ 

--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
@@ -36,6 +36,7 @@ SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia;branch
            file://0001-Makefile-Fix-RCP-flags-and-change-path-definitions-s.patch \
            file://0002-common.mk-Set-JETSON-variable-if-not-set-before.patch \
            file://0003-Fix-mapping-of-library-paths-for-jetson-mounts.patch \
+           file://0004-Fix-build.h-generation-for-cross-builds.patch \
            "
 
 SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
@@ -49,11 +50,19 @@ SRCREV_modprobe = "d97c08af5061f1516fb2e3a26508936f69d6d71d"
 S = "${WORKDIR}/git"
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[seccomp] = " WITH_SECCOMP=yes , WITH_SECCOMP=no ,libseccomp"
+PACKAGECONFIG[seccomp] = "WITH_SECCOMP=yes,WITH_SECCOMP=no,libseccomp"
+
+def build_date(d):
+    import datetime
+    epoch = d.getVar('SOURCE_DATE_EPOCH')
+    if epoch:
+        dt = datetime.datetime.fromtimestamp(int(epoch), tz=datetime.timezone.utc)
+        return 'DATE=' + dt.isoformat(timespec='minutes')
+    return ''
 
 # We need to link with libelf, otherwise we need to
 # include bmake-native which does not exist at the moment.
-EXTRA_OEMAKE_append = " WITH_LIBELF=yes JETSON=TRUE ${PACKAGECONFIG_CONFARGS}"
+EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
 
 CFLAGS_prepend = " -I=/usr/include/tirpc "
 

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -273,6 +273,7 @@ elif [ -n "$keyfile" ]; then
     bctfilename=`echo $sdramcfg_files | cut -d, -f1`
     bctfile1name=`echo $sdramcfg_files | cut -d, -f2`
     SOSARGS="--applet mb1_t194_prod.bin "
+    NV_ARGS="--soft_fuses tegra194-mb1-soft-fuses-l4t.cfg "
     BCTARGS="$bctargs"
     . "$here/odmsign.func"
     (odmsign_ext) || exit 1

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -85,10 +85,14 @@ if [ -z "$CHIPREV" ]; then
 	echo "ERR: chip ID mismatch for Xavier" >&2
 	exit 1
     fi
-    if [ "${chipid:2:1}" != "8" ]; then
-	echo "ERR: non-production chip found" >&2
-	exit 1
-    fi
+    case "${chipid:2:1}" in
+	8|9|d)
+	    ;;
+	*)
+	    echo "ERR: non-production chip found" >&2
+	    exit 1
+	    ;;
+    esac
     CHIPREV="${chipid:5:1}"
     skipuid="--skipuid"
 fi

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
@@ -4,11 +4,13 @@ keyfile=
 keyfile_args=
 spi_only=
 no_flash=0
+flash_cmd=
 sdcard=
 make_sdcard_args=
 imgfile=
 blocksize=4096
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,spi-only" -o "u:s:b:B:y" -- "$@")
+
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,spi-only" -o "u:s:b:B:yc:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1
@@ -54,6 +56,10 @@ while true; do
 	-y)
 	    make_sdcard_args="$make_sdcard_args -y"
 	    shift
+	    ;;
+	-c)
+	    flash_cmd="$2"
+	    shift 2
 	    ;;
 	--)
 	    shift
@@ -193,6 +199,10 @@ else
     if [ -z "$sdcard" -a $no_flash -eq 0 ]; then
 	rm -f "$appfile"
 	$here/mksparse -b ${blocksize} -v --fillpattern=0 "$imgfile"  "$appfile" || exit 1
+    fi
+    cmd=${flash_cmd:-"flash;reboot"}
+    if [ "$boardid" = "3448" ]; then
+        binargs="--bins \"EBT cboot.bin;DTB $dtb_file\""
     fi
 fi
 

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 bup_build=
 keyfile=
+spi_only=
 no_flash=0
 sdcard=
 make_sdcard_args=
 imgfile=
 blocksize=4096
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard" -o "u:s:b:B:y" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,spi-only" -o "u:s:b:B:y" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1
@@ -26,6 +27,10 @@ while true; do
 	    ;;
 	--sdcard)
 	    sdcard=yes
+	    shift
+	    ;;
+	--spi-only)
+	    spi_only=yes
 	    shift
 	    ;;
 	-u)
@@ -166,7 +171,17 @@ elif [ $no_flash -eq 0 ]; then
 else
     touch APPFILE
 fi
-sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,DTBFILE,$DTBFILE," $appfile_sed "$flash_in" > flash.xml
+if [ "$spi_only" = "yes" ]; then
+    if [ ! -e "$here/nvflashxmlparse" ]; then
+	echo "ERR: missing nvflashxmlparse script" >&2
+	exit 1
+    fi
+    "$here/nvflashxmlparse" --extract -t spi -o flash.xml.tmp "$flash_in" || exit 1
+else
+    cp "$flash_in" flash.xml.tmp
+fi
+sed -e"s,VERFILE,${MACHINE}_bootblob_ver.txt," -e"s,DTBFILE,$DTBFILE," $appfile_sed flash.xml.tmp > flash.xml
+rm flash.xml.tmp
 boardcfg=
 [ -z "$boardcfg_file" ] || boardcfg="--boardconfig $boardcfg_file"
 if [ "$bup_build" = "yes" -o "$sdcard" = "yes" ]; then

--- a/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
@@ -72,6 +72,7 @@ RDEPENDS_${PN} = "libasound"
 RDEPENDS_${PN}-argus = "tegra-argus-daemon"
 RDEPENDS_${PN}-argus-daemon-base = "${PN} libglvnd"
 RDEPENDS_${PN}-libnvosd = "${PN} pango cairo glib-2.0"
+RRECOMMENDS_${PN}-libnvosd = "liberation-fonts"
 RRECOMMENDS_${PN} = "kernel-module-nvgpu"
 
 INSANE_SKIP_${PN}-libv4l-plugins = "dev-so textrel ldflags build-deps"

--- a/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
@@ -72,6 +72,7 @@ RDEPENDS_${PN} = "libasound"
 RDEPENDS_${PN}-argus = "tegra-argus-daemon"
 RDEPENDS_${PN}-argus-daemon-base = "${PN} libglvnd"
 RDEPENDS_${PN}-libnvosd = "${PN} pango cairo glib-2.0"
+RRECOMMENDS_${PN} = "kernel-module-nvgpu"
 
 INSANE_SKIP_${PN}-libv4l-plugins = "dev-so textrel ldflags build-deps"
 INSANE_SKIP_${PN} = "dev-so textrel ldflags build-deps libdir"

--- a/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries_32.3.1.bb
@@ -3,7 +3,8 @@ require tegra-shared-binaries.inc
 
 inherit container-runtime-csv
 
-CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/plugins/* ${datadir}/glvnd/egl_vendor.d/* ${sysconfdir}/vulkan/icd.d/*"
+CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/plugins/* ${datadir}/glvnd/egl_vendor.d/* ${sysconfdir}/vulkan/icd.d/* \
+                      /usr/lib/aarch64-linux-gnu/tegra/nvidia_icd.json"
 CONTAINER_CSV_EXTRA = "lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0"
 
 do_configure() {
@@ -46,8 +47,10 @@ do_install() {
     install -m755 ${B}/usr/sbin/nvargus-daemon ${D}${sbindir}/
     install -d ${D}${datadir}/glvnd/egl_vendor.d
     install -m644 ${DRVROOT}/tegra-egl/nvidia.json ${D}${datadir}/glvnd/egl_vendor.d/10-nvidia.json
+    install -d ${D}/usr/lib/aarch64-linux-gnu/tegra
+    install -m644 ${DRVROOT}/tegra/nvidia_icd.json ${D}/usr/lib/aarch64-linux-gnu/tegra/
     install -d ${D}${sysconfdir}/vulkan/icd.d
-    install -m644 ${DRVROOT}/tegra/nvidia_icd.json ${D}${sysconfdir}/vulkan/icd.d/
+    ln -sf /usr/lib/aarch64-linux-gnu/tegra/nvidia_icd.json ${D}${sysconfdir}/vulkan/icd.d/
     rm ${D}${libdir}/libnvidia-egl-wayland*
 }
 
@@ -62,7 +65,8 @@ FILES_${PN}-libv4l-plugins = "${libdir}/libv4l"
 FILES_${PN}-argus = "${libdir}/libnvargus*"
 FILES_${PN}-argus-daemon-base = "${sbindir}/nvargus-daemon"
 FILES_${PN}-libnvosd = "${libdir}/libnvosd*"
-FILES_${PN} = "${libdir} ${sbindir} ${nonarch_libdir} ${localstatedir} ${sysconfdir} ${datadir}"
+FILES_${PN} = "${libdir} ${sbindir} ${nonarch_libdir} ${localstatedir} ${sysconfdir} ${datadir} \
+               /usr/lib/aarch64-linux-gnu/tegra/nvidia_icd.json"
 FILES_${PN}-dev = "${libdir}/lib*GL*.so"
 RDEPENDS_${PN} = "libasound"
 RDEPENDS_${PN}-argus = "tegra-argus-daemon"

--- a/recipes-bsp/tegra-binaries/tegra-nvphs/nvphs.service
+++ b/recipes-bsp/tegra-binaries/tegra-nvphs/nvphs.service
@@ -8,6 +8,7 @@ Before=graphical.target
 Type=simple
 ExecStartPre=/usr/sbin/nvphsd_setup.sh
 ExecStart=/usr/sbin/nvphsd
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-devtools/gie/tensorrt_6.0.1-1.bb
+++ b/recipes-devtools/gie/tensorrt_6.0.1-1.bb
@@ -85,6 +85,9 @@ BASEVER = "${@d.getVar('PV').split('-')[0]}"
 
 S = "${WORKDIR}/tensorrt"
 
+DEPENDS = "libcublas cudnn cuda-cudart cuda-nvrtc libglvnd"
+DEPENDS_append_tegra194 = " tegra-libraries"
+
 CONTAINER_CSV_FILES = "${libdir}/*.so* /usr/src/*"
 
 do_configure() {

--- a/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
@@ -52,4 +52,5 @@ RCONFLICTS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
 RREPLACES_${PN} = "libegl libgl libgles1 ligbles2"
 RREPLACESS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
 
+RDEPENDS_${PN}_append_tegra = " tegra-libraries"
 RRECOMMENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'egl-wayland', '', d)}"

--- a/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
+++ b/recipes-graphics/libglvnd/libglvnd_1.2.0.bb
@@ -51,3 +51,5 @@ RCONFLICTS_${PN} = "libegl libgl ligbles1 libgles2"
 RCONFLICTS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
 RREPLACES_${PN} = "libegl libgl libgles1 ligbles2"
 RREPLACESS_${PN}-dev += "libegl-dev libgl-dev libgles1-dev libgles2-dev"
+
+RRECOMMENDS_${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'egl-wayland', '', d)}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.3.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.3.1.bb
@@ -1,8 +1,6 @@
 SUMMARY = "OpenMAX IL plugins for GStreamer (Nvidia-specific)"
 SECTION = "multimedia"
 LICENSE = "LGPLv2.1"
-LICENSE_FLAGS = "commercial"
-HOMEPAGE = "http://www.gstreamer.net/"
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-nveglgles gstreamer1.0-plugins-tegra"
 DEPENDS += "tegra-libraries"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_%.bbappend
@@ -1,0 +1,2 @@
+PACKAGECONFIG_append_tegra = " v4l2"
+PACKAGE_ARCH_tegra = "${TEGRA_PKGARCH}"


### PR DESCRIPTION
Port of several updates from dunfell-l4t-r32.4.3 to dunfell:

* Updates to support secure boot flashing on tegra210 and tegra194 platforms.
* Addition of `--spi-only` option for the tegra210 flash helper to simplify split SDcard burning and SPI flashing
* Fixes for gstreamer plugins, libglvnd, container support, etc.