### PR TITLE
tegra-boot-tools update

### DIFF
--- a/recipes-bsp/tools/tegra-boot-tools_2.4.0.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_2.4.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=7a9217de7f233011b127382da9a035a1"
 DEPENDS = "zlib util-linux-libuuid systemd tegra-eeprom-tool"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "624329d1a4e4e542815d59f7ba8c03cab31a3ef13890b5a37e10ff0cb6891e8f"
+SRC_URI[sha256sum] = "26894f4bddaf6ccad2048c6f10452feef53c131ebd65b08a97f79bafe1c1453f"
 
 OTABOOTDEV ??= "/dev/mmcblk0boot0"
 OTAGPTDEV ??= "/dev/mmcblk0boot1"

--- a/recipes-bsp/tools/tegra-bootpart-config_1.0.bb
+++ b/recipes-bsp/tools/tegra-bootpart-config_1.0.bb
@@ -34,10 +34,11 @@ do_compile() {
     while read line; do
         eval "$line"
 	if [ -n "$start_location" ]; then
-            if [ $cursize -gt $start_location ]; then
-                bberror "Partition $partname start location ($start_location) is less than current offset ($cursize)"
+	    startbytes=$(expr $start_location \* $blksize || true)
+            if [ $cursize -gt $startbytes ]; then
+                bberror "Partition $partname start location ($startbytes) is less than current offset ($cursize)"
             fi
-            cursize=$start_location
+            cursize=$startbytes
         fi
         partbytes=$(expr $partsize \* $blksize)
         echo "$partname:$cursize:$partbytes" >> ${B}/layout.conf


### PR DESCRIPTION
* Updates tegra-boot-tools to v2.4.0, which has some optimizations to reduce the number of writes to SPI flash when initializing.
* Update the `nvflashxmlparse` script to improve handling of `<align_boundary>` elements more generally and to consistently use sectors as the unit for both the start location and partition size in its output.
* Update tegra-bootpart-config recipe for the `nvflashxmlparse` changes.

The latter two changes fix an issue where tegra-boot-tools would lay out the boot device partitions differently than the normal L4T flashing tools.