### PR TITLE
recipes-containers: rdepend on docker instead of docker-ce

### DIFF
--- a/external/virtualization-layer/recipes-containers/nvidia-container-runtime/nvidia-container-runtime_3.1.0.bb
+++ b/external/virtualization-layer/recipes-containers/nvidia-container-runtime/nvidia-container-runtime_3.1.0.bb
@@ -44,6 +44,6 @@ do_install:append:tegra() {
 
 RDEPENDS:${PN} = "\
     nvidia-container-toolkit \
-    docker-ce \
+    docker \
 "
 RDEPENDS:${PN}-dev += "bash make"

--- a/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.0.5.bb
+++ b/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.0.5.bb
@@ -35,6 +35,6 @@ FILES:${PN} += "${datadir}/oci"
 
 RDEPENDS:${PN} = "\
     libnvidia-container-tools \
-    docker-ce \
+    docker \
 "
 RDEPENDS:${PN}-dev += "bash make"


### PR DESCRIPTION
Allow the user to select either docker-moby or docker-ce as the default
docker provider (docker.inc, used by both docker-moby and docker-ce has
the required rprovides logic for the common docker package).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>