### PR TITLE
linux-tegra: bump SRCREV

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -18,7 +18,7 @@ LINUX_VERSION_EXTENSION ?= "-l4t-r${@'.'.join(d.getVar('L4T_VERSION').split('.')
 SCMVERSION ??= "y"
 
 SRCBRANCH = "oe4t-patches${LINUX_VERSION_EXTENSION}"
-SRCREV = "87e09c14b15ad302b451f40f4237bb14f553c1e0"
+SRCREV = "a28ca7b3779d65b032aecf80b58be4d8458a2ded"
 KBRANCH = "${SRCBRANCH}"
 SRC_REPO = "github.com/OE4T/linux-tegra-4.9;protocol=https"
 KERNEL_REPO = "${SRC_REPO}"


### PR DESCRIPTION
To pick up fixes for KVM support as well as patches
for recently-announced security vulnerabilities
CVE-2021-1069 and CVE-2021-1071.

Signed-off-by: Matt Madison <matt@madison.systems>