### PR TITLE
Refinements to l4t_deb_pkgfeed.bbclass

### DIFF
--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -1,20 +1,34 @@
 HOMEPAGE = "https://developer.nvidia.com/embedded/jetpack"
-L4T_DEB_GROUP ?= "${BPN}"
+L4T_DEB_GROUP ?= ""
 L4T_DEB_FEED_BASE ??= "https://repo.download.nvidia.com/jetson"
 
 def l4t_deb_src_uri(d):
-    import string
+    def generate_uris(d, debclass, deblist):
+        result = []
+        for pkg in deblist:
+            pkgelements = pkg.split(';')
+            pkgbase = pkgelements[0].split('_')[0]
+            name = None
+            for pe in pkgelements:
+                try:
+                    tag, val = pe.split('=')
+                    if tag == 'name':
+                        name = val
+                        break
+                except ValueError:
+                    pass
+            group = None
+            if name:
+                group = d.getVarFlag('L4T_DEB_GROUP', name)
+            group = group or d.getVar('L4T_DEB_GROUP') or pkgbase
+            subdir = group[0:4] if group.startswith('lib') else group[0]
+            result.append("${L4T_DEB_FEED_BASE}/%s/pool/main/%s/%s/%s" % (debclass, subdir, group, pkg))
+        return result
+
     common_debs = (d.getVar('SRC_COMMON_DEBS') or '').split()
     soc_debs = (d.getVar('SRC_SOC_DEBS') or '').split()
     soc = d.getVar('L4T_DEB_SOCNAME')
-    group = d.getVar('L4T_DEB_GROUP')
-    if group.startswith('lib'):
-        subdir = group[0:4]
-        return ' '.join(["${L4T_DEB_FEED_BASE}/common/pool/main/%s/%s/%s" % (subdir, pkg.split('_')[0].rstrip(string.digits), pkg) for pkg in common_debs] +
-                    ["${L4T_DEB_FEED_BASE}/%s/pool/main/%s/%s/%s" % (soc, subdir, pkg.split('_')[0].rstrip(string.digits), pkg) for pkg in soc_debs])
-    subdir = group[0:4] if group.startswith('lib') else group[0]
-    return ' '.join(["${L4T_DEB_FEED_BASE}/common/pool/main/%s/%s/%s" % (subdir, group, pkg) for pkg in common_debs] +
-                    ["${L4T_DEB_FEED_BASE}/%s/pool/main/%s/%s/%s" % (soc, subdir, group, pkg) for pkg in soc_debs])
+    return ' '.join(generate_uris(d, 'common', common_debs) + generate_uris(d, soc, soc_debs))
 
 l4t_deb_src_uri[vardepsexclude] += "L4T_DEB_SOCNAME"
 

--- a/recipes-devtools/cuda/cuda-samples_10.2.89-1.bb
+++ b/recipes-devtools/cuda/cuda-samples_10.2.89-1.bb
@@ -5,6 +5,7 @@ LIC_FILES_CHKSUM = "file://EULA.txt;md5=37774d0b88c5743e8fe8e5c10b057270"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
+L4T_DEB_GROUP = "cuda-samples"
 CUDA_VERSION_DASHED = "${@d.getVar('CUDA_VERSION').replace('.','-')}"
 SRC_COMMON_DEBS = "${BPN}-${CUDA_VERSION_DASHED}_${PV}_arm64.deb;unpack=false"
 SRC_URI[sha256sum] = "121e273d8586bde904ceeab72a603a86d781f3bac6d3a21732703ca2ca9ec528"

--- a/recipes-devtools/cudnn/cudnn_8.0.0.180-1.bb
+++ b/recipes-devtools/cudnn/cudnn_8.0.0.180-1.bb
@@ -5,6 +5,8 @@ LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/cudnn_v8.h;endline=47;m
 
 inherit l4t_deb_pkgfeed container-runtime-csv
 
+L4T_DEB_GROUP = "cudnn"
+
 SRC_COMMON_DEBS = "\
     libcudnn8_${PV}+cuda10.2_arm64.deb;name=lib;subdir=cudnn \
     libcudnn8-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=cudnn \

--- a/recipes-devtools/gie/tensorrt_7.1.3-1.bb
+++ b/recipes-devtools/gie/tensorrt_7.1.3-1.bb
@@ -8,6 +8,8 @@ HOMEPAGE = "http://developer.nvidia.com/tensorrt"
 PREFIX = "NoDLA-"
 PREFIX_tegra194 = "DLA-"
 
+L4T_DEB_GROUP = "tensorrt"
+
 SRC_SOC_DEBS = "\
     libnvinfer7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer7_${PV}+cuda10.2_arm64.deb;name=lib;subdir=tensorrt \
     libnvinfer-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=tensorrt \

--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos.inc
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos.inc
@@ -4,7 +4,6 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 # The sources for t186 and t210 are identical, so just pick one
 L4T_DEB_SOCNAME = "t186"
-L4T_DEB_GROUP = "nvidia-l4t-graphics-demos"
 SRC_SOC_DEBS = "nvidia-l4t-graphics-demos_${PV}-20210115151051_arm64.deb;subdir=l4t-graphics-demos"
 
 inherit l4t_deb_pkgfeed

--- a/recipes-multimedia/argus/tegra-mmapi-32.5.0.inc
+++ b/recipes-multimedia/argus/tegra-mmapi-32.5.0.inc
@@ -1,7 +1,6 @@
 HOMEPAGE = "http://developer.nvidia.com"
 LICENSE = "Proprietary & BSD"
 
-L4T_DEB_GROUP = "nvidia-l4t-jetson-multimedia-api"
 SRC_SOC_DEBS = "nvidia-l4t-jetson-multimedia-api_${PV}-20210115151051_arm64.deb;subdir=tegra-mmapi"
 SRC_SOC_DEBS_tegra210 = "nvidia-l4t-jetson-multimedia-api_${PV}-20210115145440_arm64.deb;subdir=tegra-mmapi"
 SRC_SHA256SUM = "6b1059873492834a3b7fb89ef31d2fb393a15c39f7ff545506eee50a215853c8"


### PR DESCRIPTION
Integrating VPI is presenting a problem due to the way we compose the SRC_URIs for packages coming from the L4T feeds.

Reworking the logic to calculate the download path on a per-package basis works better for VPI and some of the other L4T packages, and should be more future-proof.  This does require the addition of an L4T_DEB_GROUP setting for some of the recipes, since it's no longer set by default, but we can also drop that setting from some other recipes.