### PR TITLE
external/openembedded-layer: opencv: update opticalflow download hash

### DIFF
--- a/external/openembedded-layer/recipes-support/opencv/opencv_4.5.%.bbappend
+++ b/external/openembedded-layer/recipes-support/opencv/opencv_4.5.%.bbappend
@@ -8,13 +8,13 @@ EXTRA_OECMAKE_append_tegra194 = ' -DWITH_CUDA=ON -DCUDA_ARCH_BIN="7.2" -DCUDA_AR
 
 EXTRA_OECMAKE_append = " -DOPENCV_GENERATE_PKGCONFIG=ON"
 
-OPTICALFLOW_MD5 = "ca5acedee6cb45d0ec610a6732de5c15"
-OPTICALFLOW_HASH = "79c6cee80a2df9a196f20afd6b598a9810964c32"
+OPTICALFLOW_MD5 = "a73cd48b18dcc0cc8933b30796074191"
+OPTICALFLOW_HASH = "edb50da3cf849840d680249aa6dbef248ebce2ca"
 
 SRC_URI += "https://github.com/NVIDIA/NVIDIAOpticalFlowSDK/archive/${OPTICALFLOW_HASH}.zip;name=opticalflow;unpack=false;subdir=${OPENCV_DLDIR}/nvidia_optical_flow;downloadfilename=${OPTICALFLOW_MD5}-${OPTICALFLOW_HASH}.zip"
 
 SRC_URI[opticalflow.md5sum] = "${OPTICALFLOW_MD5}"
-SRC_URI[opticalflow.sha256sum] = "c6ce0a9bc628b354b0b59a9677edc45c9ee2f640f3abb7353a94fe28b2689ed4"
+SRC_URI[opticalflow.sha256sum] = "e300c02e4900741700b2b857965d2589f803390849e1e2022732e02f4ae9be44"
 
 # No stable URI is available for NVIDIAOpticalFlowSDK
 INSANE_SKIP_append = " src-uri-bad"


### PR DESCRIPTION
The required version changed upstream. Adjust recipe to fetch this
version.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>