### PR TITLE
image_tegraflash: fix no bootargs in DTS

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -462,7 +462,7 @@ create_tegraflash_pkg_tegra194() {
     fi
     if [ -n "${KERNEL_ARGS}" ]; then
         cp -L "${DEPLOY_DIR_IMAGE}/${DTBFILE}" ./${DTBFILE}
-        bootargs="`fdtget ./${DTBFILE} /chosen bootargs 2>/dev/null`"
+        bootargs="`fdtget -d '' ./${DTBFILE} /chosen bootargs 2>/dev/null`"
         fdtput -t s ./${DTBFILE} /chosen bootargs "$bootargs ${KERNEL_ARGS}"
     else
         cp "${DEPLOY_DIR_IMAGE}/${DTBFILE}" ./${DTBFILE}


### PR DESCRIPTION
For #503 

If the kernel DTS does not contain an entry for /chosen bootargs,
fdtget returns with exit code 1, then the image task fails.

Signed-off-by: Ludovic Cintrat <ludovic.cintrat@nexvision.fr>