### PR TITLE
virglrenderer depends on gbm.h

### DIFF
--- a/external/virtualization-layer/recipes-graphics/virglrenderer/virglrenderer_%.bbappend
+++ b/external/virtualization-layer/recipes-graphics/virglrenderer/virglrenderer_%.bbappend
@@ -1,0 +1,3 @@
+
+DEPENDS += "virtual/libgbm"
+


### PR DESCRIPTION
Signed-off-by: Joel Winarske <joel.winarske@gmail.com>

This enables the building of qemu package without changing qemu's package config.