### PR TITLE
Revert "jetson-xavier-nx-devkit-emmc: add BUP support for FAB 300"

### DIFF
--- a/conf/machine/jetson-xavier-nx-devkit-emmc.conf
+++ b/conf/machine/jetson-xavier-nx-devkit-emmc.conf
@@ -5,8 +5,7 @@
 
 TEGRA_BOARDSKU ?= "0001"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0001;boardrev= \
-		       fab=200;boardsku=0001;boardrev= \
-		       fab=300;boardsku=0001;boardrev="
+		       fab=200;boardsku=0001;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
 require conf/machine/include/xavier-nx.inc


### PR DESCRIPTION
This reverts commit f89a07ce91d43dbdb175d746e8c7c0292e14ff37.

No need to add FAB 300 because it's related to PCN206980 (hardware
changes in Jetson Xavier NX)

Please refer to the the document:
https://developer.nvidia.com/jetson-xavier-nx-pcn206980-dram-emmc-manufacturing-bom-expansion

Signed-off-by: Ilies CHERGUI ilies.chergui@gmail.com