### PR TITLE
Add workaround to fix nvvideo4linux2 build

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.5.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.5.0.bb
@@ -27,6 +27,7 @@ DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-lib
 PACKAGECONFIG ??= "libv4l2"
 PACKAGECONFIG[libv4l2] = ",,v4l-utils,tegra-libraries-libv4l-plugins"
 EXTRA_OEMAKE = "${@bb.utils.contains('PACKAGECONFIG', 'libv4l2', 'USE_LIBV4L2=1', '', d)}"
+CFLAGS += "-fcommon"
 
 S = "${WORKDIR}/gst-v4l2"
 


### PR DESCRIPTION
With GCC 10+, `-fcommon` is no longer the default. This is not a significant issue for the majority of packages, as they have been updated to reflect this change. However, nvvideo4linux2 has not, and requires this work-around to successfully build with GCC 10+.

Please let me know if this isn't the desired way to fix this issue!