### PR TITLE
Bootloader seamless display transition support

### DIFF
--- a/recipes-bsp/cboot/cboot-t19x/0013-display-nvdisp-sor-enable-seamless-display-transitio.patch
+++ b/recipes-bsp/cboot/cboot-t19x/0013-display-nvdisp-sor-enable-seamless-display-transitio.patch
@@ -1,0 +1,82 @@
+From e750298e345281ae54c286910a184f650b682246 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kekiefer@gmail.com>
+Date: Wed, 7 Apr 2021 20:42:49 -0700
+Subject: [PATCH 1/1] display: nvdisp/sor: enable seamless display transition
+
+When the CMU is enabled in the bootloader, the Linux tegra display
+drivers will set up a limited range output by default. This caused
+a discontinuity in the image when the range changed from cboot's
+default full range output.
+
+Additionally, the gamma correction was broken. Although an sRGB
+ouput gamma is applied through the CMU on the display as a sane
+default, the window settings weren't applying an sRGB degamma to
+the framebuffer, so gamma was getting applied twice.
+
+This change fixes both problems, enabling a truly seamless display
+transition to Linux.
+
+Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
+---
+ .../common/drivers/display/nvdisp/tegrabl_nvdisp_cmu.c   | 9 +++++++++
+ .../common/drivers/display/nvdisp/tegrabl_nvdisp_win.c   | 4 ++++
+ .../partner/common/drivers/display/sor/tegrabl_sor.c     | 9 +++++++--
+ 3 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_cmu.c b/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_cmu.c
+index 1bb3076..5e4b22c 100644
+--- a/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_cmu.c
++++ b/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_cmu.c
+@@ -275,5 +275,14 @@ void nvdisp_cmu_set(struct tegrabl_nvdisp *nvdisp, struct nvdisp_cmu *cmu)
+ 								 DISABLE, val);
+ 	nvdisp_writel(nvdisp, DISP_DISP_COLOR_CONTROL, val);
+ 
++	val = nvdisp_readl(nvdisp, DISP_CSC2_CONTROL);
++	if (nvdisp->flags & NVDISP_FLAG_CMU_ENABLE)
++		val = NV_FLD_SET_DRF_DEF(DC, DISP_CSC2_CONTROL, LIMIT_RGB_COLOR,
++								 ENABLE, val);
++	else
++		val = NV_FLD_SET_DRF_DEF(DC, DISP_CSC2_CONTROL, LIMIT_RGB_COLOR,
++								 DISABLE, val);
++	nvdisp_writel(nvdisp, DISP_CSC2_CONTROL, val);
++
+ 	pr_debug("%s: exit\n", __func__);
+ }
+diff --git a/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_win.c b/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_win.c
+index ea7dd12..a6b060d 100644
+--- a/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_win.c
++++ b/bootloader/partner/common/drivers/display/nvdisp/tegrabl_nvdisp_win.c
+@@ -186,6 +186,10 @@ void nvdisp_win_config(struct tegrabl_nvdisp *nvdisp, uint32_t win_id)
+ 					 win->pitch / NVDISP_PITCH_UNIT);
+ 	nvdisp_writel(nvdisp, WIN_A_WINDOW_SET_PLANAR_STORAGE, val);
+ 
++	val = nvdisp_readl(nvdisp, WIN_A_WINDOW_SET_PARAMS);
++	val = NV_FLD_SET_DRF_DEF(DC, WIN_A_WINDOW_SET_PARAMS, A_DE_GAMMA, SRGB, val);
++	nvdisp_writel(nvdisp, WIN_A_WINDOW_SET_PARAMS, val);
++
+ 	val = nvdisp_readl(nvdisp, WIN_A_WIN_OPTIONS);
+ 	val = NV_FLD_SET_DRF_DEF(DC, WIN_A_WIN_OPTIONS, A_WIN_ENABLE, ENABLE, val);
+ 	nvdisp_writel(nvdisp, WIN_A_WIN_OPTIONS, val);
+diff --git a/bootloader/partner/common/drivers/display/sor/tegrabl_sor.c b/bootloader/partner/common/drivers/display/sor/tegrabl_sor.c
+index 90d8368..61aeb1c 100644
+--- a/bootloader/partner/common/drivers/display/sor/tegrabl_sor.c
++++ b/bootloader/partner/common/drivers/display/sor/tegrabl_sor.c
+@@ -499,8 +499,13 @@ static void sor_config_panel(struct sor_data *sor, bool is_lvds)
+ 
+ 	sor_writel(sor, SOR_NV_PDISP_SOR_STATE1_0, r_val);
+ 
+-	/* Skipping programming NV_HEAD_STATE0, assuming:
+-	   interlacing: PROGRESSIVE, dynamic range: VESA, colorspace: RGB */
++	/* Program NV_HEAD_STATE0 to match linux defaults */
++	if (sor->nvdisp->flags & NVDISP_FLAG_CMU_ENABLE) {
++		r_val = sor_readl(sor, SOR_NV_PDISP_HEAD_STATE0_0 + sor->nvdisp->instance);
++		r_val = NV_FLD_SET_DRF_DEF(SOR_NV_PDISP, HEAD_STATE0, RANGECOMPRESS, ENABLE, r_val);
++		r_val = NV_FLD_SET_DRF_DEF(SOR_NV_PDISP, HEAD_STATE0, DYNRANGE, CEA, r_val);
++		sor_writel(sor, SOR_NV_PDISP_HEAD_STATE0_0 + sor->nvdisp->instance, r_val);
++	}
+ 
+ 	vtotal = nvdisp_mode->v_sync_width + nvdisp_mode->v_back_porch +
+ 		nvdisp_mode->v_active + nvdisp_mode->v_front_porch;
+-- 
+2.29.2
+

