### PR TITLE
meta-tegra-bug-report: cleanup and fix links

### DIFF
--- a/.github/ISSUE_TEMPLATE/meta-tegra-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/meta-tegra-bug-report.md
@@ -10,11 +10,12 @@ assignees: ''
 **Describe the bug**
 A clear and concise description of what the bug is.
 
-Not a bug?  Review the [CONTRIBUTING.md](CONTRIBUTING.md) file for other ways to get help or feedback.
+Not a bug?  Review the [README.md](https://github.com/OE4T/meta-tegra/blob/master/README.md#getting-help)
+file for other ways to get help or feedback.
 
 **To Reproduce**
 Steps to reproduce the behavior:
-1. Build meta-tegra branch '...' with MACHINE based on '...' 
+1. Build `meta-tegra` branch '...' with `MACHINE` based on '...'
 2. Build with bitbake argument '...'
 3. Deploy to hardware with method '...'
 4. See error '...' with link to any relevant logs at '...'


### PR DESCRIPTION
Use markdown.

Remove relative link which doesn't work and use link to README.md
getting help section instead.

Signed-off-by: Dan Walkes <danwalkes@boulderai.com>