### PR TITLE
In-build signing fixes

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -693,10 +693,8 @@ oe_make_bup_payload() {
         cp -R ${STAGING_DATADIR}/nv_tegra/rollback/t${@d.getVar('NVIDIA_CHIP')[2:]}x ./rollback/
     fi
     if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
-        [ "${SOC_FAMILY}" = "tegra210" ] || cp ${STAGING_BINDIR_NATIVE}/tegra186-flash/rollback_parser.py ./rollback/
-        cp ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/${SOC_FAMILY}-flash-helper.sh ./
-        sed -e 's,^function ,,' ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/l4t_bup_gen.func > ./l4t_bup_gen.func
-        cp ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/*.py .
+        cp -R ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/* ./
+        sed -i -e 's,^function ,,' ./l4t_bup_gen.func
         tegraflash_generate_bupgen_script ./doflash.sh
     fi
     tegraflash_custom_sign_bup

--- a/conf/machine/include/tegra210.inc
+++ b/conf/machine/include/tegra210.inc
@@ -21,6 +21,8 @@ KERNEL_ARGS ?= "sdhci_tegra.en_boot_part_access=1"
 
 NVIDIA_CHIP = "0x21"
 
+TEGRA_SIGNING_ENV ?= "BOARDID=${TEGRA_BOARDID} FAB=${TEGRA_FAB} BOARDSKU=${TEGRA_BOARDSKU} BOARDREV=${TEGRA_BOARDREV}"
+
 CUDA_NVCC_ARCH_FLAGS ?= "--gpu-architecture=compute_53 --gpu-code=sm_53"
 
 require conf/machine/include/tegra-common.inc

--- a/recipes-bsp/tegra-binaries/files/0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch
+++ b/recipes-bsp/tegra-binaries/files/0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch
@@ -1,0 +1,29 @@
+From 2287cb39236f850acd94ac5fd628c8985e3495c1 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 26 Apr 2021 07:52:31 -0700
+Subject: [PATCH] Remove xxd dependency from l4t_sign_image.sh
+
+since it's not necessarily available in the build environment.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ l4t_sign_image.sh | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/l4t_sign_image.sh b/l4t_sign_image.sh
+index 87d426d..a04fc39 100755
+--- a/l4t_sign_image.sh
++++ b/l4t_sign_image.sh
+@@ -91,8 +91,7 @@ function write_size_to_sig
+ 	echo "${SCRIPT_NAME}: chip ${chip}: add $(printf "0x%x" "${size}") to offset "\
+ 		"$(printf "0x%x" "${offset}") in sig file" >&5
+ 	# Convert size to bytes in little endian
+-	printf "%16x" "${size}" | tr '[:blank:]' '0' | fold -w2 | tac | tr -d "\n" \
+-		| xxd -p -r > "${tempfile}"
++	python3 -c "f = open(\"${tempfile}\",'wb'); f.write(int(${size}).to_bytes(8,'little')); f.close()"
+ 	# write to header at position 0x8
+ 	dd conv=notrunc if="${tempfile}" of="${sig_file}" bs=1 seek="${offset}" > /dev/null 2>&1;
+ 	rm "${tempfile}"
+-- 
+2.27.0
+

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra186-flash-helper.sh
@@ -178,6 +178,7 @@ echo "BYTES:$bytes CRC32:$cksum" >>${MACHINE}_bootblob_ver.txt
 appfile_sed=
 if [ $bup_blob -ne 0 ]; then
     appfile_sed="-e/APPFILE/d -e/DATAFILE/d"
+    kernfile="${kernfile:-boot.img}"
 elif [ $no_flash -eq 0 ]; then
     if [ -n "$imgfile" -a -e "$imgfile" ]; then
 	appfile_sed="-es,APPFILE,$imgfile, -es,DATAFILE,$dataimg,"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -265,6 +265,7 @@ else
 fi
 appfile_sed=
 if [ $bup_blob -ne 0 ]; then
+    kernfile="${kernfile:-boot.img}"
     appfile_sed="-e/APPFILE/d -e/DATAFILE/d"
 elif [ $no_flash -eq 0 -a -z "$sdcard" ]; then
     appfile_sed="-es,APPFILE,$appfile, -es,DATAFILE,$datafile,"

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
@@ -17,6 +17,7 @@ SRC_URI += "\
            file://0005-Convert-rollback_parser.py-to-Python3.patch \
            file://0006-Update-tegraflash_internal.py-for-Python3.patch \
            file://0007-Update-check-functions-in-BUP_generator.py-for-Pytho.patch \
+           file://0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"


### PR DESCRIPTION
Fixes for handling signing during builds (using `TEGRA_SIGNING_ARGS` to point to the key files) for all platforms.

See https://github.com/OE4T/meta-tegra/discussions/684