### PR TITLE
u-boot-tegra: set UBOOT_INITIAL_ENV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tegra_2020.10.bb
+++ b/recipes-bsp/u-boot/u-boot-tegra_2020.10.bb
@@ -1,3 +1,5 @@
+UBOOT_INITIAL_ENV ?= "u-boot-initial-env"
+
 require recipes-bsp/u-boot/u-boot-common.inc
 require recipes-bsp/u-boot/u-boot.inc
 


### PR DESCRIPTION
to 'u-boot-initial-env' so that the libubootenv tools can
find the file automatically.

Signed-off-by: Matt Madison <matt@madison.systems>

Fixes #510 