--- a/recipes-bsp/cboot/cboot-t19x_32.5.0.bb
+++ b/recipes-bsp/cboot/cboot-t19x_32.5.0.bb
@@ -14,6 +14,7 @@ SRC_URI = "${L4T_ALT_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t1
            file://0010-t194-add-bootinfo-to-build.patch \
            file://0011-Add-machine-ID-to-kernel-command-line.patch \
            file://0012-bmp-support-A-B-slots.patch \
+           file://0013-display-nvdisp-sor-enable-seamless-display-transitio.patch \
 "
 
 SRC_URI[sha256sum] = "80a5b0491d75ea8f2d5f49e93e6d5b4986c739ff29f62133585c2fe7880e8fa9"

--- a/recipes-kernel/linux/linux-tegra-4.9/0001-nvdisp-Apply-correct-csc-settings-at-boot.patch
+++ b/recipes-kernel/linux/linux-tegra-4.9/0001-nvdisp-Apply-correct-csc-settings-at-boot.patch
@@ -1,0 +1,41 @@
+From f27d1a289cdbefe414f0dfc88a05d7152123ccc2 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kekiefer@gmail.com>
+Date: Wed, 7 Apr 2021 20:30:09 -0700
+Subject: [PATCH 1/1] nvdisp: Apply correct csc settings at boot
+
+This enables seemless display transition in concert with changes
+to bootloader to configure a limited range display mode by default.
+
+Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
+---
+ nvidia/drivers/video/tegra/dc/nvdisp/nvdisp.c | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/nvidia/drivers/video/tegra/dc/nvdisp/nvdisp.c b/nvidia/drivers/video/tegra/dc/nvdisp/nvdisp.c
+index 3626f39885f83..14476847fb68b 100644
+--- a/nvidia/drivers/video/tegra/dc/nvdisp/nvdisp.c
++++ b/nvidia/drivers/video/tegra/dc/nvdisp/nvdisp.c
+@@ -1373,12 +1373,6 @@ void tegra_nvdisp_set_ocsc(struct tegra_dc *dc, struct tegra_dc_mode *mode)
+ {
+ 	u32 csc2_control;
+ 
+-	/* If mode is not dirty, then set user cached csc2 values */
+-	if (!dc->mode_dirty) {
+-		csc2_control = dc->cached_settings.csc2_control;
+-		goto write_reg;
+-	}
+-
+ 	if (mode->vmode & FB_VMODE_BYPASS) {
+ 		/* Use rgb ocsc and disable range scaling for yuv bypass. */
+ 		csc2_control = nvdisp_csc2_control_output_color_sel_rgb_f() |
+@@ -1421,7 +1415,6 @@ void tegra_nvdisp_set_ocsc(struct tegra_dc *dc, struct tegra_dc_mode *mode)
+ 	/* Set user data cache */
+ 	dc->cached_settings.csc2_control = csc2_control;
+ 
+-write_reg:
+ 	tegra_dc_writel(dc, csc2_control, nvdisp_csc2_control_r());
+ }
+ 
+-- 
+2.29.2
+

--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -25,6 +25,7 @@ KERNEL_REPO = "${SRC_REPO}"
 SRC_URI = "git://${KERNEL_REPO};name=machine;branch=${KBRANCH} \
            ${@'file://localversion_auto.cfg' if d.getVar('SCMVERSION') == 'y' else ''} \
            ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://systemd.cfg', '', d)} \
+           file://0001-nvdisp-Apply-correct-csc-settings-at-boot.patch \
 "
 
 PATH_prepend = "${STAGING_BINDIR_NATIVE}/kern-tools-tegra:"


### PR DESCRIPTION
Patches to support seamless display transition from bootloader.

I assume we will probably apply the linux-tegra patches to the forked repo, but provided here for evaluation.

Taking over the framebuffer requires somewhat delicate handling as there seems to be some inconsistency between the currently set mode, and what the framebuffer emulation thinks the settings are, and the contents of the framebuffer memory don't seem to match what was present in the bootloader (although maybe they should?). Simply mapping the framebuffer won't show anything on the screen until the mode is written back.

First, update the framebuffer contents to match what was written in the bootloader, then:

```
cat /sys/class/graphics/fb0/mode | cat > /sys/class/graphics/fb0/mode
```

From an application, it is also possible, but similarly the initial framebuffer settings read back from the kernel can be incorrect. In particular, the display drivers want to see detailed+cea mode flags, or else it will mark the mode as dirty, even if the timings don't change.

The necessary flags can be seen by looking at the kernel logs. When the framebuffer virtual size is changed, you'll see a line like this:

```
tegradc 15200000.nvdisplay: tegra_dp_get_bpp: vmode=0x10000000 did not specify bpp
```

Then if the other application takes over and the display blinks while the link retrains (at least for displayport), you'll see the following:

```
tegradc 15200000.nvdisplay: blank - powerdown
...
tegradc 15200000.nvdisplay: tegra_dp_get_bpp: vmode=0x10600000 did not specify bpp
```

The vmode flags were what triggered the display update, and those could be added to the framebuffer settings.

```
ioctl(fd, FBIOGET_VSCREENINFO, &vinfo);

vinfo.vmode |= 0x200000;
vinfo.vmode |= 0x400000;

// existing code to mmap and draw any updates, the won't be visible until the following call is made:

ioctl(fd, FBIOPUT_VSCREENINFO, &vinfo);

// continue display progress
```

If using the ioctl method to "match" the display mode set by the bootloader, also check the virtual size settings and make sure the pixel clock matches the mode set by the bootloader.