### PR TITLE
tegra-boot-tools updates

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -566,7 +566,7 @@ TEGRAFLASH_PKG_DEPENDS = "${@'zip-native:do_populate_sysroot' if d.getVar('TEGRA
 do_image_tegraflash[depends] += "${TEGRAFLASH_PKG_DEPENDS} dtc-native:do_populate_sysroot \
                                  ${SOC_FAMILY}-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
-                                 tegra-redundant-boot-base:do_populate_sysroot virtual/kernel:do_deploy \
+                                 tegra-redundant-boot-rollback:do_populate_sysroot virtual/kernel:do_deploy \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \
                                  ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''} \
                                  cboot:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
@@ -676,6 +676,6 @@ create_bup_payload_image() {
 create_bup_payload_image[vardepsexclude] += "DATETIME"
 
 CONVERSIONTYPES += "bup-payload"
-CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-base dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
+CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-rollback dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
 CONVERSION_CMD_bup-payload = "create_bup_payload_image ${type}"
 IMAGE_TYPES += "cpio.gz.cboot.bup-payload"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
@@ -37,6 +37,8 @@ class Partition(object):
         self.oem_sign = element.get('oemsign', 'false') == 'true'
         guid = element.find('unique_guid')
         self.partguid = "" if guid is None else validate_guid(guid.text.strip())
+        startloc = element.find('start_location')
+        self.start_location = "" if startloc is None else str(int(startloc.text.strip(), base=0))
         aa = element.find('allocation_attribute')
         if aa is None:
             self.alloc_attr = 0
@@ -142,10 +144,11 @@ Extracts partition information from an NVIDIA flash.xml file
         partitions = [part for part in layout.devices[args.type].partitions if not part.is_partition_table()]
         blksize = layout.devices[args.type].sector_size
         for n, part in enumerate(partitions):
-            print("blksize={};partnumber={};partname=\"{}\";partsize={};"
+            print("blksize={};partnumber={};partname=\"{}\";start_location={};partsize={};"
                   "partfile=\"{}\";partguid=\"{}\";partfilltoend={}".format(blksize,
                                                                             part.id,
                                                                             part.name,
+                                                                            part.start_location,
                                                                             part.size,
                                                                             part.filename,
                                                                             part.partguid,

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_32.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_32.4.4.bb
@@ -29,16 +29,6 @@ do_install() {
 	install -d ${D}/opt/ota_package
 }
 
-do_install_append_tegra186() {
-	install -d ${D}${datadir}/nv_tegra/rollback/t18x
-	install -m 0644 ${S}/bootloader/rollback/t18x/rollback.cfg ${D}${datadir}/nv_tegra/rollback/t18x/
-}
-
-do_install_append_tegra194() {
-	install -d ${D}${datadir}/nv_tegra/rollback/t19x
-	install -m 0644 ${S}/bootloader/rollback/t19x/rollback.cfg ${D}${datadir}/nv_tegra/rollback/t19x/
-}
-
 do_install_tegra210() {
 	install -d ${D}${sbindir}
 	install -m 0755 ${B}/usr/sbin/l4t_payload_updater_t210 ${D}${sbindir}
@@ -51,7 +41,6 @@ INHIBIT_SYSROOT_STRIP = "1"
 PACKAGES = "tegra-redundant-boot-nvbootctrl ${PN} ${PN}-dev"
 FILES_tegra-redundant-boot-nvbootctrl = "${sbindir}/nvbootctrl"
 FILES_${PN} += "/opt/ota_package"
-FILES_${PN}-dev = "${datadir}/nv_tegra/rollback"
 RDEPENDS_${PN} = "tegra-redundant-boot-nvbootctrl setup-nv-boot-control-service"
 RDEPENDS_${PN}_tegra210 = "setup-nv-boot-control-service python3-core"
 INSANE_SKIP_${PN} = "ldflags"

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot-rollback_32.4.3.bb
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot-rollback_32.4.3.bb
@@ -1,0 +1,28 @@
+require tegra-binaries-${PV}.inc
+require tegra-shared-binaries.inc
+
+COMPATIBLE_MACHINE = "(tegra)"
+PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"
+
+inherit nopackages
+
+do_configure() {
+	:
+}
+do_compile() {
+	:
+}
+
+do_install() {
+	:
+}
+
+do_install_append_tegra186() {
+	install -d ${D}${datadir}/nv_tegra/rollback/t18x
+	install -m 0644 ${S}/bootloader/rollback/t18x/rollback.cfg ${D}${datadir}/nv_tegra/rollback/t18x/
+}
+
+do_install_append_tegra194() {
+	install -d ${D}${datadir}/nv_tegra/rollback/t19x
+	install -m 0644 ${S}/bootloader/rollback/t19x/rollback.cfg ${D}${datadir}/nv_tegra/rollback/t19x/
+}

--- a/recipes-bsp/tools/tegra-boot-tools_2.1.0.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_2.1.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f547d56278324f08919c3805e5fb8df9"
 DEPENDS = "zlib systemd tegra-eeprom-tool"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "da67d7ab0b32b9e762b9bdceaba85fb00b14e9a228555073a03d772677d60c51"
+SRC_URI[sha256sum] = "f69851e449b80e91df9a7ab577ae3808ee36035c3850ac37b4b860973997e525"
 
 OTABOOTDEV ??= "/dev/mmcblk0boot0"
 OTAGPTDEV ??= "/dev/mmcblk0boot1"
@@ -18,13 +18,32 @@ EXTRA_OECONF = "--with-systemdsystemunitdir=${systemd_system_unitdir} \
 inherit autotools pkgconfig systemd
 
 SYSTEMD_PACKAGES = "${PN}-earlyboot ${PN}-lateboot"
-PACKAGES =+ "libtegra-boot-tools ${PN}-earlyboot ${PN}-lateboot ${PN}-updater"
+
+PACKAGES =+ "libtegra-boot-tools ${PN}-earlyboot ${PN}-lateboot ${PN}-updater ${PN}-nvbootctrl ${PN}-nv-update-engine"
+
 SYSTEMD_SERVICE_${PN}-earlyboot = "bootcountcheck.service"
 SYSTEMD_SERVICE_${PN}-lateboot = "update_bootinfo.service"
+
 FILES_libtegra-boot-tools = "${libdir}/libtegra-boot-tools${SOLIBS} ${datadir}/tegra-boot-tools"
+
 FILES_${PN}-earlyboot = "${sbindir}/bootcountcheck"
 RDEPENDS_${PN}-earlyboot = "${PN}"
+
 RDEPENDS_${PN}-lateboot = "${PN}"
+
 FILES_${PN}-updater = "${bindir}/tegra-bootloader-update"
 RDEPENDS_${PN}-updater = "${PN}"
+
 FILES_${PN} += "${libdir}/tmpfiles.d"
+RDEPENDS_${PN} = "tegra-bootpart-config"
+
+FILES_${PN}-nvbootctrl = "${sbindir}/nvbootctrl"
+RDEPENDS_${PN}-nvbootctrl = "${PN}"
+RPROVIDES_${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
+RREPLACES_${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
+RCONFLICTS_${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
+FILES_${PN}-nv-update-engine = "${sbindir}/nv_update_engine"
+RDEPENDS_${PN}-nv-update-engine = "${PN}-updater ${PN}"
+RPROVIDES_${PN}-nv-update-engine = "tegra-redundant-boot-base"
+RREPLACES_${PN}-nv-update-engine = "tegra-redundant-boot-base"
+RCONFLICTS_${PN}-nv-update-engine = "tegra-redundant-boot-base"

--- a/recipes-bsp/tools/tegra-bootpart-config_1.0.bb
+++ b/recipes-bsp/tools/tegra-bootpart-config_1.0.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "Boot partition layout configuration file for tegra210 targets"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+DEPENDS = "tegra-bootfiles tegra-helper-scripts-native"
+
+PATH =. "${STAGING_BINDIR_NATIVE}/tegra210-flash:"
+
+BOOTDEVNAME = "${@'spi' if d.getVar('TEGRA_SPIFLASH_BOOT') == '1' else 'sdmmc_boot'}"
+
+S = "${WORKDIR}"
+B = "${WORKDIR}/build"
+
+do_compile() {
+    :
+}
+
+do_compile_tegra210() {
+    nvflashxmlparse -t ${BOOTDEVNAME} ${STAGING_DATADIR}/tegraflash/${PARTITION_LAYOUT_TEMPLATE} > ${B}/layout.tmp
+    sed -e 's,NXC,NVC,g' -e's,TXC,TBC,g' -e's,WX0,WB0,g' -e 's,BXF,BPF,g' ${B}/layout.tmp > ${B}/layout.txt
+    cursize=0
+    rm -f ${B}/layout.conf
+    touch ${B}/layout.conf
+    while read line; do
+        eval "$line"
+	if [ -n "$start_location" ]; then
+            if [ $cursize -gt $start_location ]; then
+                bberror "Partition $partname start location ($start_location) is less than current offset ($cursize)"
+            fi
+            cursize=$start_location
+        fi
+        partbytes=$(expr $partsize \* $blksize)
+        echo "$partname:$cursize:$partbytes" >> ${B}/layout.conf
+        cursize=$(expr $cursize \+ $partbytes)
+    done < ${B}/layout.txt
+}
+
+do_install() {
+    :
+}
+do_install_tegra210() {
+    install -d ${D}${datadir}/tegra-boot-tools
+    install -m 0644 ${B}/layout.conf ${D}${datadir}/tegra-boot-tools/boot-partitions.conf
+}
+
+FILES_${PN} = "${datadir}/tegra-boot-tools"
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}_tegra210 = "0"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/u-boot/u-boot-bup-payload.bb
+++ b/recipes-bsp/u-boot/u-boot-bup-payload.bb
@@ -65,7 +65,7 @@ do_deploy() {
     fi
 }
 do_deploy[depends] += "virtual/bootloader:do_deploy virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot"
-do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
+do_deploy[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
 do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
 addtask deploy before do_build
 

--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -34,7 +34,7 @@ do_deploy() {
     fi
 }
 do_deploy[depends] += "virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
-do_deploy[depends] += "tegra-redundant-boot-base:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
+do_deploy[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
 do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
 addtask deploy before do_build
 


### PR DESCRIPTION
* Update tegra-boot-tools to version 2.1.0, which supports tegra210 platforms for bootloader updates
* Add recipe to build the config file that tegra-boot-tools needs on tegra210 platforms
* Refactor the tegra-redundant-boot recipes to make it easier to replace the NV-provided updater tools