### PR TITLE
tegra-boot-tools update

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -226,7 +226,7 @@ tegraflash_create_flash_config_tegra186() {
         -e"s,WB0TYPE,WB0," -e"s,WB0FILE,warmboot.bin," -e"s,SC7NAME,sc7," \
         -e"s,TOSFILE,${TOSIMGFILENAME}," -e"s,TOSNAME,secure-os," \
         -e"s,EKSFILE,eks.img," \
-        -e"s,FBTYPE,data," -e"s,FBSIGN,false," -e"/FBFILE/d" \
+        -e"s,FBNAME,fusebypass," -e"s,FBTYPE,data," -e"s,FBSIGN,false," -e"/FBFILE/d" \
         -e"s,KERNELDTB-NAME,kernel-dtb," \
         -e"s,APPSIZE,${ROOTFSPART_SIZE}," \
         -e"s,RECNAME,recovery," -e"s,RECSIZE,66060288," -e"s,RECDTB-NAME,recovery-dtb," -e"s,BOOTCTRLNAME,kernel-bootctrl," \

--- a/recipes-bsp/tegra-binaries/files/0011-Fix-missing-t186-boot-partitions-in-l4t_bup_gen.func.patch
+++ b/recipes-bsp/tegra-binaries/files/0011-Fix-missing-t186-boot-partitions-in-l4t_bup_gen.func.patch
@@ -1,0 +1,26 @@
+From 6edf320b9798992a0659e223d76401ac72751db4 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 3 May 2021 07:20:13 -0700
+Subject: [PATCH] Fix missing t186 boot partitions in l4t_bup_gen.func
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/l4t_bup_gen.func | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/bootloader/l4t_bup_gen.func b/bootloader/l4t_bup_gen.func
+index a2c5c84..a429fd2 100644
+--- a/bootloader/l4t_bup_gen.func
++++ b/bootloader/l4t_bup_gen.func
+@@ -197,7 +197,10 @@ _generate_bl_update_payload()
+ 				"${signed_dir}"/spe_sigheader.bin.${signed_ext} spe-fw 2 0 $_common_spec; \
+ 				"${signed_dir}"/adsp-fw_sigheader.bin.${signed_ext} adsp-fw 2 0 $_common_spec; \
+ 				"${signed_dir}"/badpage_sigheader.bin.${signed_ext} badpage-fw 2 0 $_common_spec; \
+-				"${signed_dir}"/tos-trusty_sigheader.img.${signed_ext} secure-os 2 0 $_common_spec;"
++				"${signed_dir}"/eks_sigheader.img.${signed_ext} eks 2 0 $_common_spec; \
++				"${signed_dir}"/dram-ecc_sigheader.bin.${signed_ext} dram-ecc-fw 2 0 $_common_spec; \
++				"${signed_dir}"/tos-trusty_sigheader.img.${signed_ext} secure-os 2 0 $_common_spec; \
++				bmp.blob BMP 2 0 $_common_spec;"
+ 		ENTRY_LIST[kernel]=""${signed_dir}"/${kernel_image_base}_sigheader.img.${signed_ext} kernel 2 0 $_common_spec;"
+ 
+ 		if [ "${fuselevel}" == "fuselevel_nofuse" ]; then

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
@@ -19,6 +19,7 @@ SRC_URI += "\
            file://0007-Update-check-functions-in-BUP_generator.py-for-Pytho.patch \
            file://0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch \
            file://0010-Rework-logging-in-l4t_sign_image.sh.patch \
+           file://0011-Fix-missing-t186-boot-partitions-in-l4t_bup_gen.func.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"

--- a/recipes-bsp/tools/tegra-boot-tools_2.3.0.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_2.3.0.bb
@@ -3,10 +3,10 @@ HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
 LICENSE = "MIT & BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=7a9217de7f233011b127382da9a035a1"
 
-DEPENDS = "zlib systemd tegra-eeprom-tool"
+DEPENDS = "zlib util-linux systemd tegra-eeprom-tool"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "c77a1d5e1d2b77022581e32e2a79cd1fe2d158e0ca4ade332e482e92e0b544f7"
+SRC_URI[sha256sum] = "80e2d97a679253849d0c9e2b9063d694cf7fa4343f90db18eb9d6997f5371c77"
 
 OTABOOTDEV ??= "/dev/mmcblk0boot0"
 OTAGPTDEV ??= "/dev/mmcblk0boot1"


### PR DESCRIPTION
Updated tegra-boot-tools to support a complete reformatting/repartitioning/overwrite of the boot device on t186 and t194 platforms. 

Combined with an installer program/script that runs from an initrd, can be used to handle wipe-and-reinstall upgrades between L4T versions that change flash layouts by:
* reformatting and repartitioning the eMMC
* installing the new rootfs into the new partitions
* using `tegra-bootloader-upgrade --initialize` to make the system bootable
