### PR TITLE
libnvidia-container-tools: update SRC_URIs

### DIFF
--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
@@ -33,8 +33,8 @@ NVIDIA_MODPROBE_VERSION = "396.51"
 ELF_TOOLCHAIN_VERSION = "0.7.1"
 LIBTIRPC_VERSION = "1.1.4"
 
-SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia;branch=jetson \
-           git://github.com/NVIDIA/nvidia-modprobe.git;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
+SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;protocol=https;name=libnvidia;branch=jetson \
+           git://github.com/NVIDIA/nvidia-modprobe.git;protocol=https;branch=main;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
            file://0001-Makefile-Fix-RCP-flags-and-change-path-definitions-s.patch \
            file://0002-common.mk-Set-JETSON-variable-if-not-set-before.patch \
            file://0003-Fix-mapping-of-library-paths-for-jetson-mounts.patch \

--- a/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
+++ b/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_1.0.6.bb
@@ -34,8 +34,8 @@ ELF_TOOLCHAIN_VERSION = "0.7.1"
 LIBTIRPC_VERSION = "1.1.4"
 
 SRC_URI = " \
-    git://github.com/NVIDIA/libnvidia-container.git;name=libnvidia \
-    git://github.com/NVIDIA/nvidia-modprobe.git;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
+    git://github.com/NVIDIA/libnvidia-container.git;protocol=https;name=libnvidia \
+    git://github.com/NVIDIA/nvidia-modprobe.git;protocol=https;branch=main;name=modprobe;destsuffix=git/deps/src/nvidia-modprobe-${NVIDIA_MODPROBE_VERSION} \
     file://0001-Makefile-Fix-RCP-flags-and-change-prefix.patch \
 "
 


### PR DESCRIPTION
- use protocol=https
- modprobe repo renamed master branch to 'main'

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>