### PR TITLE
cboot: add patch for gcc-10 compilation failures

### DIFF
--- a/recipes-bsp/cboot/cboot-t18x_32.4.4.bb
+++ b/recipes-bsp/cboot/cboot-t18x_32.4.4.bb
@@ -1,6 +1,7 @@
 DESCRIPTION = "cboot bootloader for Tegra186"
 
 SRC_URI = "${L4T_URI_BASE}/cboot_src_t18x.tbz2;downloadfilename=cboot_src_t18x-${PV}.tbz2;subdir=${BP} \
+           file://0000-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch \
            file://0001-Convert-Python-scripts-to-Python3.patch \
            file://0002-macros.mk-fix-GNU-make-4.3-compatibility.patch \
            file://0003-Restore-version-number-to-L4T-builds.patch \

--- a/recipes-bsp/cboot/cboot-t19x_32.4.4.bb
+++ b/recipes-bsp/cboot/cboot-t19x_32.4.4.bb
@@ -1,6 +1,7 @@
 DESCRIPTION = "cboot bootloader for Tegra194"
 
 SRC_URI = "${L4T_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t19x-${PV}.tbz2;subdir=${BP} \
+           file://0000-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch \
            file://0001-Convert-Python-scripts-to-Python3.patch \
            file://0002-macros.mk-fix-GNU-make-4.3-compatibility.patch \
            file://0003-Restore-version-number-to-L4T-builds.patch \

--- a/recipes-bsp/cboot/files/0000-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
+++ b/recipes-bsp/cboot/files/0000-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
@@ -1,0 +1,30 @@
+From d8bee04385ee424441e7dacab64d576ba39c7498 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Tue, 2 Feb 2021 09:43:51 -0800
+Subject: [PATCH] Drop mistaken global variable definition in sdmmc_defs
+
+which looks like it was meant to be a typedef, but the
+code actually uses the struct tag in all declarations,
+so dropping the type name is OK.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h b/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
+index 0130ad8..77e86fc 100644
+--- a/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
++++ b/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
+@@ -224,7 +224,7 @@ struct tegrabl_sdmmc {
+ 	bnum_t last_xfer_blocks;
+ 	void *last_xfer_buf;
+ 
+-} sdmmc_context_t;
++};
+ 
+ #define SDMMC_BLOCK_SIZE_LOG2			9U	/* 512 bytes */
+ 
+-- 
+2.27.0
+


### PR DESCRIPTION
A typo in a header file results in a global variable instead of
a type definitions, leading to linker failures when compiling
with gcc 10 and its defaulting to -fno-common.

Signed-off-by: Matt Madison <matt@madison.systems>