### PR TITLE
Fixes for L4T container compatibility

### DIFF
--- a/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils/0002-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch
+++ b/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils/0002-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch
@@ -1,0 +1,47 @@
+From 5182f0b73262eaad3c7fba695d823e2fb37c266d Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 11 Apr 2021 06:48:54 -0700
+Subject: [PATCH] Replace stat/fstat calls with __xstat/__fxstat
+
+The stat-family syscalls were reworked in
+glibc 2.33, so make the libv4lconvert plugin
+compatible with the older glibc used in L4T
+containers.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+
+---
+ lib/libv4lconvert/control/libv4lcontrol.c | 4 ++--
+ utils/media-ctl/libmediactl.c             | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/lib/libv4lconvert/control/libv4lcontrol.c b/lib/libv4lconvert/control/libv4lcontrol.c
+index 0b0a346..15e4146 100644
+--- a/lib/libv4lconvert/control/libv4lcontrol.c
++++ b/lib/libv4lconvert/control/libv4lcontrol.c
+@@ -370,10 +370,10 @@ static int v4lcontrol_get_usb_info(struct v4lcontrol_data *data,
+ 	    "%s/sys/class/video4linux", sysfs_prefix);
+ 
+ 	/* Check for sysfs mounted before trying to search */
+-	if (stat(sysfs_name, &st) != 0)
++	if (__xstat(0, sysfs_name, &st) != 0)
+ 		return 0; /* Not found, sysfs not mounted? */
+ 
+-	if (fstat(data->fd, &st) || !S_ISCHR(st.st_mode))
++	if (__fxstat(0, data->fd, &st) || !S_ISCHR(st.st_mode))
+ 		return 0; /* Should never happen */
+ 
+ 	/* <Sigh> find ourselve in sysfs */
+diff --git a/utils/media-ctl/libmediactl.c b/utils/media-ctl/libmediactl.c
+index 1fd6525..4fc1bed 100644
+--- a/utils/media-ctl/libmediactl.c
++++ b/utils/media-ctl/libmediactl.c
+@@ -486,7 +486,7 @@ static int media_get_devname_sysfs(struct media_entity *entity)
+ 	} else {
+ 		sprintf(devname, "/dev/%s", p + 1);
+ 	}
+-	ret = stat(devname, &devstat);
++	ret = __xstat(0, devname, &devstat);
+ 	if (ret < 0)
+ 		return -errno;
+ 

--- a/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
+++ b/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
@@ -1,5 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-SRC_URI_append_tegra = " file://0001-Make-plugin-directory-relative-to-ORIGIN.patch"
+SRC_URI_append_tegra = " \
+    file://0001-Make-plugin-directory-relative-to-ORIGIN.patch \
+    file://0002-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch \
+"
 
 EXTRA_OECONF_tegra = " --without-jpeg"
 DEPENDS_remove_tegra = "jpeg"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.5.0/0008-Replace-stat-call-with-__xstat.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r32.5.0/0008-Replace-stat-call-with-__xstat.patch
