### PR TITLE
u-boot-tegra: update SRCBRANCH and SRCREV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-tegra_2020.04.bb
+++ b/recipes-bsp/u-boot/u-boot-tegra_2020.04.bb
@@ -9,8 +9,8 @@ DEPENDS += "bc-native dtc-native ${SOC_FAMILY}-flashtools-native"
 
 SRC_REPO ?= "github.com/OE4T/u-boot-tegra.git;protocol=https"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
-SRCBRANCH ?= "patches-v2020.04"
-SRCREV = "5e1f83dc9886345e79a074c2aefa33e06f0cec33"
+SRCBRANCH ?= "patches-v2020.04-l4t-r32.4.3"
+SRCREV = "31814111b144ea6feeb6ec96818a48528ea31807"
 
 PV .= "+g${SRCPV}"
 


### PR DESCRIPTION
so we are now based off patches-v2020.04-l4t-r32.4.3
to be aligned with L4T R32.4.3.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>