### PR TITLE
tegra186-flashtools-native: patch to convert BMP_generator_L4T.py to …

### DIFF
--- a/recipes-bsp/tegra-binaries/files/0012-BMP_generator_L4T.py-to-Python3.patch
+++ b/recipes-bsp/tegra-binaries/files/0012-BMP_generator_L4T.py-to-Python3.patch
@@ -1,0 +1,71 @@
+--- Linux_for_Tegra/tools/bmp-splash/BMP_generator_L4T.py.orig	2021-06-02 02:26:34.460334063 +0000
++++ Linux_for_Tegra/tools/bmp-splash/BMP_generator_L4T.py	2021-06-02 02:54:01.965137867 +0000
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (c) 2017-2020, NVIDIA CORPORATION.  All rights reserved.
+ #
+@@ -26,7 +26,7 @@
+ import sys
+ 
+ if sys.hexversion < 0x02060000:
+-  print >> sys.stderr, "Python 2.6 or newer is required."
++  print("Python 2.6 or newer is required.", file=sys.stderr)
+   sys.exit(1)
+ 
+ import os
+@@ -112,10 +112,10 @@
+             self.header_size += accessory_handle.tell()
+ 
+         if self.header_version == '0':
+-            header_tuple = (self.magic, self.version, 0, self.header_size,
++            header_tuple = (self.magic.encode('utf-8'), self.version, 0, self.header_size,
+                             len(self.entry_info_list), self.blob_type)
+         else:
+-            header_tuple = (self.magic, self.version, 0, self.header_size,
++            header_tuple = (self.magic.encode('utf-8'), self.version, 0, self.header_size,
+                             len(self.entry_info_list), self.blob_type, 0)
+ 
+         header = struct.pack(self.header_packing, *header_tuple)
+@@ -169,7 +169,7 @@
+         payload.__init__(self, arg)
+         self.blob_type = 1
+         self.entry_packing = '=IIII36s'
+-        self.entry_tuple = (0, 0, 0, 0, '')
++        self.entry_tuple = (0, 0, 0, 0, ''.encode('utf-8'))
+         self.param_c = 3
+         self.outfile = 'bmp.blob'
+ 
+@@ -181,7 +181,7 @@
+ 
+             entry_info = self.entry_info_list[i]
+             if len(entry_info) != self.param_c:
+-                print 'Invalid entry tuple:', entry_info
++                print('Invalid entry tuple:', entry_info)
+                 return
+ 
+             binary_name = payload.get_binary_name(self, entry_info[0])
+@@ -208,7 +208,7 @@
+             entry_update = self.entry_update_list[i]
+             offset = entry_update[0]
+             length = entry_update[1]
+-            entry_tuple = (tp, offset, length, res, '')
++            entry_tuple = (tp, offset, length, res, ''.encode('utf-8'))
+             updated_entry = struct.pack(self.entry_packing, *entry_tuple)
+             blob.write(updated_entry)
+ 
+@@ -217,11 +217,11 @@
+ def main(arg):
+ 
+     # Check "OUT" variable is set and is valid
+-    if not os.environ.has_key("OUT") or not os.path.isdir(os.environ["OUT"]):
++    if "OUT" not in os.environ or not os.path.isdir(os.environ["OUT"]):
+         sys.stderr.write("Environment variable OUT not set or invalid.\n")
+         return
+ 
+-    print 'BMP IMAGE INFO   :', arg.entry_list
++    print('BMP IMAGE INFO   :', arg.entry_list)
+ 
+     if arg.blob_type == 'bmp':
+         payload_obj = bmp_payload(arg)

--- a/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra186-flashtools-native_32.5.1.bb
@@ -20,6 +20,7 @@ SRC_URI += "\
            file://0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch \
            file://0010-Rework-logging-in-l4t_sign_image.sh.patch \
            file://0011-Fix-missing-t186-boot-partitions-in-l4t_bup_gen.func.patch \
+           file://0012-BMP_generator_L4T.py-to-Python3.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"


### PR DESCRIPTION
…python3

Change python shebang to python3 shebang and
other python3 conversions (print and string encodes)

bootlogo-custom recipe was unable to build due to python2
build dependency

Signed-off-by: Geoff Parker <geoffrey.parker@arthrex.com>