### PR TITLE
Workarounds for handling zstd-compressed tarballs in L4T deb packages

### DIFF
--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -21,3 +21,11 @@ l4t_deb_src_uri[vardepsexclude] += "L4T_DEB_SOCNAME"
 SRC_URI = "${@l4t_deb_src_uri(d)}"
 do_unpack[depends] += "zstd-l4t-workaround-native:do_populate_sysroot"
 EXTRANATIVEPATH += "zstd-l4t-workaround-native"
+
+do_unpack[depends] += "tar-l4t-workaround-native:do_populate_sysroot"
+EXTRANATIVEPATH += "tar-l4t-workaround-native"
+
+do_unpack_prepend() {
+    subpath = ':'.join([p for p in d.getVar('PATH').split(':') if 'tar-l4t-workaround-native' not in p])
+    os.environ['TAR_WRAPPER_STRIPPED_PATH'] = subpath
+}

--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -19,4 +19,5 @@ def l4t_deb_src_uri(d):
 l4t_deb_src_uri[vardepsexclude] += "L4T_DEB_SOCNAME"
 
 SRC_URI = "${@l4t_deb_src_uri(d)}"
-do_unpack[depends] += "zstd-native:do_populate_sysroot"
+do_unpack[depends] += "zstd-l4t-workaround-native:do_populate_sysroot"
+EXTRANATIVEPATH += "zstd-l4t-workaround-native"

--- a/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
+++ b/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "tar wrapper script for handling zstd suffix"
+LICENSE = "MIT"
+
+SRC_URI = "file://tar-wrapper.sh"
+
+NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"
+
+inherit native
+
+do_configure() {
+    :
+}
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -m 0755 -D ${WORKDIR}/tar-wrapper.sh ${D}${bindir}/tar
+}

--- a/recipes-l4t-workarounds/tar/tar-l4t-workaround/tar-wrapper.sh
+++ b/recipes-l4t-workarounds/tar/tar-l4t-workaround/tar-wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# bitbake fetcher passes --no-same-owner -xpf <filename>
+tarargs=
+extraarg=
+while [ $# -gt 0 ]; do
+    case "$1" in
+	-x*f)
+	    tarargs="$tarargs $1 $2"
+	    if [ "$2" = "data.tar.zst" ]; then
+		tarargs="$tarargs -Iunzstd"
+	    fi
+	    shift 2
+	    ;;
+	*)
+	    tarargs="$tarargs $1"
+	    shift
+	    ;;
+    esac
+done
+PATH="$TAR_WRAPPER_STRIPPED_PATH" tar $tarargs

--- a/recipes-l4t-workarounds/zstd/zstd-l4t-workaround-native_1.4.8.bb
+++ b/recipes-l4t-workarounds/zstd/zstd-l4t-workaround-native_1.4.8.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Zstandard - Fast real-time compression algorithm"
+DESCRIPTION = "Zstandard is a fast lossless compression algorithm, targeting \
+real-time compression scenarios at zlib-level and better compression ratios. \
+It's backed by a very fast entropy stage, provided by Huff0 and FSE library."
+HOMEPAGE = "http://www.zstd.net/"
+SECTION = "console/utils"
+
+LICENSE = "BSD-3-Clause & GPLv2"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=c7f0b161edbe52f5f345a3d1311d0b32 \
+                    file://COPYING;md5=39bba7d2cf0ba1036f2a6e2be52fe3f0"
+
+SRC_URI = "git://github.com/facebook/zstd.git;branch=release \
+           file://0001-Makefile-sort-all-wildcard-file-list-expansions.patch \
+           "
+
+SRCREV = "97a3da1df009d4dc67251de0c4b1c9d7fe286fc1"
+UPSTREAM_CHECK_GITTAGREGEX = "v(?P<pver>\d+(\.\d+)+)"
+
+S = "${WORKDIR}/git"
+
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[lz4] = "HAVE_LZ4=1,HAVE_LZ4=0,lz4"
+PACKAGECONFIG[lzma] = "HAVE_LZMA=1,HAVE_LZMA=0,xz"
+PACKAGECONFIG[zlib] = "HAVE_ZLIB=1,HAVE_ZLIB=0,zlib"
+
+# See programs/README.md for how to use this
+ZSTD_LEGACY_SUPPORT ??= "4"
+
+do_compile () {
+    oe_runmake ${PACKAGECONFIG_CONFARGS} ZSTD_LEGACY_SUPPORT=${ZSTD_LEGACY_SUPPORT}
+}
+
+do_install () {
+    oe_runmake install 'DESTDIR=${D}'
+    rm -rf ${D}${includedir}
+}
+
+NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"
+
+inherit native

