### PR TITLE
tegra-wifi_1.0.bb: increase udev rules priority

### DIFF
--- a/recipes-bsp/tegra-wifi/tegra-wifi_1.0.bb
+++ b/recipes-bsp/tegra-wifi/tegra-wifi_1.0.bb
@@ -13,7 +13,7 @@ S = "${WORKDIR}"
 do_install() {
     if [ -s ${S}/tegra-wifi.rules ]; then
 	install -d ${D}${nonarch_base_libdir}/udev/rules.d
-	install -m 0644 ${S}/tegra-wifi.rules ${D}${nonarch_base_libdir}/udev/rules.d/99-tegra-wifi.rules
+	install -m 0644 ${S}/tegra-wifi.rules ${D}${nonarch_base_libdir}/udev/rules.d/98-tegra-wifi.rules
     fi
 }
 


### PR DESCRIPTION
Make sure tegra-wifi rules are applied before applying systemd rules.
Otherwise, systemd will use an incorrect name for the wifi interface.

Fixes #571 

Signed-off-by: Niels Avonds <niels@nobi.life>