### PR TITLE
tegra-helper-scripts: delay before partprobe in make-sdcard

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -335,6 +335,7 @@ if ! sgdisk "$output" --verify >/dev/null 2>&1; then
     exit 1
 fi
 if [ -b "$output" ]; then
+    sleep 1
     if ! $SUDO partprobe "$output" >/dev/null 2>&1; then
 	echo "ERR: partprobe failed after partitioning $output" >&2
 	exit 1


### PR DESCRIPTION
Fixes an issue where the card may still be busy before the partprobe
sync, resulting in "partprobe failed after partitioning" failure.

Signed-off-by: Jon Magnuson <jon.magnuson@gmail.com>

---

It could have just been a fluke, but my very first attempt at running `make-sdcard` failed with:

```
About to make an SDcard image on /dev/sdh. OK? y
Init...TBC...RP1...EBT...WB0...BPF...BPF-DTB...FX...TOS...DTB...LNX...EKS...BMP...RP4...APP...[OK]
ERR: partprobe failed after partitioning /dev/sdh
```

Adding a 1s sleep and running again succeeded:

```
About to make an SDcard image on /dev/sdh. OK? y
Init...TBC...RP1...EBT...WB0...BPF...BPF-DTB...FX...TOS...DTB...LNX...EKS...BMP...RP4...APP...[OK]
Writing...TBC...RP1...EBT...WB0...BPF...TOS...DTB...LNX...EKS...BMP...RP4...APP...[OK: /dev/sdh]
```
