### PR TITLE
Update compiled-in build strings in TOS components

### DIFF
--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware.inc
@@ -25,10 +25,22 @@ LD[unexport] = "1"
 TARGET_SOC = "t186"
 TARGET_SOC_tegra194 = "t194"
 
-do_configure[noexec] = "1"
+def generate_build_timestamp(d):
+    from datetime import datetime
+    sde = d.getVar('SOURCE_DATE_EPOCH')
+    if sde:
+        return 'BUILD_MESSAGE_TIMESTAMP="\\\"{}\\\""'.format(datetime.utcfromtimestamp(int(sde)).strftime('%Y-%m-%d %H:%M:%S'))
+    return ''
+
+BUILDTIMESTAMP ?= "${@generate_build_timestamp(d)}"
+BUILD_STRING ??= ""
 
 EXTRA_OEMAKE = 'BUILD_BASE=${B} CROSS_COMPILE="${TARGET_PREFIX}" PLAT=tegra \
-	        DEBUG=0 LOG_LEVEL=20 V=0 TARGET_SOC=${TARGET_SOC} ${PACKAGECONFIG_CONFARGS}'
+	        DEBUG=0 LOG_LEVEL=20 V=0 TARGET_SOC=${TARGET_SOC} ${BUILDTIMESTAMP} ${BUILD_STRING} ${PACKAGECONFIG_CONFARGS}'
+
+do_configure_append() {
+	oe_runmake -C ${S} clean
+}
 
 do_compile() {
 	oe_runmake -C ${S} all

--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_1.3-l4t-32.5.0.bb
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_1.3-l4t-32.5.0.bb
@@ -2,4 +2,11 @@ TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/public/atf_src.tbz2"
 require recipes-bsp/tegra-sources/tegra-sources-32.5.0.inc
 S = "${WORKDIR}/arm-trusted-firmware"
 
+def generate_build_string(d):
+    pv = d.getVar('PV').split('-')
+    if len(pv) > 1:
+        return 'BUILD_STRING={}'.format('-'.join(pv[1:]))
+
+BUILD_STRING ?= "${@generate_build_string(d)}"
+
 require arm-trusted-firmware.inc

--- a/recipes-bsp/trusty/trusty-l4t.inc
+++ b/recipes-bsp/trusty/trusty-l4t.inc
@@ -47,13 +47,28 @@ do_configure() {
     make_tc_wrappers ${B}/bin-${BUILD_ARCH} as cpp gcc ld ld.bfd
 }
 
+def extract_version(i, d):
+    pv = d.getVar('PV').split('.')
+    if i < len(pv):
+        return pv[i]
+    return ''
+
+def generate_build_timestamp(d):
+    from datetime import datetime
+    sde = d.getVar('SOURCE_DATE_EPOCH')
+    if sde:
+        return 'BUILDTIMESTAMP="\\\"{}\\\""'.format(datetime.utcfromtimestamp(int(sde)).strftime('%Y-%m-%d %H:%M:%S'))
+    return ''
+
+VERSION_DEFS ?= "VERSION_MAJOR=${@extract_version(0, d)} VERSION_MINOR=${@extract_version(1, d)}"
+BUILDTIMESTAMP ?= "${@generate_build_timestamp(d)}"
 
 EXTRA_OEMAKE = 'PROJECT=t186 TARGET=t186 BUILDROOT=${B} \
                 TOOLCHAIN_PREFIX="${TARGET_PREFIX}" ARCH_arm64_TOOLCHAIN_PREFIX="${TARGET_PREFIX}" \
 		ARCH_arm_TOOLCHAIN_PREFIX="arm-eabi-" \
 	        DEBUG=0 DEBUG_LVL=0 V=0 DEFAULT_OTE_APP_DEBUGLEVEL=1 NOECHO=@ \
 		TRUSTY_VARIANT=l4t-public TRUSTY_MULTI_GUEST_CONFIGURATION= \
-		TARGET_SOC=${TARGET_SOC}'
+		TARGET_SOC=${TARGET_SOC} ${VERSION_DEFS} ${BUILDTIMESTAMP}'
 
 do_compile() {
     oe_runmake -C ${S} t186


### PR DESCRIPTION
Make the ATF and trusty builds more reproducible by explicitly setting build time stamps based on SOURCE_DATE_EPOCH,
and improve the version information.