### PR TITLE
l4t-usb-device-mode: refresh systemd-networkd config files

### DIFF
--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4t-usb-gadget.network
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4t-usb-gadget.network
@@ -2,5 +2,8 @@
 Name=usb* rndis*
 Type=gadget
 
+[Link]
+RequiredForOnline=no
+
 [Network]
 Bridge=l4tbr0

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4tbr0.network
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/70-l4tbr0.network
@@ -6,9 +6,14 @@ Address=192.168.55.1/24
 DHCPServer=yes
 
 [DHCPServer]
-PoolOffset=99
+PoolOffset=100
 PoolSize=1
-DefaultLeaseTime=900
+DefaultLeaseTimeSec=900
+EmitTimezone=no
+EmitDNS=no
+EmitNTP=no
+EmitSIP=no
+EmitRouter=no
 
 [Route]
 Gateway=192.168.55.100


### PR DESCRIPTION
The original config files were for use with an older version of systemd
and needed some tweaks to work with newer versions.

Also flag the links as not required for network-online, especially
since some connected hosts may try to activate both of them, but only
one will come on-line at a time.

Signed-off-by: Matt Madison <matt@madison.systems>