### PR TITLE
Script fixes for SDcard creation with R32.5.x

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -215,7 +215,6 @@ confirm() {
 		    ;;
 		*)
 		    echo "Please answer 'yes' or' no'."
-		    break;
 		    ;;
 	    esac
 	else

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -434,7 +434,7 @@ if [ $bup_blob -ne 0 ]; then
     spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-${BOOTDEV}"
     l4t_bup_gen "$flashcmd" "$spec" "$fuselevel" t186ref "$keyfile" "$sbk_keyfile" 0x19 || exit 1
 else
-    eval $flashcmd || exit 1
+    eval $flashcmd < /dev/null || exit 1
     if [ -n "$sdcard" ]; then
 	if [ -n "$pre_sdcard_sed" ]; then
 	    rm -f signed/flash.xml.tmp.in


### PR DESCRIPTION
Fixes #621 by redirecting input for `tegraflash.py` to `/dev/null` so whatever it is in the NVIDIA tools that's messing with the input stream doesn't affect the terminal input, so the confirmation prompt in `make-sdcard` works again.  Only Xavier flash helper needs this, as the problem doesn't manifest itself for Nano (t210).

Also fixes a minor issue in handling unrecognized responses to the confirmation prompt in make-sdcard.