### PR TITLE
Support customizable bootlogo blob

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -63,6 +63,7 @@ CBOOTFILENAME_tegra194 = "cboot_t194.bin"
 TOSIMGFILENAME = "tos-trusty.img"
 TOSIMGFILENAME_tegra194 = "tos-trusty_t194.img"
 TOSIMGFILENAME_tegra210 = "tos-mon-only.img"
+BMPBLOBFILENAME = "bmp.blob"
 
 BUP_PAYLOAD_DIR = "payloads_t${@d.getVar('NVIDIA_CHIP')[2:]}x"
 FLASHTOOLS_DIR = "${SOC_FAMILY}-flash"
@@ -267,7 +268,6 @@ tegraflash_create_flash_config_tegra194() {
 
 BOOTFILES = ""
 BOOTFILES_tegra210 = "\
-    bmp.blob \
     eks.img \
     nvtboot_recovery.bin \
     nvtboot.bin \
@@ -278,7 +278,6 @@ BOOTFILES_tegra210 = "\
 "
 BOOTFILES_tegra186 = "\
     adsp-fw.bin \
-    bmp.blob \
     bpmp.bin \
     camera-rtcpu-sce.img \
     dram-ecc.bin \
@@ -301,7 +300,6 @@ BOOTFILES_tegra186 = "\
 
 BOOTFILES_tegra194 = "\
     adsp-fw.bin \
-    bmp.blob \
     bpmp_t194.bin \
     camera-rtcpu-rce.img \
     eks.img \
@@ -351,6 +349,7 @@ create_tegraflash_pkg_tegra210() {
     done
     cp "${DEPLOY_DIR_IMAGE}/cboot-${MACHINE}.bin" ./${CBOOTFILENAME}
     cp "${DEPLOY_DIR_IMAGE}/tos-${MACHINE}.img" ./${TOSIMGFILENAME}
+    cp "${DEPLOY_DIR_IMAGE}/bootlogo-${MACHINE}.blob" ./${BMPBLOBFILENAME}
     for f in ${BOOTFILES}; do
         cp "${STAGING_DATADIR}/tegraflash/$f" .
     done
@@ -417,6 +416,7 @@ create_tegraflash_pkg_tegra186() {
     fi
     cp "${DEPLOY_DIR_IMAGE}/cboot-${MACHINE}.bin" ./${CBOOTFILENAME}
     cp "${DEPLOY_DIR_IMAGE}/tos-${MACHINE}.img" ./${TOSIMGFILENAME}
+    cp "${DEPLOY_DIR_IMAGE}/bootlogo-${MACHINE}.blob" ./${BMPBLOBFILENAME}
     for f in ${BOOTFILES}; do
         cp "${STAGING_DATADIR}/tegraflash/$f" .
     done
@@ -499,6 +499,7 @@ create_tegraflash_pkg_tegra194() {
     fi
     cp "${DEPLOY_DIR_IMAGE}/cboot-${MACHINE}.bin" ./${CBOOTFILENAME}
     cp "${DEPLOY_DIR_IMAGE}/tos-${MACHINE}.img" ./${TOSIMGFILENAME}
+    cp "${DEPLOY_DIR_IMAGE}/bootlogo-${MACHINE}.blob" ./${BMPBLOBFILENAME}
     for f in ${BOOTFILES}; do
         cp "${STAGING_DATADIR}/tegraflash/$f" .
     done
@@ -613,13 +614,14 @@ do_image_tegraflash[depends] += "${TEGRAFLASH_PKG_DEPENDS} dtc-native:do_populat
                                  tegra-redundant-boot-rollback:do_populate_sysroot virtual/kernel:do_deploy \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \
                                  ${@'${IMAGE_UBOOT}:do_deploy ${IMAGE_UBOOT}:do_populate_lic' if d.getVar('IMAGE_UBOOT') != '' else  ''} \
-                                 cboot:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
+                                 cboot:do_deploy virtual/secure-os:do_deploy virtual/bootlogo:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
 IMAGE_TYPEDEP_tegraflash += "${IMAGE_TEGRAFLASH_FS_TYPE}"
 
 oe_make_bup_payload() {
     PATH="${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}:${PATH}"
     export cbootfilename=${CBOOTFILENAME}
     export tosimgfilename=${TOSIMGFILENAME}
+    export bmpblobfilename=${BMPBLOBFILENAME}
     rm -rf ${WORKDIR}/bup-payload
     mkdir ${WORKDIR}/bup-payload
     oldwd="$PWD"
@@ -648,6 +650,7 @@ oe_make_bup_payload() {
     done
     cp "${DEPLOY_DIR_IMAGE}/cboot-${MACHINE}.bin" ./$cbootfilename
     cp "${DEPLOY_DIR_IMAGE}/tos-${MACHINE}.img" ./$tosimgfilename
+    cp "${DEPLOY_DIR_IMAGE}/bootlogo-${MACHINE}.blob" ./$bmpblobfilename
     for f in ${BOOTFILES}; do
         cp "${STAGING_DATADIR}/tegraflash/$f" .
     done
@@ -720,6 +723,6 @@ create_bup_payload_image() {
 create_bup_payload_image[vardepsexclude] += "DATETIME"
 
 CONVERSIONTYPES += "bup-payload"
-CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-rollback dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
+CONVERSION_DEPENDS_bup-payload = "${SOC_FAMILY}-flashtools-native coreutils-native tegra-bootfiles tegra-redundant-boot-rollback dtc-native virtual/bootloader:do_deploy virtual/kernel:do_deploy virtual/secure-os:do_deploy virtual/bootlogo:do_deploy ${TEGRA_SIGNING_EXTRA_DEPS}"
 CONVERSION_CMD_bup-payload = "create_bup_payload_image ${type}"
 IMAGE_TYPES += "cpio.gz.cboot.bup-payload"

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -28,6 +28,7 @@ PREFERRED_PROVIDER_virtual/libgles2 = "libglvnd"
 PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
 PREFERRED_PROVIDER_libv4l = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
 PREFERRED_PROVIDER_v4l-utils = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
+PREFERRED_PROVIDER_virtual/bootlogo ?= "bootlogo-prebuilt"
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 TEGRA_BLBLOCKSIZE ?= "${@int(d.getVar('IMAGE_ROOTFS_ALIGNMENT')) * 1024}"

--- a/recipes-bsp/bootlogo/bootlogo-custom_1.0.bb
+++ b/recipes-bsp/bootlogo/bootlogo-custom_1.0.bb
@@ -1,0 +1,85 @@
+DESCRIPTION = "Deploy a custom boot screen for L4T bootloader"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+DEPENDS = "tegra186-flashtools-native lz4-native"
+
+inherit deploy nopackages
+
+PROVIDES += "virtual/bootlogo"
+
+SRC_URI = "git://github.com/OE4T/bootlogo-oe4t;protocol=https"
+SRCREV = "a8bb17ae9932645c5f562f8922e82565b964a7c4"
+
+S = "${WORKDIR}/git"
+
+# One of 'raw' or 'cooked'
+PACKAGECONFIG ?= "cooked"
+
+PACKAGECONFIG[raw] = ",,imagemagick-native,,,cooked"
+PACKAGECONFIG[cooked] = ",,,,,raw"
+
+# Input input graphic to be scaled
+RAW_GRAPHIC_FILE ?= "input.png"
+
+# Config file definting pregenerated bitmap files
+COOKED_CONFIG_FILE ?= "config_file"
+
+BMP_BLOB = "bootlogo-${MACHINE}-${PV}-${PR}.blob"
+BMP_SYMLINK = "bootlogo-${MACHINE}.blob"
+
+include bootlogo.inc
+
+do_compile() {
+
+    LIST=""
+
+    if [ "${@bb.utils.contains("PACKAGECONFIG", "raw", "1", "0", d)}" = "1" ]; then
+        if [ ! -s "${S}/${RAW_GRAPHIC_FILE}" ]; then
+            bbfatal "RAW_GRAPHIC_FILE must exist"
+        fi
+
+        cook_bitmaps "${S}/${RAW_GRAPHIC_FILE}"
+    else
+        if [ ! -s "${S}/${COOKED_CONFIG_FILE}" ]; then
+            bbfatal "COOKED_CONFIG_FILE must exist"
+        fi
+
+        while read _line
+        do
+            _line="${S}/${_line}"
+            LIST="${LIST}${_line};"
+        done < ${S}/${COOKED_CONFIG_FILE}
+    fi
+
+    # NB that '%?' gets rid of the trailing ';' because BMP_generator blows up
+    LIST="${LIST%?}"
+
+    rm -f ${B}/bmp.blob
+    rm -f ${B}/bmp-compressed.blob
+
+    OUT=${B} ${STAGING_BINDIR_NATIVE}/tegra186-flash/BMP_generator_L4T.py -t bmp -e "${LIST}" -v 0
+
+    if [ ! -s ${B}/bmp.blob ]; then
+        bbfatal "BMP_generator_L4T.py failed to create bmp.blob"
+    fi
+
+    compress_blob "${B}/bmp.blob" "${B}/bmp-compressed.blob"
+
+    if [ ! -s ${B}/bmp-compressed.blob ]; then
+        bbfatal "failed to create compressed bmp-compressed.blob"
+    fi
+}
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${B}/bmp-compressed.blob ${DEPLOYDIR}/${BMP_BLOB}
+    ln -sf ${BMP_BLOB} ${DEPLOYDIR}/${BMP_SYMLINK}
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+do_install[noexec] = "1"
+
+addtask deploy before do_build after do_install

--- a/recipes-bsp/bootlogo/bootlogo.inc
+++ b/recipes-bsp/bootlogo/bootlogo.inc
@@ -1,0 +1,64 @@
+# Helpers for bootlogo-custom
+
+SPLASH_GRAPHIC_BACKGROUND ?= "white"
+BMP_BLOB_SIZES ?= "1920x1080 1280x720 640x480"
+
+# generate bitmaps by imagemagick based on single input image
+cook_bitmaps() {
+    local _input_file=$1
+
+    for size in ${BMP_BLOB_SIZES}
+    do
+        local W=${size%x*}
+        local H=${size#*x}
+        bbdebug 1 "Resizing ${SPLASH_GRAPHIC_FILENAME} to ${W}x${H} with background ${SPLASH_GRAPHIC_BACKGROUND}"
+        # resize input with size reduction only, pad remaining about center with color
+        convert.im7 ${_input_file} -type truecolor -resize ${W}x${H}\> -gravity center -background ${SPLASH_GRAPHIC_BACKGROUND} -extent ${W}x${H} ${B}/logo-${H}.bmp
+        LIST="${LIST}${B}/logo-${H}.bmp nvidia ${H};"
+    done
+
+    return 0
+}
+
+# compress blob function from genbmpblob_L4T.sh
+compress_blob() {
+
+    _blob_file=$1
+    _blob_output_file=$2
+
+    _blob_size_pos=20
+    _header_len_offset=24
+    _blob_header_len=`od -An -j ${_header_len_offset} -N 4 -t d4 ${B}/bmp.blob`
+
+    _blob_size=`cat ${_blob_file} | wc -c`
+    _compressed_blob=${_blob_file}.lz4
+
+    head -c ${_blob_header_len} ${_blob_file} > ${_compressed_blob}
+
+    _blob_size=`expr ${_blob_size} - ${_blob_header_len}`
+    _cmd="lz4c -l -c1 -f stdin >> ${_compressed_blob}"
+    tail -c ${_blob_size} ${_blob_file} | eval ${_cmd}
+
+    # update blob size(4Bytes) in header
+    _compressed_size=`cat ${_compressed_blob} | wc -c`
+
+    local _i=${_blob_size_pos}
+    local _end=`expr $_i + 4`
+    local _byte=0
+    while [ $_i -lt $_end ]
+    do
+        _byte=$(expr $_compressed_size % 256 || echo 0)
+        _byte=`printf %o $_byte`
+        printf "\\$_byte" | dd conv=notrunc of="${_compressed_blob}" bs=1 seek=${_i}
+        # expr returns non-zero for purely fractional results
+        _compressed_size=$(expr $_compressed_size / 256 || echo 0)
+        _i=`expr $_i + 1`
+    done
+
+    bbdebug 1 "done with compression"
+
+    cp "${_compressed_blob}" "${_blob_output_file}"
+
+    return 0
+}
+

--- a/recipes-bsp/cboot/cboot-t19x/0012-bmp-support-A-B-slots.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0012-bmp-support-A-B-slots.patch
@@ -1,0 +1,55 @@
+From 310686635f504f45bef1217b0a5d5377f7ad7b92 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kekiefer@gmail.com>
+Date: Thu, 1 Apr 2021 08:29:25 -0700
+Subject: [PATCH] bmp: support A/B slots
+
+Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
+---
+ .../t18x/cboot/app/kernel_boot/kernel_boot.c  | 21 +++++++++++++++++++
+ 1 file changed, 21 insertions(+)
+
+diff --git a/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c b/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c
+index 79bd566..93f845e 100644
+--- a/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c
++++ b/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c
+@@ -234,6 +234,10 @@ static status_t kernel_boot(void)
+ 	bool is_enter_fastboot = false;
+ #endif
+ 
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	uint32_t slot = BOOT_SLOT_A;
++#endif
++
+ #if defined(IS_T186)
+ 	tegrabl_error_t ret = TEGRABL_NO_ERROR;
+ 	bool is_skip_menu = true;
+@@ -284,9 +288,26 @@ static status_t kernel_boot(void)
+ #endif
+ 
+ #if defined(CONFIG_ENABLE_DISPLAY) && defined(CONFIG_ENABLE_NVBLOB)
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	err = tegrabl_a_b_get_active_slot(NULL, &slot);
++	if (err != TEGRABL_NO_ERROR) {
++		if (TEGRABL_ERROR_REASON(err) == TEGRABL_ERR_NOT_FOUND) {
++			/*
++			 * No slot number has been set by MB1
++			 * Device is handled as non A/B system
++			 */
++		} else {
++			pr_warn("Select a/b slot for bmp blob failed\n");
++		}
++	}
++	err = tegrabl_load_bmp_blob((slot == BOOT_SLOT_A ) ? "BMP" : "BMP_b");
++	if (err != TEGRABL_NO_ERROR)
++		pr_warn("Loading bmp blob to memory failed\n");
++#else
+ 	err = tegrabl_load_bmp_blob("BMP");
+ 	if (err != TEGRABL_NO_ERROR)
+ 		pr_warn("Loading bmp blob to memory failed\n");
++#endif
+ 
+ #if defined(IS_T186)
+ 	tegrabl_profiler_record("Load BMP blob", 0, DETAILED);
+-- 
+2.29.2
+

--- a/recipes-bsp/cboot/cboot-t19x_32.5.0.bb
+++ b/recipes-bsp/cboot/cboot-t19x_32.5.0.bb
@@ -13,6 +13,7 @@ SRC_URI = "${L4T_ALT_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t1
            file://0009-tegrabl_cbo-support-A-B-slots.patch \
            file://0010-t194-add-bootinfo-to-build.patch \
            file://0011-Add-machine-ID-to-kernel-command-line.patch \
+           file://0012-bmp-support-A-B-slots.patch \
 "
 
 SRC_URI[sha256sum] = "80a5b0491d75ea8f2d5f49e93e6d5b4986c739ff29f62133585c2fe7880e8fa9"

--- a/recipes-bsp/tegra-binaries/bootlogo-prebuilt_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/bootlogo-prebuilt_32.5.1.bb
@@ -1,0 +1,23 @@
+require recipes-bsp/tegra-binaries/tegra-binaries-${PV}.inc
+require recipes-bsp/tegra-binaries/tegra-shared-binaries.inc
+
+COMPATIBLE_MACHINE = "(tegra)"
+INHIBIT_DEFAULT_DEPS = "1"
+
+BMPBLOB_PREBUILT = "bmp.blob"
+PREFERRED_PROVIDER_virtual/bootlogo ??= ""
+PROVIDES += "virtual/bootlogo"
+BMP_BLOB ?= "bootlogo-${MACHINE}-${PV}-${PR}.blob"
+BMP_SYMLINK ?= "bootlogo-${MACHINE}.blob"
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${S}/bootloader/${BMPBLOB_PREBUILT} ${DEPLOYDIR}/${BMP_BLOB}
+    ln -sf ${BMP_BLOB} ${DEPLOYDIR}/${BMP_SYMLINK}
+}
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+addtask deploy before do_build after do_install

--- a/recipes-bsp/tegra-binaries/tegra-bootfiles_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-bootfiles_32.5.1.bb
@@ -15,7 +15,6 @@ ODMFUSE_FILE ?= ""
 
 BOOTBINS_tegra186 = "\
     adsp-fw.bin \
-    bmp.blob \
     bpmp.bin \
     camera-rtcpu-sce.img \
     dram-ecc.bin \
@@ -31,7 +30,6 @@ BOOTBINS_tegra186 = "\
 "
 BOOTBINS_tegra194 = "\
     adsp-fw.bin \
-    bmp.blob \
     bpmp_t194.bin \
     camera-rtcpu-rce.img \
     eks.img \
@@ -50,7 +48,6 @@ BOOTBINS_tegra194 = "\
 "
 
 BOOTBINS_tegra210 = "\
-    bmp.blob \
     eks.img \
     nvtboot_cpu.bin \
     nvtboot_recovery.bin \

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
@@ -66,6 +66,8 @@ do_install() {
 
     install -m 0755 ${S}/nv_tegra/tos-scripts/gen_tos_part_img.py ${D}${BINDIR}
 
+    install -m 0755 ${S}/tools/bmp-splash/BMP_generator_L4T.py ${D}${BINDIR}
+
     install -m 0755 ${S}/l4t_sign_image.sh ${D}${BINDIR}
     sed -i -e's,^\(L4T_BOOTLOADER_DIR=.*\)/bootloader,\1,' ${D}${BINDIR}/l4t_sign_image.sh
 }

--- a/recipes-bsp/u-boot/u-boot-bup-payload.bb
+++ b/recipes-bsp/u-boot/u-boot-bup-payload.bb
@@ -66,7 +66,7 @@ do_deploy() {
 }
 do_deploy[depends] += "virtual/bootloader:do_deploy virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot"
 do_deploy[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
-do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
+do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy virtual/bootlogo:do_deploy"
 addtask deploy before do_build
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -35,7 +35,7 @@ do_deploy() {
 }
 do_deploy[depends] += "virtual/kernel:do_deploy ${SOC_FAMILY}-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
 do_deploy[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
-do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy"
+do_deploy[depends] += "coreutils-native:do_populate_sysroot cboot:do_deploy virtual/secure-os:do_deploy virtual/bootlogo:do_deploy"
 addtask deploy before do_build
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
This adds support for packaging a custom bootlogo in the tegraflash package to show at boot. Leaving `PREFERRED_PROVIDER_virtual/bootlogo` set to the default `bootlogo-prebuilt` will package the default `bmp.blob`. An alternative `bootlogo-custom` recipe will use `imagemagick-native` (meta-oe) to resize an arbitrary input image and construct the blob from scratch.

Note that the boot logo is put in the deploy directory. This location is used so that updaters can leverage this artifact to handle as required. The BMP/BMP_b partitions are not part of the bootloader or kernel update payloads. 