### PR TITLE
tegra-eeprom-tool: add at24 kernel module dependency

### DIFF
--- a/recipes-bsp/tools/tegra-eeprom-tool_1.1.2.bb
+++ b/recipes-bsp/tools/tegra-eeprom-tool_1.1.2.bb
@@ -10,5 +10,7 @@ SRC_URI[sha256sum] = "18002a9a09262b2167d97b4c77ec3ed304f6244383a36b63ba20c1503b
 
 inherit autotools pkgconfig
 
+RRECOMMENDS_${PN} += "kernel-module-at24"
+
 PACKAGES =+ "${PN}-boardspec"
 FILES_${PN}-boardspec = "${bindir}/tegra-boardspec"


### PR DESCRIPTION
Signed-off-by: Shlomi Vaknin <shlomi.39sd@gmail.com>