### PR TITLE
gstreamer: add libgst packages to PACKAGES_DYNAMIC

### DIFF
--- a/contrib/recipes-multimedia/gstreamer-1.14/gst-plugins-package.inc
+++ b/contrib/recipes-multimedia/gstreamer-1.14/gst-plugins-package.inc
@@ -49,6 +49,9 @@ ALLOW_EMPTY_${PN}-staticdev = "1"
 
 PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
 
+# Dynamically generate packages for all enabled plugins
+PACKAGES_DYNAMIC = "^${PN}-.* ^libgst.*"
+
 FILES_${PN} = ""
 FILES_${PN}-apps = "${bindir}"
 FILES_${PN}-glib = "${datadir}/glib-2.0"

--- a/contrib/recipes-multimedia/gstreamer-1.14/gstreamer1.0-plugins-base_1.14.4.bb
+++ b/contrib/recipes-multimedia/gstreamer-1.14/gstreamer1.0-plugins-base_1.14.4.bb
@@ -32,8 +32,6 @@ DEPENDS += "iso-codes util-linux"
 
 inherit gettext gobject-introspection
 
-PACKAGES_DYNAMIC =+ "^libgst.*"
-
 # opengl packageconfig factored out to make it easy for distros
 # and BSP layers to pick either (desktop) opengl, gles2, or no GL
 PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"

--- a/contrib/recipes-multimedia/gstreamer-1.14/gstreamer1.0-plugins.inc
+++ b/contrib/recipes-multimedia/gstreamer-1.14/gstreamer1.0-plugins.inc
@@ -37,5 +37,3 @@ delete_pkg_m4_file() {
 }
 
 do_configure[prefuncs] += " delete_pkg_m4_file"
-
-PACKAGES_DYNAMIC = "^${PN}-.*"


### PR DESCRIPTION
gstreamer1.0-plugins-tegra-nvcompositor RDEPENDS on libgstbadvideo-1.0,
but no providers of the package can be found.

This commit was patterned after:

https://git.openembedded.org/openembedded-core/commit/?id=d5650e00f7b26b8949ca3baad7df4b8a4ea918a7

Signed-off-by: Chad McQuillen <chad.mcquillen@lexmark.com>