### PR TITLE
l4t_deb_pkgfeed.bbclass: one more fix for the tar/zstd issue

### DIFF
--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -25,6 +25,8 @@ do_unpack[depends] += "tar-l4t-workaround-native:do_populate_sysroot"
 EXTRANATIVEPATH_append_task-unpack = " tar-l4t-workaround-native"
 
 do_unpack_prepend() {
-    subpath = ':'.join([p for p in d.getVar('PATH').split(':') if 'tar-l4t-workaround-native' not in p])
+    path = d.getVar('PATH')
+    subpath = ':'.join([p for p in path.split(':') if 'tar-l4t-workaround-native' not in p])
     os.environ['TAR_WRAPPER_STRIPPED_PATH'] = subpath
+    os.environ['PATH'] = path
 }


### PR DESCRIPTION
I missed this in prior testing somehow, but the PATH= being
prepended to the command string in the bitbake fetcher's
unpack method isn't actually doing what we need it to - the
environment only changes for the first command in the string
of commands &&ed together, so the tar wrapper script wasn't
actually getting used.

So yet another workaround here, to set PATH in the environment
so from do_unpack().

Signed-off-by: Matt Madison <matt@madison.systems>

Yet another fix related to #559.