### PR TITLE
linux-tegra: bump SRCREV

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -15,7 +15,7 @@ LINUX_VERSION_EXTENSION ?= "-l4t-r${@'.'.join(d.getVar('L4T_VERSION').split('.')
 SCMVERSION ??= "y"
 
 SRCBRANCH = "patches${LINUX_VERSION_EXTENSION}"
-SRCREV = "3924d6fccfbf4757b40adf3e06628d566681b011"
+SRCREV = "166b394331e2ffc509368b7942d8821a711ef381"
 KBRANCH = "${SRCBRANCH}"
 SRC_REPO = "github.com/OE4T/linux-tegra-4.9;protocol=https"
 KERNEL_REPO = "${SRC_REPO}"


### PR DESCRIPTION
To pick up fixes for recently-announced security
vulnerabilities CVE-2021-1069 and CVE-2021-1071.

Signed-off-by: Matt Madison <matt@madison.systems>