--- a/recipes-l4t-workarounds/zstd/zstd-l4t-workaround/0001-Makefile-sort-all-wildcard-file-list-expansions.patch
+++ b/recipes-l4t-workarounds/zstd/zstd-l4t-workaround/0001-Makefile-sort-all-wildcard-file-list-expansions.patch
@@ -1,0 +1,80 @@
+From 8d01b0753162681dcdbb7cf56f1e393c261e3eb0 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Wed, 23 Dec 2020 19:14:32 +0100
+Subject: [PATCH] Makefile: sort all wildcard file list expansions
+
+Otherwise the order is non-deterministic and breaks
+reproducible builds.
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ programs/Makefile   | 10 +++++-----
+ tests/Makefile      |  4 ++--
+ tests/fuzz/Makefile |  2 +-
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/programs/Makefile b/programs/Makefile
+index 8641d0ee..26fee45f 100644
+--- a/programs/Makefile
++++ b/programs/Makefile
+@@ -72,11 +72,11 @@ ZSTDLEGACY_DIR := $(ZSTDDIR)/legacy
+ 
+ vpath %.c $(ZSTDLIB_COMMON) $(ZSTDLIB_COMPRESS) $(ZSTDLIB_DECOMPRESS) $(ZDICT_DIR) $(ZSTDLEGACY_DIR)
+ 
+-ZSTDLIB_COMMON_C := $(wildcard $(ZSTDLIB_COMMON)/*.c)
+-ZSTDLIB_COMPRESS_C := $(wildcard $(ZSTDLIB_COMPRESS)/*.c)
+-ZSTDLIB_DECOMPRESS_C := $(wildcard $(ZSTDLIB_DECOMPRESS)/*.c)
++ZSTDLIB_COMMON_C := $(sort $(wildcard $(ZSTDLIB_COMMON)/*.c))
++ZSTDLIB_COMPRESS_C := $(sort $(wildcard $(ZSTDLIB_COMPRESS)/*.c))
++ZSTDLIB_DECOMPRESS_C := $(sort $(wildcard $(ZSTDLIB_DECOMPRESS)/*.c))
+ ZSTDLIB_CORE_SRC := $(ZSTDLIB_DECOMPRESS_C) $(ZSTDLIB_COMMON_C) $(ZSTDLIB_COMPRESS_C)
+-ZDICT_SRC := $(wildcard $(ZDICT_DIR)/*.c)
++ZDICT_SRC := $(sort $(wildcard $(ZDICT_DIR)/*.c))
+ 
+ ZSTD_LEGACY_SUPPORT ?= 5
+ ZSTDLEGACY_SRC :=
+@@ -91,7 +91,7 @@ ZSTDLIB_FULL_SRC = $(sort $(ZSTDLIB_CORE_SRC) $(ZSTDLEGACY_SRC) $(ZDICT_SRC))
+ ZSTDLIB_LOCAL_SRC := $(notdir $(ZSTDLIB_FULL_SRC))
+ ZSTDLIB_LOCAL_OBJ := $(ZSTDLIB_LOCAL_SRC:.c=.o)
+ 
+-ZSTD_CLI_SRC := $(wildcard *.c)
++ZSTD_CLI_SRC := $(sort $(wildcard *.c))
+ ZSTD_CLI_OBJ := $(ZSTD_CLI_SRC:.c=.o)
+ 
+ ZSTD_ALL_SRC := $(ZSTDLIB_LOCAL_SRC) $(ZSTD_CLI_SRC)
+diff --git a/tests/Makefile b/tests/Makefile
+index 42bc353c..5f5654f0 100644
+--- a/tests/Makefile
++++ b/tests/Makefile
+@@ -49,7 +49,7 @@ ZSTD_FILES  := $(ZSTDDECOMP_FILES) $(ZSTDCOMMON_FILES) $(ZSTDCOMP_FILES)
+ ZBUFF_FILES := $(ZSTDDIR)/deprecated/*.c
+ ZDICT_FILES := $(ZSTDDIR)/dictBuilder/*.c
+ 
+-ZSTD_F1 := $(wildcard $(ZSTD_FILES))
++ZSTD_F1 := $(sort $(wildcard $(ZSTD_FILES)))
+ ZSTD_OBJ1 := $(subst $(ZSTDDIR)/common/,zstdm_,$(ZSTD_F1))
+ ZSTD_OBJ2 := $(subst $(ZSTDDIR)/compress/,zstdc_,$(ZSTD_OBJ1))
+ ZSTD_OBJ3 := $(subst $(ZSTDDIR)/decompress/,zstdd_,$(ZSTD_OBJ2))
+@@ -212,7 +212,7 @@ bigdict: $(ZSTDMT_OBJECTS) $(PRGDIR)/datagen.c bigdict.c
+ invalidDictionaries : $(ZSTD_OBJECTS) invalidDictionaries.c
+ 
+ legacy : CPPFLAGS += -I$(ZSTDDIR)/legacy -DZSTD_LEGACY_SUPPORT=4
+-legacy : $(ZSTD_FILES) $(wildcard $(ZSTDDIR)/legacy/*.c) legacy.c
++legacy : $(ZSTD_FILES) $(sort $(wildcard $(ZSTDDIR)/legacy/*.c)) legacy.c
+ 
+ decodecorpus : LDLIBS += -lm
+ decodecorpus : $(filter-out zstdc_zstd_compress.o, $(ZSTD_OBJECTS)) $(ZDICT_FILES) $(PRGDIR)/util.c $(PRGDIR)/timefn.c decodecorpus.c
+diff --git a/tests/fuzz/Makefile b/tests/fuzz/Makefile
+index 36232a8c..574fe877 100644
+--- a/tests/fuzz/Makefile
++++ b/tests/fuzz/Makefile
+@@ -58,7 +58,7 @@ FUZZ_SRC       := \
+ 	$(ZSTDCOMP_SRC) \
+ 	$(ZSTDDICT_SRC) \
+ 	$(ZSTDLEGACY_SRC)
+-FUZZ_SRC := $(wildcard $(FUZZ_SRC))
++FUZZ_SRC := $(sort $(wildcard $(FUZZ_SRC)))
+ 
+ FUZZ_D_OBJ1 := $(subst $(ZSTDDIR)/common/,d_lib_common_,$(FUZZ_SRC))
+ FUZZ_D_OBJ2 := $(subst $(ZSTDDIR)/compress/,d_lib_compress_,$(FUZZ_D_OBJ1))


### PR DESCRIPTION
Second attempt, targeting the correct branch this time.

Fixes #559 