### PR TITLE
cboot: add patches setting machine ID in kernel command line

### DIFF
--- a/recipes-bsp/cboot/cboot-t18x/0007-t186-l4t.mk-make-some-build-options-configurable.patch
+++ b/recipes-bsp/cboot/cboot-t18x/0007-t186-l4t.mk-make-some-build-options-configurable.patch
@@ -1,7 +1,7 @@
-From e87411d0ae296226ba68129c5011bc19c01325ad Mon Sep 17 00:00:00 2001
+From 36e9410daca494317df175063179aa5a3eb54f42 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Tue, 17 Nov 2020 06:23:04 -0800
-Subject: [PATCH] t186/l4t.mk: make some build options configurable
+Subject: [PATCH 7/9] t186/l4t.mk: make some build options configurable
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
@@ -34,5 +34,5 @@ index 4ce060a..64c0e80 100644
 +
  # 0-DSI, 1-HDMI, 2-DP, 3-EDP
 -- 
-2.25.1
+2.27.0
 

--- a/recipes-bsp/cboot/cboot-t18x/0008-t186-add-bootinfo-to-build.patch
+++ b/recipes-bsp/cboot/cboot-t18x/0008-t186-add-bootinfo-to-build.patch
@@ -1,0 +1,25 @@
+From 4a1560c114aaa46f01dece848eaf60e9084a78b4 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 07:48:50 -0800
+Subject: [PATCH 8/9] t186: add bootinfo to build
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/t18x/cboot/platform/t186/rules.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bootloader/partner/t18x/cboot/platform/t186/rules.mk b/bootloader/partner/t18x/cboot/platform/t186/rules.mk
+index 049adac..8569cc8 100644
+--- a/bootloader/partner/t18x/cboot/platform/t186/rules.mk
++++ b/bootloader/partner/t18x/cboot/platform/t186/rules.mk
+@@ -56,6 +56,7 @@ MODULE_DEPS += \
+ 	$(LOCAL_DIR)/../../../../common/drivers/pmic \
+ 	$(LOCAL_DIR)/../../../../common/drivers/pmic/max77620 \
+ 	$(LOCAL_DIR)/../../../../common/drivers/regulator \
++	$(LOCAL_DIR)/../../../../common/lib/bootinfo \
+ 	$(LOCAL_DIR)/../../../../common/lib/storage
+ 
+ GLOBAL_INCLUDES += \
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t18x/0009-Add-machine-ID-to-kernel-command-line.patch
+++ b/recipes-bsp/cboot/cboot-t18x/0009-Add-machine-ID-to-kernel-command-line.patch
@@ -1,0 +1,94 @@
+From dc011c6c33b0b5df2628e92e359af645014269d4 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 07:52:45 -0800
+Subject: [PATCH 9/9] Add machine ID to kernel command line
+
+Set CONFIG_ENABLE_MACHINE_ID during the build
+to enable.
+
+Check and use the first four ODM reserved fuses
+if CONFIG_ENABLE_FUSED_MACHINE_ID is also set and
+the fuses are programmed (non-0), falling back to
+checking the variable.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ .../lib/linuxboot/t186/linuxboot_helper.c     | 48 +++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/bootloader/partner/t18x/common/lib/linuxboot/t186/linuxboot_helper.c b/bootloader/partner/t18x/common/lib/linuxboot/t186/linuxboot_helper.c
+index 158370c..ef70d76 100644
+--- a/bootloader/partner/t18x/common/lib/linuxboot/t186/linuxboot_helper.c
++++ b/bootloader/partner/t18x/common/lib/linuxboot/t186/linuxboot_helper.c
+@@ -48,6 +48,10 @@
+ #include <tegrabl_gpt.h>
+ #include <tegrabl_sigheader.h>
+ 
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++#include <tegrabl_bootinfo.h>
++#endif
++
+ #define SDRAM_START_ADDRESS			0x80000000
+ 
+ #define mc_read32(reg)				NV_READ32(NV_ADDRESS_MAP_MCB_BASE + reg)
+@@ -499,6 +503,47 @@ static int add_vbmeta_info(char *cmdline, int len, char *param, void *priv)
+ }
+ #endif
+ 
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++static int __attribute__((unused)) add_machine_id(char *cmdline, int len, char *param, void *priv)
++{
++	char machineid[65];
++	tegrabl_error_t status;
++	struct devinfo_context *ctx;
++#if defined(CONFIG_ENABLE_FUSED_MACHINE_ID)
++	uint32_t val;
++	int midlen, i;
++#endif
++	if (cmdline == NULL || param == NULL)
++		return -1;
++
++#if defined(CONFIG_ENABLE_FUSED_MACHINE_ID)
++	for (midlen = 0, i = 0; i < 4; i += 1, midlen += 8) {
++		status = tegrabl_fuse_read(FUSE_RESERVED_ODM0 + i, &val, sizeof(val));
++		if (status != TEGRABL_NO_ERROR)
++			goto skip_fuses;
++		if (val == 0)
++			goto skip_fuses;
++		if (tegrabl_snprintf(machineid+midlen, sizeof(machineid)-midlen, "%08x", val) != 8) {
++			pr_error("Error formatting machine ID word %d\n", i);
++			goto skip_fuses;
++		}
++	}
++	machineid[midlen] = '\0';
++	return tegrabl_snprintf(cmdline, len, "%s=%s", param, machineid);
++skip_fuses:
++#endif /* CONFIG_ENABLE_FUSED_MACHINE_ID */
++
++	status = tegrabl_bootinfo_open(&ctx);
++	if (status == TEGRABL_NO_ERROR) {
++		status = tegrabl_bootinfo_getvar(ctx, "machine_id", machineid, sizeof(machineid));
++		if (status == TEGRABL_NO_ERROR)
++			return tegrabl_snprintf(cmdline, len, "%s=%s ", param, machineid);
++		tegrabl_bootinfo_close(ctx);
++	}
++	return -1;
++}
++#endif /* CONFIG_ENABLE_MACHINE_ID */
++
+ static struct tegrabl_linuxboot_param extra_params[] = {
+ 	{ "tegraid", add_tegraid, NULL },
+ 	{ "maxcpus", add_maxcpus, NULL },
+@@ -530,6 +575,9 @@ static struct tegrabl_linuxboot_param extra_params[] = {
+ 	{ "sdhci_tegra.en_boot_part_access", tegrabl_linuxboot_add_string, "1" },
+ #if defined(CONFIG_ENABLE_NVDEC)
+ 	{ "nvdec_enabled", tegrabl_linuxboot_add_nvdec_enabled_info, NULL },
++#endif
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++	{ "systemd.machine_id", add_machine_id, NULL },
+ #endif
+ 	{ NULL, NULL, NULL},
+ };
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t18x_32.4.4.bb
+++ b/recipes-bsp/cboot/cboot-t18x_32.4.4.bb
@@ -4,13 +4,19 @@ SRC_URI = "${L4T_URI_BASE}/cboot_src_t18x.tbz2;downloadfilename=cboot_src_t18x-$
            file://0001-Convert-Python-scripts-to-Python3.patch \
            file://0002-macros.mk-fix-GNU-make-4.3-compatibility.patch \
            file://0003-Restore-version-number-to-L4T-builds.patch \
-           file://0003-t186-l4t.mk-make-some-build-options-configurable.patch \
+           file://0004-Fix-spurious-console-none-warning.patch \
+           file://0005-Add-bootinfo-module-definition-to-tegrabl_error.patch \
+           file://0006-Add-bootinfo-module.patch \
+           file://0007-t186-l4t.mk-make-some-build-options-configurable.patch \
+           file://0008-t186-add-bootinfo-to-build.patch \
+           file://0009-Add-machine-ID-to-kernel-command-line.patch \
 "
 SRC_URI[sha256sum] = "c0921202b563089cd9d1e1860a6822e16729b08ce4b5e1fa5950ab784723cc3c"
 
 PACKAGECONFIG ??= "display recovery"
 PACKAGECONFIG[display] = "CONFIG_ENABLE_DISPLAY=1,,"
 PACKAGECONFIG[recovery] = "CONFIG_ENABLE_L4T_RECOVERY=1,,"
+PACKAGECONFIG[machine-id] = "CONFIG_ENABLE_MACHINE_ID=1,,"
 
 TARGET_SOC = "t186"
 COMPATIBLE_MACHINE = "(tegra186)"

--- a/recipes-bsp/cboot/cboot-t19x/0007-t194-l4t.mk-make-some-build-options-configurable.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0007-t194-l4t.mk-make-some-build-options-configurable.patch
@@ -1,7 +1,7 @@
-From b1b95dcb7762004027b07ce32959db4d41b0073c Mon Sep 17 00:00:00 2001
+From f520ce1f498dfd0341b1becd1f9b9fb4805957ef Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Tue, 17 Nov 2020 05:36:58 -0800
-Subject: [PATCH] t194/l4t.mk: make some build options configurable
+Subject: [PATCH 07/12] t194/l4t.mk: make some build options configurable
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
@@ -41,3 +41,6 @@ index 54629cf..ba0e9f4 100644
  
  MODULE_DEPS +=	\
  	lib/lwip \
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t19x/0008-Support-A-B-slot-for-kernel-on-SDcards-and-USB-devic.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0008-Support-A-B-slot-for-kernel-on-SDcards-and-USB-devic.patch
@@ -1,7 +1,7 @@
-From 775267749384fe31ea5653e76fd77e1c64a7e280 Mon Sep 17 00:00:00 2001
+From 172396c6a6beabca7709d2b64f13ffce179f4878 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Sun, 15 Nov 2020 08:39:41 -0800
-Subject: [PATCH] Support A/B slot for kernel on SDcards and USB devices
+Subject: [PATCH 08/12] Support A/B slot for kernel on SDcards and USB devices
 
 The kernel and DTB loader for USB and SDcard devices
 wasn't checking for A/B slot, and just hard-coded the
@@ -65,5 +65,5 @@ index add52bb..76ad17e 100644
  		goto fail;
  	}
 -- 
