### PR TITLE
Fixes and cleanup for different kernel/initramfs combinations

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -30,7 +30,19 @@ RECROOTFSSIZE ?= "314572800"
 
 IMAGE_TEGRAFLASH_FS_TYPE ??= "ext4"
 IMAGE_TEGRAFLASH_ROOTFS ?= "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_TEGRAFLASH_FS_TYPE}"
-IMAGE_TEGRAFLASH_KERNEL ?= "${DEPLOY_DIR_IMAGE}/${@'${IMAGE_UBOOT}-${MACHINE}.bin' if '${IMAGE_UBOOT}' != '' else '${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'}"
+
+def tegra_kernel_image(d):
+    if d.getVar('IMAGE_UBOOT'):
+        return '${DEPLOY_DIR_IMAGE}/${IMAGE_UBOOT}-${MACHINE}.bin'
+    if d.getVar('INITRAMFS_IMAGE'):
+        if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
+            img = '${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'
+        else:
+            img = '${DEPLOY_DIR_IMAGE}/${INITRD_IMAGE}-${MACHINE}.cboot'
+        return img
+    return '${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.cboot'
+
+IMAGE_TEGRAFLASH_KERNEL ?= "${@tegra_kernel_image(d)}"
 DATAFILE ??= ""
 IMAGE_TEGRAFLASH_DATA ??= ""
 

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -12,7 +12,6 @@ def tegra_default_rootfs_size(d):
 IMAGE_ROOTFS_SIZE ?= "${@tegra_default_rootfs_size(d)}"
 
 IMAGE_UBOOT ??= "u-boot"
-INITRD_IMAGE ??= ""
 KERNEL_ARGS ??= ""
 TEGRA_SIGNING_ARGS ??= ""
 TEGRA_SIGNING_ENV ??= ""
@@ -30,6 +29,15 @@ RECROOTFSSIZE ?= "314572800"
 
 IMAGE_TEGRAFLASH_FS_TYPE ??= "ext4"
 IMAGE_TEGRAFLASH_ROOTFS ?= "${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${IMAGE_TEGRAFLASH_FS_TYPE}"
+
+def tegra_initrd_image(d):
+    if d.getVar('IMAGE_UBOOT'):
+        return ''
+    if d.getVar('INITRAMFS_IMAGE'):
+        return '' if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')) else '${INITRAMFS_IMAGE}'
+    return ''
+
+INITRD_IMAGE ?= "${@tegra_initrd_image(d)}"
 
 def tegra_kernel_image(d):
     if d.getVar('IMAGE_UBOOT'):

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -12,7 +12,7 @@ UBOOT_EXTLINUX_ROOT ?= "${cbootargs} ${KERNEL_ROOTSPEC}"
 # Console setting comes from ${cbootargs}
 UBOOT_EXTLINUX_CONSOLE = ""
 UBOOT_EXTLINUX_KERNEL_ARGS ?= "${bootargs}"
-UBOOT_EXTLINUX_INITRD ?= "${@'../initrd' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
+UBOOT_EXTLINUX_INITRD ?= "${@'../initrd' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('INITRAMFS_IMAGE_BUNDLE') != '1' else ''}"
 
 TNSPEC_BOOTDEV ??= "mmcblk0p1"
 TNSPEC ?= "${TEGRA_BOARDID}-${TEGRA_FAB}-${TEGRA_BOARDSKU}-${TEGRA_BOARDREV}-1-${TEGRA_CHIPREV}-${MACHINE}-${TNSPEC_BOOTDEV}"

--- a/conf/machine/include/tegra186.inc
+++ b/conf/machine/include/tegra186.inc
@@ -11,7 +11,6 @@ KERNEL_ARGS ?= "console=ttyS0,115200 console=tty0 fbcon=map:0 isolcpus=1-2"
 TEGRA_ESSENTIAL_EXTRA_RDEPENDS = "${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'kernel-image u-boot-extlinux'}"
 
 INITRAMFS_IMAGE ?= "tegra-minimal-initramfs"
-TEGRA_INITRAMFS_INITRD ?= "${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else '1'}"
 INITRAMFS_IMAGE_BUNDLE ?= "${@'1' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
 IMAGE_UBOOT ?= "${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'u-boot'}"
 INITRAMFS_FSTYPES_append = "${@'' if not (d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') and d.getVar('INITRAMFS_IMAGE_BUNDLE') != '1') else ' cpio.gz.cboot cpio.gz.cboot.bup-payload'}"

--- a/conf/machine/include/tegra210.inc
+++ b/conf/machine/include/tegra210.inc
@@ -10,7 +10,6 @@ KERNEL_IMAGETYPE = "Image"
 TEGRA_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image u-boot-extlinux"
 
 INITRAMFS_IMAGE ?= "tegra-minimal-initramfs"
-TEGRA_INITRAMFS_INITRD ?= "1"
 
 TEGRA_AUDIO_DEVICE ?= "tegrahda"
 

--- a/recipes-bsp/u-boot/u-boot-tegra-bootimg.inc
+++ b/recipes-bsp/u-boot/u-boot-tegra-bootimg.inc
@@ -41,11 +41,11 @@ do_compile_append_tegra() {
 }
 
 do_install_append_tegra() {
-    if [ -n "${INITRAMFS_IMAGE}" -a "${TEGRA_INITRAMFS_INITRD}" = "1" ]; then
+    if [ -n "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" != "1" ]; then
         install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.cpio.gz ${D}/boot/initrd
     fi
 }
 
 EXTRADOINSTDEPS = ""
-EXTRADOINSTDEPS_tegra = "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('TEGRA_INITRAMFS_INITRD') == '1' else ''}"
+EXTRADOINSTDEPS_tegra = "${@'${INITRAMFS_IMAGE}:do_image_complete' if d.getVar('INITRAMFS_IMAGE') != '' and d.getVar('INITRAMFS_IMAGE_BUNDLE') != '1' else ''}"
 do_install[depends] += "${EXTRADOINSTDEPS}"

--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -61,6 +61,22 @@ bootimg_from_bundled_initramfs() {
             chmod 0644 $deployDir/${initramfs_base_name}.cboot
             ln -sf ${initramfs_base_name}.cboot $deployDir/${initramfs_symlink_name}.cboot
         done
+    elif [  -z "${INITRAMFS_IMAGE}" ]; then
+        rm -f ${WORKDIR}/initrd
+        touch ${WORKDIR}/initrd
+        for imageType in ${KERNEL_IMAGETYPES} ; do
+            if [ "$imageType" = "fitImage" ] ; then
+                continue
+            fi
+	    baseName=$imageType-${KERNEL_IMAGE_NAME}
+            ${STAGING_BINDIR_NATIVE}/tegra186-flash/mkbootimg \
+                                    --kernel $deployDir/${baseName}.bin \
+                                    --ramdisk ${WORKDIR}/initrd \
+                                    --output $deployDir/${baseName}.cboot
+            chmod 0644 $deployDir/${baseName}.cboot
+            ln -sf ${baseName}.cboot $deployDir/$imageType-${KERNEL_IMAGE_LINK_NAME}.cboot
+            ln -sf ${baseName}.cboot $deployDir/$imageType.cboot
+        done
     fi
 }
 do_deploy_append_tegra186() {


### PR DESCRIPTION
* Fixes an issue with omitting the initramfs completely
* Cleanup for handling separate kernel + initrd
* Drop extra variable and just use INITRAMFS_IMAGE_BUNDLE to determine if we're using a bundled vs separate initramfs

For #591