@@ -1,0 +1,28 @@
+From 1b5c0bda3970c722b3f257266bca9b72dcf6d2b4 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 11 Apr 2021 06:17:38 -0700
+Subject: [PATCH] Replace stat call with __xstat
+
+glibc 2.33 reworked the stat() family of syscalls, but we
+need this plugin to work inside L4T containers that use
+an older version of glibc, so replace stat() with the
+older __xstat(0, ...) for compatibility.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ v4l2_calls.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/v4l2_calls.c b/v4l2_calls.c
+index dea63b4..644050a 100644
+--- a/v4l2_calls.c
++++ b/v4l2_calls.c
+@@ -550,7 +550,7 @@ gst_v4l2_open (GstV4l2Object * v4l2object)
+     }
+   } else if (is_cuvid == FALSE) {
+     /* check if it is a device */
+-    if (stat (v4l2object->videodev, &st) == -1)
++    if (__xstat (0, v4l2object->videodev, &st) == -1)
+       goto stat_failed;
+ 
+     if (!S_ISCHR (st.st_mode))

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.5.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.5.0.bb
@@ -19,6 +19,7 @@ SRC_URI += "\
     file://0005-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch \
     file://0006-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch \
     file://0007-Import-gstv4l2bufferpool-patch-from-R32.5.1.patch \
+    file://0008-Replace-stat-call-with-__xstat.patch \
 "
 
 DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries"
@@ -35,11 +36,13 @@ CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 copy_headers() {
 	cp ${WORKDIR}/nvbuf_utils.h ${S}/
+	cp ${WORKDIR}/nvbufsurface.h ${S}/
 	cp ${WORKDIR}/v4l2_nv_extensions.h ${S}/
 }
 
 do_unpack_append() {
-    bb.build.exec_func("copy_headers", d)
+    if not bb.data.inherits_class("externalsrc", d):
+        bb.build.exec_func("copy_headers", d)
 }
 
 do_install() {

--- a/recipes-multimedia/libv4l2/libv4l2-minimal/0001-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch
+++ b/recipes-multimedia/libv4l2/libv4l2-minimal/0001-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch
@@ -1,0 +1,32 @@
+From 523d2b060f9d7cf340baa0615443e3fae7f25555 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 11 Apr 2021 06:48:54 -0700
+Subject: [PATCH] Replace stat/fstat calls with __xstat/__fxstat
+
+The stat-family syscalls were reworked in
+glibc 2.33, so make the libv4lconvert plugin
+compatible with the older glibc used in L4T
+containers.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ lib/libv4lconvert/control/libv4lcontrol.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/lib/libv4lconvert/control/libv4lcontrol.c b/lib/libv4lconvert/control/libv4lcontrol.c
+index 0b0a346..5643dbe 100644
+--- a/lib/libv4lconvert/control/libv4lcontrol.c
++++ b/lib/libv4lconvert/control/libv4lcontrol.c
+@@ -370,10 +370,10 @@ static int v4lcontrol_get_usb_info(struct v4lcontrol_data *data,
+ 	    "%s/sys/class/video4linux", sysfs_prefix);
+ 
+ 	/* Check for sysfs mounted before trying to search */
+-	if (stat(sysfs_name, &st) != 0)
++	if (__xstat(0, sysfs_name, &st) != 0)
+ 		return 0; /* Not found, sysfs not mounted? */
+ 
+-	if (fstat(data->fd, &st) || !S_ISCHR(st.st_mode))
++	if (__fxstat(0, data->fd, &st) || !S_ISCHR(st.st_mode))
+ 		return 0; /* Should never happen */
+ 
+ 	/* <Sigh> find ourselve in sysfs */

--- a/recipes-multimedia/libv4l2/libv4l2-minimal_1.18.0.bb
+++ b/recipes-multimedia/libv4l2/libv4l2-minimal_1.18.0.bb
@@ -6,7 +6,9 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 DEPENDS = "${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'virtual/libx11', '', d)}"
 
-SRC_URI = "http://linuxtv.org/downloads/v4l-utils/v4l-utils-${PV}.tar.bz2"
+SRC_URI = "http://linuxtv.org/downloads/v4l-utils/v4l-utils-${PV}.tar.bz2 \
+           file://0001-Replace-stat-fstat-calls-with-__xstat-__fxstat.patch \
+           "
 SRC_URI[md5sum] = "18996bd5e9d83d47055c05de376708cd"
 SRC_URI[sha256sum] = "6cb60d822eeed20486a03cc23e0fc65956fbc1e85e0c1a7477f68bbd9802880d"
 


### PR DESCRIPTION
With the [upgrade of glibc to 2.33 in OE-Core](https://git.openembedded.org/openembedded-core/commit/meta/recipes-core/glibc?id=aa87638cf4f2bef66df92f961c7814f6b482fd3d), some libraries in the OS that get mapped directly into containers are making syscalls that were re-implemented in the new version, resulting in symbol failures when trying to run applications in the NGC-hosted L4T containers.

It's the `stat()` family of calls that are causing the problem, so apply patches to use an older mechanism for making those calls which is compatible with the older glibc present in the containers.