-2.25.1
+2.27.0
 

--- a/recipes-bsp/cboot/cboot-t19x/0009-tegrabl_cbo-support-A-B-slots.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0009-tegrabl_cbo-support-A-B-slots.patch
@@ -1,0 +1,64 @@
+From 4c01a6c6b5b7bdcdc6881deaf31d0d8b8ca107c6 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Tue, 17 Nov 2020 07:51:45 -0800
+Subject: [PATCH 09/12] tegrabl_cbo: support A/B slots
+
+Flash layouts include two CPUBL-CFG partitions for A/B support,
+so update the code to handle this.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/common/lib/cbo/tegrabl_cbo.c | 17 +++++++++++++++--
+ 1 file changed, 15 insertions(+), 2 deletions(-)
+
+diff --git a/bootloader/partner/common/lib/cbo/tegrabl_cbo.c b/bootloader/partner/common/lib/cbo/tegrabl_cbo.c
+index 031d608..eb7ae0b 100644
+--- a/bootloader/partner/common/lib/cbo/tegrabl_cbo.c
++++ b/bootloader/partner/common/lib/cbo/tegrabl_cbo.c
+@@ -17,6 +17,9 @@
+ #include <tegrabl_partition_manager.h>
+ #include <tegrabl_cbo.h>
+ #include <string.h>
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++#include <tegrabl_a_b_boot_control.h>
++#endif
+ 
+ #define NVIDIA_BOOT_PARTITION_GUID	"6637b54f-c21b-48a7-952e-a8d071029d6b"
+ #define CBO_DT_SIZE					(4 * 1024) /* 4KB */
+@@ -53,10 +56,14 @@ static struct boot_devices g_boot_devices[] = {
+ 
+ tegrabl_error_t tegrabl_read_cbo(char *part_name)
+ {
++	char cbo_partname[MAX_PARTITION_NAME];
+ 	tegrabl_error_t err = TEGRABL_NO_ERROR;
+ 	void *cbo_buf = NULL;
+ 	struct tegrabl_partition partition;
+ 	uint64_t partition_size;
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	char slot_suffix[MAX_PARTITION_NAME];
++#endif
+ 
+ 	pr_debug("%s: Entry\n", __func__);
+ 
+@@ -65,10 +72,16 @@ tegrabl_error_t tegrabl_read_cbo(char *part_name)
+ 		err = TEGRABL_ERROR(TEGRABL_ERR_INVALID, 0);
+ 		goto fail;
+ 	}
++	strcpy(cbo_partname, part_name);
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	if (tegrabl_a_b_get_bootslot_suffix(slot_suffix, false) == TEGRABL_NO_ERROR) {
++		strcat(cbo_partname, slot_suffix);
++	}
++#endif
+ 
+-	err = tegrabl_partition_open(part_name, &partition);
++	err = tegrabl_partition_open(cbo_partname, &partition);
+ 	if (err != TEGRABL_NO_ERROR) {
+-		pr_error("%s: Failed to open %s partition\n", __func__, part_name);
++		pr_error("%s: Failed to open %s partition\n", __func__, cbo_partname);
+ 		goto fail;
+ 	}
+ 	partition_size = partition.partition_info->total_size;
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t19x/0010-usb_sd_boot-fix-unused-label-warning-when-extlinux-i.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0010-usb_sd_boot-fix-unused-label-warning-when-extlinux-i.patch
@@ -1,7 +1,7 @@
-From f71e34fda5232c6bed3cd7d4c53e333f905a33be Mon Sep 17 00:00:00 2001
+From 7a644be5b0c40d97d112d480d334fbfb3cb2d32c Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Wed, 18 Nov 2020 05:54:03 -0800
-Subject: [PATCH] usb_sd_boot: fix unused-label warning when extlinux is
+Subject: [PATCH 10/12] usb_sd_boot: fix unused-label warning when extlinux is
  disabled
 
 Signed-off-by: Matt Madison <matt@madison.systems>
@@ -25,5 +25,5 @@ index 76ad17e..e15e018 100644
  		/* No partitions found */
  		err = TEGRABL_ERROR(TEGRABL_ERR_NOT_FOUND, 0);
 -- 
-2.25.1
+2.27.0
 

--- a/recipes-bsp/cboot/cboot-t19x/0011-t194-add-bootinfo-to-build.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0011-t194-add-bootinfo-to-build.patch
@@ -1,0 +1,25 @@
+From 4440375389ef68c223d8488c444d69a2ffa2e9cb Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 05:59:33 -0800
+Subject: [PATCH 11/12] t194: add bootinfo to build
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/t18x/cboot/platform/t194/rules.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bootloader/partner/t18x/cboot/platform/t194/rules.mk b/bootloader/partner/t18x/cboot/platform/t194/rules.mk
+index d1e944e..8e2b9d3 100644
+--- a/bootloader/partner/t18x/cboot/platform/t194/rules.mk
++++ b/bootloader/partner/t18x/cboot/platform/t194/rules.mk
+@@ -74,6 +74,7 @@ MODULE_DEPS += \
+ 	$(LOCAL_DIR)/../../../../common/drivers/pwm \
+ 	$(LOCAL_DIR)/../../../../common/drivers/display \
+ 	$(LOCAL_DIR)/../../../../common/lib/cbo \
++	$(LOCAL_DIR)/../../../../common/lib/bootinfo \
+ 	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/lib/device_prod
+ 
+ ifeq ($(filter t19x, $(TARGET_FAMILY)),)
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t19x/0012-Add-machine-ID-to-kernel-command-line.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0012-Add-machine-ID-to-kernel-command-line.patch
@@ -1,0 +1,98 @@
+From c49ed879b88194bb6ae337fd5a5372fc2d1a8d19 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 06:25:49 -0800
+Subject: [PATCH 12/12] Add machine ID to kernel command line
+
+Set CONFIG_ENABLE_MACHINE_ID during the build
+to enable.
+
+Check and use the first four ODM reserved fuses
+if CONFIG_ENABLE_FUSED_MACHINE_ID is also set and
+the fuses are programmed (non-0), falling back to
+checking the variable.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+
+Add machine ID from fuses to kernel command line
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ .../lib/linuxboot/t194/linuxboot_helper.c     | 48 +++++++++++++++++++
+ 1 file changed, 48 insertions(+)
+
+diff --git a/bootloader/partner/t19x/common/lib/linuxboot/t194/linuxboot_helper.c b/bootloader/partner/t19x/common/lib/linuxboot/t194/linuxboot_helper.c
+index 65884cd..aea7395 100644
+--- a/bootloader/partner/t19x/common/lib/linuxboot/t194/linuxboot_helper.c
++++ b/bootloader/partner/t19x/common/lib/linuxboot/t194/linuxboot_helper.c
+@@ -54,6 +54,10 @@
+ #include <tegrabl_a_b_boot_control.h>
+ #endif
+ 
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++#include <tegrabl_bootinfo.h>
++#endif
++
+ #if defined(CONFIG_ENABLE_ANDROID_BOOTREASON)
+ #include <arpmc_impl.h>
+ #include <tegrabl_pmic.h>
+@@ -426,6 +430,47 @@ static int add_vbmeta_info(char *cmdline, int len, char *param, void *priv)
+ }
+ #endif
+ 
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++static int __attribute__((unused)) add_machine_id(char *cmdline, int len, char *param, void *priv)
++{
++	char machineid[65];
++	tegrabl_error_t status;
++	struct devinfo_context *ctx;
++#if defined(CONFIG_ENABLE_FUSED_MACHINE_ID)
++	uint32_t val;
++	int midlen, i;
++#endif
++	if (cmdline == NULL || param == NULL)
++		return -1;
++
++#if defined(CONFIG_ENABLE_FUSED_MACHINE_ID)
++	for (midlen = 0, i = 0; i < 4; i += 1, midlen += 8) {
++		status = tegrabl_fuse_read(FUSE_RESERVED_ODM0 + i, &val, sizeof(val));
++		if (status != TEGRABL_NO_ERROR)
++			goto skip_fuses;
++		if (val == 0)
++			goto skip_fuses;
++		if (tegrabl_snprintf(machineid+midlen, sizeof(machineid)-midlen, "%08x", val) != 8) {
++			pr_error("Error formatting machine ID word %d\n", i);
++			goto skip_fuses;
++		}
++	}
++	machineid[midlen] = '\0';
++	return tegrabl_snprintf(cmdline, len, "%s=%s", param, machineid);
++skip_fuses:
++#endif /* CONFIG_ENABLE_FUSED_MACHINE_ID */
++
++	status = tegrabl_bootinfo_open(&ctx);
++	if (status == TEGRABL_NO_ERROR) {
++		status = tegrabl_bootinfo_getvar(ctx, "machine_id", machineid, sizeof(machineid));
++		if (status == TEGRABL_NO_ERROR)
++			return tegrabl_snprintf(cmdline, len, "%s=%s ", param, machineid);
++		tegrabl_bootinfo_close(ctx);
++	}
++	return -1;
++}
++#endif /* CONFIG_ENABLE_MACHINE_ID */
++
+ #if defined(CONFIG_ENABLE_A_B_SLOT)
+ static int add_boot_slot_suffix(char *, int, char *, void *) __attribute__ ((unused));
+ static int add_boot_slot_suffix(char *cmdline, int len, char *param, void *priv)
+@@ -566,6 +611,9 @@ static struct tegrabl_linuxboot_param extra_params[] = {
+ 	{ "sdhci_tegra.en_boot_part_access", tegrabl_linuxboot_add_string, "1" },
+ #if defined(CONFIG_ENABLE_NVDEC)
+ 	{ "nvdec_enabled", tegrabl_linuxboot_add_nvdec_enabled_info, NULL },
++#endif
++#if defined(CONFIG_ENABLE_MACHINE_ID)
++	{ "systemd.machine_id", add_machine_id, NULL },
+ #endif
+ 	{ NULL, NULL, NULL},
+ };
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/cboot-t19x_32.4.4.bb
+++ b/recipes-bsp/cboot/cboot-t19x_32.4.4.bb
@@ -4,9 +4,15 @@ SRC_URI = "${L4T_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t19x-$
            file://0001-Convert-Python-scripts-to-Python3.patch \
            file://0002-macros.mk-fix-GNU-make-4.3-compatibility.patch \
            file://0003-Restore-version-number-to-L4T-builds.patch \
