### PR TITLE
jetson-tx2-devkit: add BUP support for FAB D02

### DIFF
--- a/conf/machine/jetson-tx2-devkit.conf
+++ b/conf/machine/jetson-tx2-devkit.conf
@@ -28,4 +28,4 @@ TEGRA_BOARDSKU ?= ""
 TEGRA_BOARDREV ?= ""
 TEGRA_CHIPREV ?= "0"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3310 and board=jetson-tx2-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=B00 fab=B02 fab=C04 fab=D00 fab=D01"
+TEGRA_BUPGEN_SPECS ?= "fab=B00 fab=B02 fab=C04 fab=D00 fab=D01 fab=D02"


### PR DESCRIPTION
Jetson TX2 devkit modules got a version bump, so to make
sure that we can build compatible BUP payloads, add that FAB to the
list of specs is needed.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>