### PR TITLE
jetson-xavier-nx-devkit-emmc: add BUP support for FAB 300

### DIFF
--- a/conf/machine/jetson-xavier-nx-devkit-emmc.conf
+++ b/conf/machine/jetson-xavier-nx-devkit-emmc.conf
@@ -5,7 +5,8 @@
 
 TEGRA_BOARDSKU ?= "0001"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0001;boardrev= \
-		       fab=200;boardsku=0001;boardrev="
+		       fab=200;boardsku=0001;boardrev= \
+		       fab=300;boardsku=0001;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
 require conf/machine/include/xavier-nx.inc


### PR DESCRIPTION
Jetson Xavier NX devkit modules got a version bump, so to make
sure that we can build compatible BUP payloads, add that FAB to the
list of specs is needed.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>