-           file://0003-t194-l4t.mk-make-some-build-options-configurable.patch \
-           file://0004-Support-A-B-slot-for-kernel-on-SDcards-and-USB-devic.patch \
-           file://0005-usb_sd_boot-fix-unused-label-warning-when-extlinux-i.patch \
+           file://0004-Fix-spurious-console-none-warning.patch \
+           file://0005-Add-bootinfo-module-definition-to-tegrabl_error.patch \
+           file://0006-Add-bootinfo-module.patch \
+           file://0007-t194-l4t.mk-make-some-build-options-configurable.patch \
+           file://0008-Support-A-B-slot-for-kernel-on-SDcards-and-USB-devic.patch \
+           file://0009-tegrabl_cbo-support-A-B-slots.patch \
+           file://0010-usb_sd_boot-fix-unused-label-warning-when-extlinux-i.patch \
+           file://0011-t194-add-bootinfo-to-build.patch \
+           file://0012-Add-machine-ID-to-kernel-command-line.patch \
 "
 
 SRC_URI[sha256sum] = "64acfe1f18d1541e2eb63cb0d38a73c7b85272740e2b073d02ff2100305b5659"
@@ -18,6 +24,7 @@ PACKAGECONFIG[display] = "CONFIG_ENABLE_DISPLAY=1,,"
 PACKAGECONFIG[shell] = "CONFIG_ENABLE_SHELL=1,,"
 PACKAGECONFIG[recovery] = "CONFIG_ENABLE_L4T_RECOVERY=1,,"
 PACKAGECONFIG[extlinux] = "CONFIG_ENABLE_EXTLINUX_BOOT=1,,"
