### PR TITLE
tegra-binaries: nvpmodel: support setting NVPMODEL_CONFIG_DEFAULT

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel-base_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel-base_32.5.1.bb
@@ -3,6 +3,9 @@ require tegra-shared-binaries.inc
 
 DESCRIPTION = "nvpmodel tool and configuration files"
 
+# When left unset, l4t default setting will be used
+NVPMODEL_CONFIG_DEFAULT ??= ""
+
 COMPATIBLE_MACHINE = "(tegra)"
 
 do_configure() {
@@ -16,6 +19,9 @@ do_install() {
     install -d ${D}${sysconfdir}/nvpmodel
     install -m 0755 ${B}/usr/sbin/nvpmodel ${D}${sbindir}/
     install -m 0644 ${B}/etc/nvpmodel/${NVPMODEL}.conf ${D}${sysconfdir}/nvpmodel.conf
+    if [ -n "${NVPMODEL_CONFIG_DEFAULT}" ]; then
+        sed -i -e "s/PM_CONFIG DEFAULT=[0-9]\+/PM_CONFIG DEFAULT=${NVPMODEL_CONFIG_DEFAULT}/" ${D}${sysconfdir}/nvpmodel.conf
+    fi
 }
 
 FILES_${PN} = "${sbindir}/nvpmodel ${sysconfdir}"


### PR DESCRIPTION
This change allows setting a variable in e.g. your machine configuration
to specify the default setting that nvpmodel will make at first boot.

If left unspecified, the default power model set by nvidia will be used,
as before.

To change the default config to 0 (MAXN), for example, you can add the
following to your machine configuration:

NVPMODEL_CONFIG_DEFAULT = "0"

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>