### PR TITLE
gstreamer1.0-plugins-nvvideo4linux2: check if we have a pool before t…

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0001-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0001-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
@@ -1,0 +1,36 @@
+From 9a51231d30e67a1a3e52cae44b5f14db49e12a1d Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sun, 8 Nov 2020 01:53:55 +0000
+Subject: [PATCH 1/2] gstv4l2videodec: use ifdef macro for consistency with
+ the rest of the code
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2videodec.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gstv4l2videodec.c b/gstv4l2videodec.c
+index 3a6188c..6daf863 100644
+--- a/gstv4l2videodec.c
++++ b/gstv4l2videodec.c
+@@ -593,7 +593,7 @@ gst_v4l2_video_dec_start (GstVideoDecoder * decoder)
+   gst_v4l2_object_unlock (self->v4l2output);
+   g_atomic_int_set (&self->active, TRUE);
+   self->output_flow = GST_FLOW_OK;
+-#if USE_V4L2_TARGET_NV
++#ifdef USE_V4L2_TARGET_NV
+   self->decoded_picture_cnt = 0;
+ #endif
+ 
+@@ -1178,7 +1178,7 @@ gst_v4l2_video_dec_loop (GstVideoDecoder * decoder)
+       gst_caps_unref(reference);
+     }
+ 
+-#if USE_V4L2_TARGET_NV
++#ifdef USE_V4L2_TARGET_NV
+ 
+     if (!gst_buffer_copy_into (frame->output_buffer, frame->input_buffer,
+           (GstBufferCopyFlags)GST_BUFFER_COPY_METADATA, 0, -1)) {
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0002-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.4.3/0002-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
@@ -1,0 +1,55 @@
+From 90d286c1e2261bddabdb84ea1e9a217516c4e44c Mon Sep 17 00:00:00 2001
+From: Jose Quaresma <quaresma.jose@gmail.com>
+Date: Sun, 8 Nov 2020 12:49:03 +0000
+Subject: [PATCH 2/2] gstv4l2videodec: check if we have a pool before the
+ locking in video decoder set format
+
+There's a dead lock on nvv4l2decoder.
+The dead lock is because the gstv4l2bufferpool only set capture_plane_stopped if the object
+that use the poll are V4L2_TYPE_IS_OUTPUT and in this pipeline we have an encoder and h264parse
+in front of the decoder.
+This disable the pool on the nvv4l2decoder and because of this the gstv4l2bufferpool don't
+set the capture_plane_stopped and nvv4l2decoder will waiting forever for this.
+
+This only happens because the h264parse change the caps when the pipeline goes to running
+that will trigger a restart of the nvv4l2decoder in the gst_v4l2_video_dec_set_format.
+
+So disable the the check for capture_plane_stopped on nvv4l2decoder if we don't have a pool
+otherwise nvv4l2decoder will hang forever waiting for capture_plane_stopped.
+
+Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
+---
+ gstv4l2videodec.c | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/gstv4l2videodec.c b/gstv4l2videodec.c
+index 6daf863..76a8f99 100644
+--- a/gstv4l2videodec.c
++++ b/gstv4l2videodec.c
+@@ -684,14 +684,16 @@ gst_v4l2_video_dec_set_format (GstVideoDecoder * decoder,
+     self->output_flow = GST_FLOW_OK;
+ 
+ #ifdef USE_V4L2_TARGET_NV
+-    g_mutex_lock (&self->v4l2capture->cplane_stopped_lock);
+-    while (self->v4l2capture->capture_plane_stopped != TRUE)
+-    {
+-        g_cond_wait (&self->v4l2capture->cplane_stopped_cond,
+-                &self->v4l2capture->cplane_stopped_lock);
++    if (self->v4l2capture->pool ) {
++        g_mutex_lock (&self->v4l2capture->cplane_stopped_lock);
++        while (self->v4l2capture->capture_plane_stopped != TRUE)
++        {
++            g_cond_wait (&self->v4l2capture->cplane_stopped_cond,
++                    &self->v4l2capture->cplane_stopped_lock);
++        }
++        self->v4l2capture->capture_plane_stopped = FALSE;
++        g_mutex_unlock (&self->v4l2capture->cplane_stopped_lock);
+     }
+-    self->v4l2capture->capture_plane_stopped = FALSE;
+-    g_mutex_unlock (&self->v4l2capture->cplane_stopped_lock);
+     gst_v4l2_object_close (self->v4l2output);
+     gst_v4l2_object_close (self->v4l2capture);
+     gst_v4l2_object_open (self->v4l2output);
+-- 
+2.29.2
+

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.4.3.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.4.3.bb
@@ -15,6 +15,9 @@ SRC_URI += "file://build-fixups.patch"
 SRC_URI += "file://0001-v4l2videoenc-Fix-negotiation-caps-leak.patch"
 SRC_URI += "file://0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch"
 SRC_URI += "file://0003-v4l2bufferpool-Avoid-set_flushing-warning.patch"
+# https://github.com/OE4T/meta-tegra/issues/486
+SRC_URI += "file://0001-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch"
+SRC_URI += "file://0002-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch"
 
 DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries"
 


### PR DESCRIPTION
gstreamer1.0-plugins-nvvideo4linux2: check if we have a pool before the locking in video decoder set format

There's a dead lock on nvv4l2decoder.
The dead lock is because the gstv4l2bufferpool only set capture_plane_stopped if the object
that use the poll are V4L2_TYPE_IS_OUTPUT and in this pipeline we have an encoder and h264parse
in front of the decoder.
This disable the pool on the nvv4l2decoder and because of this the gstv4l2bufferpool don't
set the capture_plane_stopped and nvv4l2decoder will waiting forever for this.

This only happens because the h264parse change the caps when the pipeline goes to running
that will trigger a restart of the nvv4l2decoder in the gst_v4l2_video_dec_set_format.

So disable the the check for capture_plane_stopped on nvv4l2decoder if we don't have a pool
otherwise nvv4l2decoder will hang forever waiting for capture_plane_stopped.

https://github.com/OE4T/meta-tegra/issues/486

Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>