### PR TITLE
conf/machine: enable serial uart via the micro-USB connector J501

### DIFF
--- a/conf/machine/include/agx-xavier-uefi.inc
+++ b/conf/machine/include/agx-xavier-uefi.inc
@@ -1,4 +1,4 @@
-SERIAL_CONSOLES ?= "115200;ttyS0"
+SERIAL_CONSOLES ?= "115200;ttyTCU0"
 
 PREFERRED_PROVIDER_virtual/bootloader ?= "jetson-uefi-prebuilt"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-tegra-upstream"
@@ -10,7 +10,7 @@ KERNEL_MODULE_AUTOLOAD = ""
 
 KERNEL_ROOTSPEC ?= ""
 KERNEL_DEVICETREE ?= "nvidia/tegra194-p2972-0000.dtb"
-KERNEL_ARGS ?= "earlycon=uart8250,mmio32,0x3110000 console=ttyS0,115200n8 fbcon=map:0 ${KERNEL_ROOTSPEC}"
+KERNEL_ARGS ?= "earlycon=uart8250,mmio32,0x3110000 console=ttyTCU0,115200n8 console=tty0 fbcon=map:0 ${KERNEL_ROOTSPEC}"
 
 EMMC_SIZE ?= "31276924928"
 EMMC_DEVSECT_SIZE ?= "512"


### PR DESCRIPTION
Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>

* here is the logs from the serial UART
[serial_uart_xavier_uefi.log](https://github.com/OE4T/meta-tegra/files/6572138/serial_uart_xavier_uefi.log)