+PACKAGECONFIG[machine-id] = "CONFIG_ENABLE_MACHINE_ID=1,,"
 
 # Xavier NX devkits *must* have this option, or they cannot boot from the SDcard:
 EXTRA_GLOBAL_DEFINES_append_jetson-xavier-nx-devkit = " CONFIG_ENABLE_BOOT_DEVICE_SELECT=1"

--- a/recipes-bsp/cboot/files/0001-Convert-Python-scripts-to-Python3.patch
+++ b/recipes-bsp/cboot/files/0001-Convert-Python-scripts-to-Python3.patch
@@ -1,7 +1,7 @@
-From 97733b0f055002e07afb11c5660916143af21424 Mon Sep 17 00:00:00 2001
+From 7c3802ac05c22ae1ed7cd4efb1a7dc46f6bee881 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Wed, 22 Jan 2020 06:57:17 -0800
-Subject: [PATCH] Convert Python scripts to Python3
+Subject: [PATCH 01/12] Convert Python scripts to Python3
 
 ---
  bootloader/partner/t18x/cboot/build/get_branch_name.py    | 4 ++--
@@ -42,5 +42,5 @@ index 1c90bc5..19f0062 100755
 -        f.write(struct.pack('%ds' % (length), version_string))
 +        f.write(struct.pack('%ds' % (length), version_string.encode('utf-8')))
 -- 
-2.20.1
+2.27.0
 

