### PR TITLE
jetson-xavier-nx-devkit: add BUP support for FAB 300

### DIFF
--- a/conf/machine/jetson-xavier-nx-devkit.conf
+++ b/conf/machine/jetson-xavier-nx-devkit.conf
@@ -5,7 +5,8 @@
 
 TEGRA_BOARDSKU ?= "0000"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0000;boardrev= \
-		       fab=200;boardsku=0000;boardrev="
+		       fab=200;boardsku=0000;boardrev= \
+		       fab=300;boardsku=0000;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "1024"
 
 require conf/machine/include/xavier-nx.inc


### PR DESCRIPTION
Recent Xavier NX devkit modules got a version bump, so to make
sure we can build compatible BUP payloads, add that FAB to the
list of specs.

Signed-off-by: Matt Madison <matt@madison.systems>