### PR TITLE
Changes to improve sstate reuse

### DIFF
--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -16,4 +16,6 @@ def l4t_deb_src_uri(d):
     return ' '.join(["${L4T_DEB_FEED_BASE}/common/pool/main/%s/%s/%s" % (subdir, group, pkg) for pkg in common_debs] +
                     ["${L4T_DEB_FEED_BASE}/%s/pool/main/%s/%s/%s" % (soc, subdir, group, pkg) for pkg in soc_debs])
 
+l4t_deb_src_uri[vardepsexclude] += "L4T_DEB_SOCNAME"
+
 SRC_URI = "${@l4t_deb_src_uri(d)}"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,3 +19,40 @@ BBFILES += "${@' '.join('${LAYERDIR}/external/%s/recipes*/*/*.bb' % layer \
                for layer in BBFILE_COLLECTIONS.split() if os.path.exists(os.path.join('${LAYERDIR}','external',layer)))}"
 BBFILES += "${@' '.join('${LAYERDIR}/external/%s/recipes*/*/*.bbappend' % layer \
                for layer in BBFILE_COLLECTIONS.split() if os.path.exists(os.path.join('${LAYERDIR}','external',layer)))}"
+
+SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += "\
+  tegra-nvstartup->tegra-configs-nvstartup \
+  xserver-xorg-video-nvidia->tegra-configs-xorg \
+  alsa-state->tegra-configs-alsa \
+  tegra-boot-tools->tegra-bootpart-config \
+  weston->tegra-udrm-probeconf \
+  gstreamer1.0-omx-tegra->tegra-configs-omx-tegra \
+  libglvnd->tegra-libraries \
+  vulkan-loader->tegra-libraries \
+  cuda-cudart->tegra-libraries \
+  cuda-cufft->tegra-libraries \
+  cuda-cuobjdump->tegra-libraries \
+  cuda-cupti->tegra-libraries \
+  cuda-curand->tegra-libraries \
+  cuda-cusolver->tegra-libraries \
+  cuda-cusparse->tegra-libraries \
+  cuda-driver->tegra-libraries \
+  cuda-gdb->tegra-libraries \
+  cuda-memcheck->tegra-libraries \
+  cuda-misc-headers->tegra-libraries \
+  cuda-npp->tegra-libraries \
+  cuda-nvcc->tegra-libraries \
+  cuda-nvcc-headers->tegra-libraries \
+  cuda-nvdisasm->tegra-libraries \
+  cuda-nvgraph->tegra-libraries \
+  cuda-nvml->tegra-libraries \
+  cuda-nvprof->tegra-libraries \
+  cuda-nvprune->tegra-libraries \
+  cuda-nvrtc->tegra-libraries \
+  cuda-nvtx->tegra-libraries \
+  libcublas->tegra-libraries \
+  tensorrt->tegra-libraries \
+  libdrm->libdrm-nvdc \
+  libdrm-nvdc->tegra-libraries \
+  tegra-nvs-service->tegra-nvs-base \
+"

--- a/recipes-bsp/tegra-binaries/tegra-nvs-base_32.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvs-base_32.4.4.bb
@@ -20,5 +20,3 @@ PACKAGES = "${PN}"
 FILES_${PN} = "${sbindir} ${sysconfdir}"
 RDEPENDS_${PN} = "bash tegra-libraries"
 INSANE_SKIP_${PN} = "ldflags"
-
-PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"


### PR DESCRIPTION
I've tracked down a bunch of cases in my test builds where packages that could be reused between different Tegra SoCs are instead getting rebuilt or repackaged.  The patches here fix all of the issues I've been able to find so far.