--- a/recipes-bsp/cboot/files/0002-macros.mk-fix-GNU-make-4.3-compatibility.patch
+++ b/recipes-bsp/cboot/files/0002-macros.mk-fix-GNU-make-4.3-compatibility.patch
@@ -1,7 +1,7 @@
-From 023eab354f691e3cd5c1f0fc7512b8a6c379a069 Mon Sep 17 00:00:00 2001
+From 6a6142cbfdfc2ce87277bb03c86c535854577787 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Tue, 17 Nov 2020 05:12:29 -0800
-Subject: [PATCH] macros.mk: fix GNU make 4.3 compatibility
+Subject: [PATCH 02/12] macros.mk: fix GNU make 4.3 compatibility
 
 Backport of lk upstream commit
 77f5dac5252a9c1a28baab6224431a06b475dba1.
@@ -26,3 +26,6 @@ index b489007..c6165cd 100644
  
  # test if two files are different, replacing the first
  # with the second if so
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/files/0003-Restore-version-number-to-L4T-builds.patch
+++ b/recipes-bsp/cboot/files/0003-Restore-version-number-to-L4T-builds.patch
@@ -1,7 +1,7 @@
-From ae140a4b488e24d8fe08f513dc51e936dc0b391f Mon Sep 17 00:00:00 2001
+From c7c79b61c94b4d7b1349bffe3d6366b925e6fbcd Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Wed, 18 Nov 2020 05:02:56 -0800
-Subject: [PATCH] Restore version number to L4T builds
+Subject: [PATCH 03/12] Restore version number to L4T builds
 
 The stock makefiles omit the version number for L4T builds,
 since they default to using a git hash that isn't available
@@ -34,5 +34,5 @@ index 3053c7f..cd14f27 100644
  $(OUTELF).hex: $(OUTELF)
  	@echo generating hex file: $@
 -- 
-2.25.1
+2.27.0
 

