### PR TITLE
[zeus] tegra186-flashtools-native: tegraflash_internal fix with python 3.9.

### DIFF
--- a/recipes-bsp/tegra-binaries/files/0009-Update-tegraflash_internal.py-for-Python-3.9.patch
+++ b/recipes-bsp/tegra-binaries/files/0009-Update-tegraflash_internal.py-for-Python-3.9.patch
@@ -1,0 +1,67 @@
+From 9e6881a09e5a0fb1e78bad182942bed9cb54939b Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kurt.kiefer@arthrex.com>
+Date: Wed, 4 Nov 2020 21:58:48 -0800
+Subject: [PATCH] Update tegraflash_internal.py for Python 3.9
+
+---
+ bootloader/tegraflash_internal.py | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/bootloader/tegraflash_internal.py b/bootloader/tegraflash_internal.py
+index e377695..c5bd6bb 100755
+--- a/bootloader/tegraflash_internal.py
++++ b/bootloader/tegraflash_internal.py
+@@ -804,7 +804,7 @@ def tegraflash_t19x_encrypt_and_sign(cfg_file):
+              list_text = "signed_file"
+          else:
+              list_text = "encrypt_file"
+-         for file_nodes in xml_tree.getiterator('file'):
++         for file_nodes in xml_tree.iter('file'):
+              file_name = file_nodes.get('name')
+              file_type = file_nodes.get('type')
+              magic_id = tegraflash_get_magicid(file_type)
+@@ -1149,7 +1149,7 @@ def tegraflash_encrypt_and_copy_signed_binaries(xml_file, output_dir):
+     else:
+         list_text = "encrypt_file"
+ 
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         file_name = file_nodes.get('name')
+         file_type = file_nodes.get('type')
+         signed_file = file_nodes.find(mode).get(list_text)
+@@ -1184,7 +1184,7 @@ def tegraflash_copy_signed_binaries(xml_file, output_dir):
+         else:
+             list_text = "encrypt_file"
+ 
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         file_name = file_nodes.get('name')
+         signed_file = file_nodes.find(mode).get(list_text)
+         shutil.copyfile(signed_file, output_dir + "/" + os.path.basename(signed_file))
+@@ -1908,7 +1908,7 @@ def tegraflash_oem_encrypt_and_sign_file(in_file, header , magic_id):
+         sig_file = "hash"
+ 
+     signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+ 
+@@ -1990,7 +1990,7 @@ def tegraflash_t21x_sign_file(magicid, in_file):
+     #signed_file = filename
+ 
+    # signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+     if mode == "pkc":
+@@ -2106,7 +2106,7 @@ def tegraflas_oem_sign_file(in_file, magic_id):
+                 sig_file = "hash"
+ 
+     signed_file = filename
+-    for file_nodes in xml_tree.getiterator('file'):
++    for file_nodes in xml_tree.iter('file'):
+         signed_file = file_nodes.find(mode).get(list_text)
+         sig_file = file_nodes.find(mode).get(sig_file)
+ 

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.3.1.bb
@@ -12,6 +12,7 @@ STAMPCLEAN = "${STAMPS_DIR}/work-shared/L4T-native-${SOC_FAMILY}-${PV}-*"
 SRC_URI += "\
            file://0001-Fix-skipuid-arg-usage-for-tx2-in-odmsign.func.patch \
            file://0002-Update-l4t_bup_gen.func-to-handle-signed-encrypted-b.patch \
+           file://0009-Update-tegraflash_internal.py-for-Python-3.9.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"

--- a/recipes-bsp/tegra-binaries/tegra210-flashtools-native_32.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra210-flashtools-native_32.3.1.bb
@@ -14,6 +14,9 @@ SSTATE_SWSPEC = "sstate:tegra-binaries-native::${PV}:${PR}::${SSTATE_VERSION}:"
 STAMP = "${STAMPS_DIR}/work-shared/L4T-native-${SOC_FAMILY}-${PV}-${PR}"
 STAMPCLEAN = "${STAMPS_DIR}/work-shared/L4T-native-${SOC_FAMILY}-${PV}-*"
 
+SRC_URI += "\
+           file://0009-Update-tegraflash_internal.py-for-Python-3.9.patch \
+           "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"
 


### PR DESCRIPTION
methods getiterator have been removed on python 3.9.

Methods getchildren() and getiterator() of classes :class:`~xml.etree.ElementTree.ElementTree`
and :class:`~xml.etree.ElementTree.Element` in the :mod:`~xml.etree.ElementTree` module
have been removed. They were deprecated in Python 3.2.
Use iter(x) or list(x) instead of x.getchildren() and x.iter() or list(x.iter()) instead
of x.getiterator(). (Contributed by Serhiy Storchaka in :issue:`36543`.)

https://github.com/python/cpython/blob/master/Doc/whatsnew/3.9.rst

Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>