### PR TITLE
tegra-eeprom-tool: udpate to 1.2.0

### DIFF
--- a/recipes-bsp/tools/tegra-eeprom-tool_1.2.0.bb
+++ b/recipes-bsp/tools/tegra-eeprom-tool_1.2.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c4bff80c7e9a90aa351e9062b5572544"
 DEPENDS = "libedit"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "18002a9a09262b2167d97b4c77ec3ed304f6244383a36b63ba20c1503b2acd12"
+SRC_URI[sha256sum] = "e65452e4abb682063d6b2b37e12596a3e8494bb5325e9fa94e65db078e855c3d"
 
 inherit autotools pkgconfig
 


### PR DESCRIPTION
No new features in the tools themselves, just a refactoring
to expose a shared library for use by other tools.

Signed-off-by: Matt Madison <matt@madison.systems>