--- a/recipes-bsp/cboot/files/0004-Fix-spurious-console-none-warning.patch
+++ b/recipes-bsp/cboot/files/0004-Fix-spurious-console-none-warning.patch
@@ -1,0 +1,30 @@
+From 8f9928eed9d7a7b30c1d666b5b7c49223f2682b6 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Thu, 19 Nov 2020 07:32:29 -0800
+Subject: [PATCH 04/12] Fix spurious console=none warning
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/common/lib/linuxboot/dtb_update.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/bootloader/partner/common/lib/linuxboot/dtb_update.c b/bootloader/partner/common/lib/linuxboot/dtb_update.c
+index 7275590..60aa749 100644
+--- a/bootloader/partner/common/lib/linuxboot/dtb_update.c
++++ b/bootloader/partner/common/lib/linuxboot/dtb_update.c
+@@ -349,9 +349,9 @@ static tegrabl_error_t add_bootarg_info(void *fdt, int nodeoffset)
+ 	err = tegrabl_linuxboot_helper_get_info(
+ 						TEGRABL_LINUXBOOT_INFO_DEBUG_CONSOLE, NULL, &console);
+ 	if (((err == TEGRABL_NO_ERROR) && (console == TEGRABL_LINUXBOOT_DEBUG_CONSOLE_NONE)) || odm_config_set) {
+-			param_value_override(dtb_cmdline, &len, "console=", "none");
+-	} else
+-		pr_warn("WARN: Fail to override \"console=none\" in commandline\n");
++		if (param_value_override(dtb_cmdline, &len, "console=", "none") != TEGRABL_NO_ERROR)
++			pr_warn("WARN: Fail to override \"console=none\" in commandline\n");
++	}
+ 
+ 	len = tegrabl_snprintf(ptr, remain, "%s ",
+ 			tegrabl_linuxboot_prepare_cmdline(dtb_cmdline));
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/files/0005-Add-bootinfo-module-definition-to-tegrabl_error.patch
+++ b/recipes-bsp/cboot/files/0005-Add-bootinfo-module-definition-to-tegrabl_error.patch
@@ -1,0 +1,42 @@
+From 69b7b0d439562abdbd09389b1faa0fcc27a4f366 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 06:10:05 -0800
+Subject: [PATCH 05/12] Add bootinfo module definition to tegrabl_error
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/common/include/tegrabl_error.h           | 3 ++-
+ bootloader/partner/common/lib/tegrabl_error/tegrabl_error.c | 1 +
+ 2 files changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/bootloader/partner/common/include/tegrabl_error.h b/bootloader/partner/common/include/tegrabl_error.h
+index 19e9c01..ed8028f 100644
+--- a/bootloader/partner/common/include/tegrabl_error.h
++++ b/bootloader/partner/common/include/tegrabl_error.h
+@@ -317,9 +317,10 @@ typedef uint32_t tegrabl_err_reason_t;
+ #define TEGRABL_ERR_USBMSD 0x7CU
+ #define TEGRABL_ERR_CBO 0x7DU
+ #define TEGRABL_ERR_SHELL 0x7EU
++#define TEGRABL_ERR_BOOTINFO 0x7FU
+ 
+ /**** This should be last ****/
+-#define TEGRABL_ERR_MODULE_END 0x7FU
++#define TEGRABL_ERR_MODULE_END 0x80U
+ #define TEGRABL_ERR_MODULE_MAX 0xffU
+ 
+ typedef uint32_t tegrabl_err_module_t;
+diff --git a/bootloader/partner/common/lib/tegrabl_error/tegrabl_error.c b/bootloader/partner/common/lib/tegrabl_error/tegrabl_error.c
+index 0c210be..60d04ee 100644
+--- a/bootloader/partner/common/lib/tegrabl_error/tegrabl_error.c
++++ b/bootloader/partner/common/lib/tegrabl_error/tegrabl_error.c
+@@ -230,6 +230,7 @@ const char *module_strings[TEGRABL_ERR_MODULE_END] = {
+ 	ADD_ERROR_MODULE(CONFIG_STORAGE),
+ 	ADD_ERROR_MODULE(USBMSD),
+ 	ADD_ERROR_MODULE(CBO),
++	ADD_ERROR_MODULE(BOOTINFO),
+ };
+ 
+ /**
+-- 
+2.27.0
+

--- a/recipes-bsp/cboot/files/0006-Add-bootinfo-module.patch
+++ b/recipes-bsp/cboot/files/0006-Add-bootinfo-module.patch
@@ -1,0 +1,438 @@
+From 191a2ae1edaacd86e433d39418419eae3213123d Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 28 Dec 2020 05:58:46 -0800
+Subject: [PATCH 06/12] Add bootinfo module
+
+for accessing variables that can be set via the tegra-bootinfo
+utility in tegra-boot-tools.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ .../common/include/lib/tegrabl_bootinfo.h     |  34 ++
+ .../partner/common/lib/bootinfo/rules.mk      |  34 ++
+ .../common/lib/bootinfo/tegrabl_bootinfo.c    | 331 ++++++++++++++++++
+ 3 files changed, 399 insertions(+)
+ create mode 100644 bootloader/partner/common/include/lib/tegrabl_bootinfo.h
+ create mode 100644 bootloader/partner/common/lib/bootinfo/rules.mk
+ create mode 100644 bootloader/partner/common/lib/bootinfo/tegrabl_bootinfo.c
+
+diff --git a/bootloader/partner/common/include/lib/tegrabl_bootinfo.h b/bootloader/partner/common/include/lib/tegrabl_bootinfo.h
+new file mode 100644
+index 0000000..1653916
+--- /dev/null
++++ b/bootloader/partner/common/include/lib/tegrabl_bootinfo.h
+@@ -0,0 +1,34 @@
++#ifndef tegrabl_bootinfo_h__
++#define tegrabl_bootinfo_h__
++/*
++ * Copyright (c) 2019-2021, Matthew Madison
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++#include <string.h>
++#include <tegrabl_error.h>
++
++struct devinfo_context;
++
++tegrabl_error_t tegrabl_bootinfo_open(struct devinfo_context **ctxp);
++void tegrabl_bootinfo_close(struct devinfo_context *ctx);
++tegrabl_error_t tegrabl_bootinfo_getvar(struct devinfo_context *ctx, const char *name, char *buf, size_t bufsiz);
++
++#endif /* tegrabl_bootinfo_h__ */
+diff --git a/bootloader/partner/common/lib/bootinfo/rules.mk b/bootloader/partner/common/lib/bootinfo/rules.mk
+new file mode 100644
+index 0000000..c81824d
+--- /dev/null
++++ b/bootloader/partner/common/lib/bootinfo/rules.mk
+@@ -0,0 +1,34 @@
++#
++# Copyright (c) 2019-2021, Matthew Madison
++#
++# Permission is hereby granted, free of charge, to any person obtaining
++# a copy of this software and associated documentation files
++# (the "Software"), to deal in the Software without restriction,
++# including without limitation the rights to use, copy, modify, merge,
++# publish, distribute, sublicense, and/or sell copies of the Software,
++# and to permit persons to whom the Software is furnished to do so,
++# subject to the following conditions:
++#
++# The above copyright notice and this permission notice shall be
++# included in all copies or substantial portions of the Software.
++#
++# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++# IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++# CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++# TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++# SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++#
++
++LOCAL_DIR := $(GET_LOCAL_DIR)
++
++MODULE := $(LOCAL_DIR)
++
++GLOBAL_INCLUDES += \
++	$(LOCAL_DIR)
++
++MODULE_SRCS += \
++	$(LOCAL_DIR)/tegrabl_bootinfo.c
++
++include make/module.mk
+diff --git a/bootloader/partner/common/lib/bootinfo/tegrabl_bootinfo.c b/bootloader/partner/common/lib/bootinfo/tegrabl_bootinfo.c
+new file mode 100644
+index 0000000..85640f8
+--- /dev/null
++++ b/bootloader/partner/common/lib/bootinfo/tegrabl_bootinfo.c
+@@ -0,0 +1,331 @@
++/*
++ * bootinfo.c - boot info variables from tegra-boot-tools
++ *
++ * Copyright (c) 2019-2021, Matthew Madison
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining
++ * a copy of this software and associated documentation files
++ * (the "Software"), to deal in the Software without restriction,
++ * including without limitation the rights to use, copy, modify, merge,
++ * publish, distribute, sublicense, and/or sell copies of the Software,
++ * and to permit persons to whom the Software is furnished to do so,
++ * subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be
++ * included in all copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
++ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
++ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
++ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
++ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
++ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
++ */
++
++#define MODULE TEGRABL_ERR_BOOTINFO
++
++#include <string.h>
++#include <stdint.h>
++#include <tegrabl_bootinfo.h>
++#include <tegrabl_blockdev.h>
++#include <tegrabl_malloc.h>
++#include <tegrabl_error.h>
++#include <tegrabl_debug.h>
++#include <zlib.h>
++
++static const char DEVICE_MAGIC[8] = {'B', 'O', 'O', 'T', 'I', 'N', 'F', 'O'};
++#define DEVICE_MAGIC_SIZE sizeof(DEVICE_MAGIC)
++
++static const uint16_t DEVINFO_VERSION_OLDER = 1;
++static const uint16_t DEVINFO_VERSION_OLD = 2;
++static const uint16_t DEVINFO_VERSION_CURRENT = 3;
++
++#define DEVINFO_BLOCK_SIZE 512
++
++struct device_info {
++	unsigned char magic[DEVICE_MAGIC_SIZE];
++	uint16_t devinfo_version;
++	uint8_t  flags;
++	uint8_t  failed_boots;
++	uint32_t crcsum;
++	uint8_t  sernum;
++	uint8_t  unused__;
++	uint16_t ext_sectors;
++} __attribute__((packed));
++#define DEVINFO_HDR_SIZE sizeof(struct device_info)
++#define EXTENSION_SIZE (511*512)
++#define VARSPACE_SIZE (DEVINFO_BLOCK_SIZE+EXTENSION_SIZE-(DEVINFO_HDR_SIZE+sizeof(uint32_t)))
++/*
++ * Maximum size for a variable value is all of the variable space minus two bytes
++ * for null terminators (for name and value) and one byte for a name, plus one
++ * byte for the null character terminating the variable list.
++ */
++#define MAX_VALUE_SIZE (VARSPACE_SIZE-4)
++
++struct devinfo_context {
++	tegrabl_bdev_t *bdev;
++	int valid[2];
++	int current;
++	size_t extsize[2];
++	uint8_t infobuf[2][DEVINFO_BLOCK_SIZE+EXTENSION_SIZE];
++};
++
++/*
++ * We stash the info at the end of mmcblk0boot1.
++ * On tegra186/194 platforms, it goes just
++ * in front of the pseudo-GPT that NVIDIA puts at the
++ * very end. On tegra210 platforms, it goes at the
++ * very end. Two copies are stored, with one 512 byte
++ * sector each for the base, plus extended storage
++ * for variables of one or more sectors (configurable
++ * at build time). On tegra186/194 platforms, the two
++ * copies are located together, while on tegra210 platforms,
++ * the second copy is located between VER_b and VER.
++ *
++ * We look for these using SEEK_END, so the offsets
++ * must be negative. The pseudo-GPT occupies the
++ * last 34 sectors of the partition, and we leave two
++ * additional sectors as buffer (on t186/t194).
++ *
++ * Note that 4 bytes are reserved at the end of
++ * each of the extended storage blocks for a CRC
++ * checksum for the block, which is maintained
++ * separately from the CRC checksum for the base
++ * block for compatibility with older versions of
++ * this tool that did not support the extensions.
++ *
++ * Example layout on t186/t194 with 256KiB (1 base sector
++ * plus 511 extension sectors) per storage copy:
++ *
++ *  sector                                          offset (hex)
++ *  7132         +---------------------------------+  37B800
++ *               |       extended var store B      |
++ *               +---------------------------------+
++ *  7643         +---------------------------------+  3BB600
++ *               |       extended var store A      |
++ *               +---------------------------------+
++ *  8154         =       base devinfo copy B       =  3FB400
++ *  8155         =       base devinfo copy A       =  3FB600
++ *               ~---------- buffer ---------------~  3FB800
++ *  8159         +---------------------------------+
++ *               |           pseudo-GPT            |
++ *  8192         +---------------------------------+
++ *
++ * Example layout on t210 (eMMC) with 8Kib (1 base sector
++ * plus 15 extension sectors) per storage copy:
++ *
++ *  sector                                          offset (hex)
++ *  7936         +---------------------------------+  3E0000
++ *               |          VER_b                  |
++ *               +---------------------------------+
++ *  8047         +---------------------------------+  3EDE00
++ *               |       extended var store B      |
++ *               +---------------------------------+
++ *  8063         =       base devinfo copy B       =  3EFE00
++ *  8064         +---------------------------------+  3F0000
++ *               |          VER                    |
++ *               +---------------------------------+
++ *  8175         +---------------------------------+  3FDE00
++ *               |       extended var store A      |
++ *               +---------------------------------+
++ *  8191         =       base devinfo copy A       =  3FFE00
++ *
++ */
++#define OFFSET_COUNT 2
++static const off_t devinfo_offset[OFFSET_COUNT] = {
++	[0] = -((36 + 1) * 512),
++	[1] = -((36 + 2) * 512),
++};
++
++/*
++ * tegrabl_bootinfo_open
++ *
++ * Tries to find a valid bootinfo block, and initializes a context
++ * if one is found.
++ *
++ */
++tegrabl_error_t
++tegrabl_bootinfo_open (struct devinfo_context **ctxp)
++{
++	struct devinfo_context *ctx;
++	struct device_info *dp;
++	tegrabl_bdev_t *bdev, *bdev_mmcboot, *bdev_spiflash;
++	tegrabl_error_t err;
++	int i;
++
++	*ctxp = NULL;
++
++	bdev_mmcboot = bdev_spiflash = NULL;
++	for (bdev = tegrabl_blockdev_next_device(NULL);
++	     bdev != NULL;
++	     bdev = tegrabl_blockdev_next_device(bdev)) {
++		if (tegrabl_blockdev_get_storage_type(bdev) == TEGRABL_STORAGE_SDMMC_BOOT)
++			bdev_mmcboot = bdev;
++		else if (tegrabl_blockdev_get_storage_type(bdev) == TEGRABL_STORAGE_QSPI_FLASH)
++			bdev_spiflash = bdev;
++	}
++
++	if (bdev_mmcboot == NULL && bdev_spiflash == NULL)
++		return TEGRABL_ERROR(TEGRABL_ERR_NOT_FOUND, 0);
++	
++	ctx = tegrabl_calloc(1, sizeof(struct devinfo_context));
++	if (ctx == NULL)
++		return TEGRABL_ERROR(TEGRABL_ERR_NO_MEMORY, 0);
++
++	ctx->bdev = bdev_mmcboot == NULL ? bdev_spiflash : bdev_mmcboot;
++	pr_debug("%s: bootinfo device: 0x%x\n", __func__, ctx->bdev->device_id);
++	
++	for (i = 0; i < OFFSET_COUNT; i++) {
++		off_t start = (off_t) ctx->bdev->size;
++		/*
++		 * Read base block
++		 */
++		pr_debug("%s: end of device = %lld, devinfo_offset[%d] = %lld\n", __func__,
++			(long long)start, i, (long long)devinfo_offset[i]);
++		start += devinfo_offset[i];
++		err = tegrabl_blockdev_read(ctx->bdev, &ctx->infobuf[i][0], start, DEVINFO_BLOCK_SIZE);
++		if (err != TEGRABL_NO_ERROR)
++			continue;
++
++		dp = (struct device_info *)(ctx->infobuf[i]);
++
++		if (memcmp(dp->magic, DEVICE_MAGIC, DEVICE_MAGIC_SIZE) != 0)
++			continue;
++		pr_debug("%s: found magic for %d\n", __func__, i);
++		/*
++		 * Automatically convert older layouts to current:
++		 *
++		 * V1 was one sector with different structure and no variable space
++		 * V2 was one sector with variables but no extension space
++		 */
++		if (dp->devinfo_version == DEVINFO_VERSION_OLDER)
++			continue;
++
++		if (dp->devinfo_version == DEVINFO_VERSION_OLD) {
++			uint32_t crcsum = dp->crcsum;
++			dp->crcsum = 0;
++			if (crc32(0, ctx->infobuf[i], DEVINFO_BLOCK_SIZE) != crcsum)
++				continue;
++			ctx->valid[i] = 1;
++			memset(ctx->infobuf[i] + DEVINFO_BLOCK_SIZE, 0, EXTENSION_SIZE);
++			dp->ext_sectors = 0;
++			ctx->extsize[i] = 0;
++			pr_debug("%s: found old devinfo version for %d\n", __func__, i);
++			continue;
++		}
++		if (dp->devinfo_version >= DEVINFO_VERSION_CURRENT) {
++			uint32_t crcsum;
++			size_t extsize;
++
++			extsize = dp->ext_sectors * 512;
++			pr_debug("%s: found current devinfo version for %d, extsize=%u\n", __func__, i, extsize);
++			/*
++			 * Read extension block:
++			 *    first sits just above the second base devinfo block
++			 *    second sits above the first
++			 */
++			start = (off_t) ctx->bdev->size + devinfo_offset[1] - (extsize * (i + 1));
++			pr_debug("%s: extension offset[%d] = %lld\n", __func__, i, (long long)start);
++			err = tegrabl_blockdev_read(ctx->bdev, &ctx->infobuf[i][DEVINFO_BLOCK_SIZE], start, extsize);
++			if (err != TEGRABL_NO_ERROR)
++				continue;
++			crcsum = *(uint32_t *)(&ctx->infobuf[i][DEVINFO_BLOCK_SIZE+extsize-sizeof(uint32_t)]);
++			if (crc32(0, &ctx->infobuf[i][DEVINFO_BLOCK_SIZE], extsize-sizeof(uint32_t)) != crcsum)
++				continue;
++			ctx->extsize[i] = extsize;
++		} else
++			continue; /* unrecognized version */
++		pr_debug("%s: devinfo[%d] is valid\n", __func__, i);
++		ctx->valid[i] = 1;
++	}
++	if (!(ctx->valid[0] || ctx->valid[1])) {
++		tegrabl_free(ctx);
++		return TEGRABL_ERROR(TEGRABL_ERR_NOT_FOUND, 0);
++	}
++
++	*ctxp = ctx;
++	if (ctx->valid[0] && !ctx->valid[1])
++		ctx->current = 0;
++	else if (!ctx->valid[0] && ctx->valid[1])
++		ctx->current = 1;
++	else {
++		/* both valid */
++		struct device_info *dp1 = (struct device_info *)(ctx->infobuf[1]);
++		dp = (struct device_info *)(ctx->infobuf[0]);
++		if (dp->sernum == 255 && dp1->sernum == 0)
++			ctx->current = 1;
++		else if (dp1->sernum == 255 && dp->sernum == 0)
++			ctx->current = 0;
++		else if (dp1->sernum > dp->sernum)
++			ctx->current = 1;
++		else
++			ctx->current = 0;
++	}
++
++	return TEGRABL_NO_ERROR;
++
++} /* tegrabl_bootinfo_open */
++
++
++/*
++ * tegrabl_bootinfo_close
++ *
++ * Cleans up a context, freeing memory and closing open channels.
++ */
++void
++tegrabl_bootinfo_close (struct devinfo_context *ctx)
++{
++	if (ctx != NULL)
++		tegrabl_free(ctx);
++
++} /* tegrabl_bootinfo_close */
++
++
++/*
++ * tegrabl_bootinfo_getvar
++ *
++ * returns the value of a bootinfo variable
++ */
++tegrabl_error_t
++tegrabl_bootinfo_getvar (struct devinfo_context *ctx, const char *name,
++			 char *buf, size_t bufsiz)
++{
++	char *cp, *endp, *valp;
++	ssize_t remain, varbytes;
++
++	if (ctx == NULL || name == NULL)
++		return TEGRABL_ERROR(TEGRABL_ERR_INVALID, 0);
++
++	pr_debug("%s: enter\n", __func__);
++	for (cp = (char *)(ctx->infobuf[ctx->current] + DEVINFO_HDR_SIZE),
++		     remain = (ssize_t) ctx->extsize + DEVINFO_BLOCK_SIZE - (DEVINFO_HDR_SIZE+sizeof(uint32_t));
++	     remain > 0 && *cp != '\0';
++	     cp += varbytes, remain -= varbytes) {
++		for (endp = cp + 1, varbytes = 1;
++		     varbytes < remain && *endp != '\0';
++		     endp++, varbytes++);
++		if (varbytes >= remain)
++			break;
++		for (valp = endp + 1, varbytes += 1;
++		     varbytes < remain && *valp != '\0';
++		     valp++, varbytes++);
++		if (varbytes >= remain)
++			break;
++		pr_debug("%s: var=%s, val=%s\n", __func__, cp, endp+1);
++		if (strcmp(cp, name) == 0) {
++			size_t valsize = valp - (endp + 1);
++			if (valsize >= bufsiz)
++				valsize = bufsiz - 1;
++			memcpy(buf, endp + 1, valsize);
++			buf[valsize] = '\0';
++			pr_debug("%s: valsize=%u\n", __func__, valsize);
++			return TEGRABL_NO_ERROR;
++		}
++		varbytes += 1; /* for trailing null at end of value */
++	}
++	pr_debug("%s: %s not found\n", __func__, name);
++
++	return TEGRABL_ERROR(TEGRABL_ERR_NOT_FOUND, 0);
++
++} /* tegrabl_bootinfo_getvar */
+-- 
+2.27.0
+


### PR DESCRIPTION
* Refreshed and rebased existing patches
* Added module for accessing tegra-bootinfo variables from
  tegra-boot-tools
* Add patch to silence a spurious warning about 'console=none'

Covers both cboot-t18x and cboot-t19x.

Signed-off-by: Matt Madison <matt@madison.systems>