### PR TITLE
TNSPEC-related length checks

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -318,6 +318,10 @@ if [ $bup_blob -ne 0 ]; then
     localbootfile="boot.img"
     . "$here/l4t_bup_gen.func"
     spec="${BOARDID}-${FAB}-${BOARDSKU}--1-0-${MACHINE}-${BOOTDEV}"
+    if [ $(expr length "$spec") -ge 64 ]; then
+	echo "ERR: TNSPEC must be shorter than 64 characters: $spec" >&2
+	exit 1
+    fi
     l4t_bup_gen "$flashcmd" "$spec" "$fuselevel" t186ref "$keyfile" "$sbk_keyfile" 0x18 || exit 1
 else
     eval $flashcmd || exit 1

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -432,6 +432,10 @@ if [ $bup_blob -ne 0 ]; then
     localbootfile="boot.img"
     . "$here/l4t_bup_gen.func"
     spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-${BOOTDEV}"
+    if [ $(expr length "$spec") -ge 64 ]; then
+	echo "ERR: TNSPEC must be shorter than 64 characters: $spec" >&2
+	exit 1
+    fi
     l4t_bup_gen "$flashcmd" "$spec" "$fuselevel" t186ref "$keyfile" "$sbk_keyfile" 0x19 || exit 1
 else
     eval $flashcmd < /dev/null || exit 1

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
@@ -287,6 +287,10 @@ if [ $bup_blob -ne 0 ]; then
     localbootfile="boot.img"
     . "$here/l4t_bup_gen.func"
     spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-0-${MACHINE}-${BOOTDEV}"
+    if [ $(expr length "$spec") -ge 64 ]; then
+	echo "ERR: TNSPEC must be shorter than 64 characters: $spec" >&2
+	exit 1
+    fi
     l4t_bup_gen "$flashcmd" "$spec" "$fuselevel" t210ref "$keyfile" "" 0x21 || exit 1
 else
     if [ -z "$keyfile" ]; then

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot-rollback_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot-rollback_32.5.1.bb
@@ -3,6 +3,7 @@ require tegra-shared-binaries.inc
 
 COMPATIBLE_MACHINE = "(tegra)"
 PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"
+TEGRA_BYPASS_TNSPEC_CHECK ??= "0"
 
 inherit nopackages
 
@@ -25,4 +26,12 @@ do_install_append_tegra186() {
 do_install_append_tegra194() {
 	install -d ${D}${datadir}/nv_tegra/rollback/t19x
 	install -m 0644 ${S}/bootloader/rollback/t19x/rollback.cfg ${D}${datadir}/nv_tegra/rollback/t19x/
+}
+
+python () {
+    if bb.utils.to_boolean(d.getVar('TEGRA_BYPASS_TNSPEC_CHECK'), False):
+        return
+    machine = d.getVar('MACHINE')
+    if machine and len(machine) > 31:
+        bb.warn('MACHINE name must be less than 32 characters for bootloader update payload generation')
 }


### PR DESCRIPTION
* Warn on machine name longer than 31 characters
* Generate error in the flash helper script during BUP generation if the TNSPEC exceeds 63 characters

Fixes #638 
