### PR TITLE
l4t_deb_pkgfeed.bbclass: fix for new override syntax

### DIFF
--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -45,7 +45,7 @@ SRC_URI = "${@l4t_deb_src_uri(d)}"
 do_unpack[depends] += "zstd-native:do_populate_sysroot"
 
 do_unpack[depends] += "tar-l4t-workaround-native:do_populate_sysroot"
-EXTRANATIVEPATH:append_task-unpack = " tar-l4t-workaround-native"
+EXTRANATIVEPATH:append:task-unpack = " tar-l4t-workaround-native"
 
 do_unpack:prepend() {
     path = d.getVar('PATH')


### PR DESCRIPTION
Fixed a missing update for the new override syntax. This fixes
an issue with l4t .deb packages using zstd compression not extracting
properly.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>