### PR TITLE
Add support for the USB device instance to update

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -6,8 +6,9 @@ no_flash=0
 flash_cmd=
 imgfile=
 dataimg=
+inst_args=""
 
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,datafile:" -o "u:v:c:" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,datafile:,usb-instance:" -o "u:v:c:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1
@@ -27,6 +28,11 @@ while true; do
 	    ;;
 	--datafile)
 	    dataimg="$2"
+	    shift 2
+	    ;;
+	--usb-instance)
+	    usb_instance="$2"
+	    inst_args="--instance ${usb_instance}"
 	    shift 2
 	    ;;
 	-u)
@@ -80,7 +86,7 @@ fi
 cvm_bin=$(mktemp cvm.bin.XXXXX)
 
 if [ -z "$BOARDID" -o -z "$FAB" ]; then
-    if ! python3 "$flashappname" --chip 0x18 --applet mb1_recovery_prod.bin --cmd "dump eeprom boardinfo ${cvm_bin}"; then
+    if ! python3 "$flashappname" ${inst_args} --chip 0x18 --applet mb1_recovery_prod.bin --cmd "dump eeprom boardinfo ${cvm_bin}"; then
 	echo "ERR: could not retrieve EEPROM board information" >&2
 	exit 1
     fi
@@ -234,7 +240,7 @@ else
     tfcmd=${flash_cmd:-"flash;reboot"}
 fi
 
-flashcmd="python3 $flashappname --chip 0x18 --bl nvtboot_recovery_cpu.bin \
+flashcmd="python3 $flashappname ${inst_args} --chip 0x18 --bl nvtboot_recovery_cpu.bin \
 	      $cfgappargs \
 	      --odmdata $odmdata \
 	      --cmd \"$tfcmd\" $skipuid \

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -8,9 +8,10 @@ no_flash=0
 flash_cmd=
 imgfile=
 dataimg=
+inst_args=""
 blocksize=4096
 
-ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,spi-only,datafile:" -o "u:v:s:b:B:yc:" -- "$@")
+ARGS=$(getopt -n $(basename "$0") -l "bup,no-flash,sdcard,spi-only,datafile:,usb-instance:" -o "u:v:s:b:B:yc:" -- "$@")
 if [ $? -ne 0 ]; then
     echo "Error parsing options" >&2
     exit 1
@@ -38,6 +39,11 @@ while true; do
 	    ;;
 	--datafile)
 	    dataimg="$2"
+	    shift 2
+	    ;;
+	--usb-instance)
+	    usb_instance="$2"
+	    inst_args="--instance ${usb_instance}"
 	    shift 2
 	    ;;
 	-u)
@@ -130,7 +136,7 @@ if [ -z "$CHIPREV" ]; then
 fi
 
 if [ -z "$FAB" -o -z "$BOARDID" -o \( "$BOARDID" = "2888" -a \( -z "$BOARDSKU" -o \( "$BOARDSKU" != "0004" -a -z "$BOARDREV" \) \) \) ]; then
-    if ! python3 $flashappname --chip 0x19 --applet mb1_t194_prod.bin $skipuid --soft_fuses tegra194-mb1-soft-fuses-l4t.cfg \
+    if ! python3 $flashappname ${inst_args} --chip 0x19 --applet mb1_t194_prod.bin $skipuid --soft_fuses tegra194-mb1-soft-fuses-l4t.cfg \
 		 --bins "mb2_applet nvtboot_applet_t194.bin" --cmd "dump eeprom boardinfo ${cvm_bin};reboot recovery"; then
 	echo "ERR: could not retrieve EEPROM board information" >&2
 	exit 1
@@ -355,7 +361,7 @@ if [ -n "$keyfile" ]; then
     touch odmsign.func
 fi
 
-flashcmd="python3 $flashappname --chip 0x19 --bl nvtboot_recovery_cpu_t194.bin \
+flashcmd="python3 $flashappname ${inst_args} --chip 0x19 --bl nvtboot_recovery_cpu_t194.bin \
 	      --sdram_config $sdramcfg_files \
 	      --odmdata $odmdata \
 	      --applet mb1_t194_prod.bin \


### PR DESCRIPTION
This commit adds support for specifying the USB device instance to update as a new command line argument. This allows supporting multiple NVIDIA devices that may be connected simultaneously with the flash script. The command line usage is as follows:
--usb-instance <id> -- Specify the USB instance to connect to; integer ID (e.g. 0, 1), bus/dev (e.g. 003/091), or USB port path (e.g. 3-14). The latter is best.