### PR TITLE
Build Tensorrt Plugins from source

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -51,7 +51,7 @@ SIGGEN_EXCLUDE_SAFE_RECIPE_DEPS += "\
   cuda-nvrtc->tegra-libraries \
   cuda-nvtx->tegra-libraries \
   libcublas->tegra-libraries \
-  tensorrt->tegra-libraries \
+  tensorrt-core->tegra-libraries \
   libdrm->libdrm-nvdc \
   libdrm-nvdc->tegra-libraries \
   tegra-nvs-service->tegra-nvs-base \

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -35,6 +35,7 @@ PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
 PREFERRED_PROVIDER_libv4l = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
 PREFERRED_PROVIDER_v4l-utils = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
 PREFERRED_PROVIDER_virtual/bootlogo ?= "bootlogo-prebuilt"
+PREFERRED_PROVIDER_tensorrt-plugins ?= "tensorrt-plugins-prebuilt"
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 TEGRA_BLBLOCKSIZE ?= "${@int(d.getVar('IMAGE_ROOTFS_ALIGNMENT')) * 1024}"

--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_8.0.1.bb
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_8.0.1.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "http://developer.nvidia.com/tensorrt"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://python/packaging/LICENSE.txt;md5=c291e0a531e08d4914e269730ba2f70d"
 
-DEPENDS = "python3-pybind11 tensorrt"
+DEPENDS = "python3-pybind11 tensorrt-core tensorrt-plugins"
 
 inherit setuptools3 cmake cuda
 

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
@@ -1,0 +1,213 @@
+From 856bfb6202058c406f6cfb47b4a2b89826a5e8c4 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Thu, 16 Sep 2021 22:44:16 +0100
+Subject: [PATCH] CMakeLists.txt: fix cross compilation issues.
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ CMakeLists.txt | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -56,12 +56,16 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_T
+ option(BUILD_PLUGINS "Build TensorRT plugin" ON)
+ option(BUILD_PARSERS "Build TensorRT parsers" ON)
+ option(BUILD_SAMPLES "Build TensorRT samples" ON)
++option(BUILD_PROTOBUF "Build internal copy of protobuf" OFF)
+ 
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss")
+ 
++# otherwise the installation directories are empty by default
++include(GNUInstallDirs)
++
+ ############################################################################################
+ # Cross-compilation settings
+ 
+@@ -96,7 +100,11 @@ message(STATUS "Protobuf version set to
+ find_package(Threads REQUIRED)
+ if (BUILD_PLUGINS OR BUILD_PARSERS)
+     include(third_party/zlib.cmake)
+-    include(third_party/protobuf.cmake)
++    if (BUILD_PROTOBUF)
++        include(third_party/protobuf.cmake)
++    else()
++        find_package(Protobuf REQUIRED)
++    endif()
+ endif()
+ if(NOT CUB_ROOT_DIR)
+     set(CUB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cub CACHE STRING "directory of CUB installation")
+@@ -111,27 +119,30 @@ include_directories(
+     ${CUDA_INCLUDE_DIRS}
+     ${CUDNN_ROOT_DIR}/include
+ )
++
+ find_library(CUDNN_LIB cudnn HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} ${CUDNN_ROOT_DIR} PATH_SUFFIXES lib64 lib)
++    ${CUDA_TOOLKIT_TARGET_DIR} ${CUDNN_ROOT_DIR} PATH_SUFFIXES lib64 lib)
+ find_library(CUBLAS_LIB cublas HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
++    ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+ find_library(CUBLASLT_LIB cublasLt HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+-if(BUILD_PARSERS)
++    ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
++if(BUILD_PROTOBUF)
+     configure_protobuf(${PROTOBUF_VERSION})
+ endif()
+-
+ find_library_create_target(nvinfer nvinfer SHARED ${TRT_LIB_DIR})
+ find_library_create_target(nvuffparser nvparsers SHARED ${TRT_LIB_DIR})
+ 
+-find_library(CUDART_LIB cudart HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib64)
++find_library(CUDART_LIB cudart HINTS ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib lib64)
+ find_library(RT_LIB rt)
+ 
+ set(CUDA_LIBRARIES ${CUDART_LIB})
+ 
+ ############################################################################################
+ # CUDA targets
+-
++if (SKIP_GPU_ARCHS)
++    set(GENCODES "")
++    set(BERT_GENCODES "")
++else()
+ if (DEFINED GPU_ARCHS)
+   message(STATUS "GPU_ARCHS defined as ${GPU_ARCHS}. Generating CUDA code for SM ${GPU_ARCHS}")
+   separate_arguments(GPU_ARCHS)
+@@ -173,6 +184,7 @@ set(GENCODES "${GENCODES} -gencode arch=
+ if (${LATEST_SM} GREATER_EQUAL 70)
+     set(BERT_GENCODES "${BERT_GENCODES} -gencode arch=compute_${LATEST_SM},code=compute_${LATEST_SM}")
+ endif()
++endif()
+ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
+ 
+ ############################################################################################
+@@ -185,6 +197,8 @@ else()
+ endif()
+ 
+ if(BUILD_PARSERS)
++    set(BUILD_LIBRARY_ONLY 1)
++    set(TENSORRT_LIBRARY_INFER_PLUGIN "nvinfer_plugin")
+     add_subdirectory(parsers)
+ else()
+     find_library_create_target(nvcaffeparser nvparsers SHARED ${TRT_OUT_DIR} ${TRT_LIB_DIR})
+Index: git/parsers/caffe/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/caffe/CMakeLists.txt
++++ git/parsers/caffe/CMakeLists.txt
+@@ -47,7 +47,7 @@ target_include_directories(${SHARED_TARG
+     PRIVATE caffeWeightFactory
+     PRIVATE ../common
+     PRIVATE ${Protobuf_INCLUDE_DIR}
+-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/proto
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+ )
+ 
+ set_target_properties(${SHARED_TARGET}
+@@ -65,6 +65,7 @@ target_link_libraries(${SHARED_TARGET}
+     nvinfer
+ )
+ 
++if(BUILD_PROTOBUF)
+ # modify google namespace to avoid namespace collision.
+ set(GOOGLE google_private)
+ target_compile_definitions(${SHARED_TARGET}
+@@ -72,6 +73,7 @@ target_compile_definitions(${SHARED_TARG
+     "-Dgoogle=${GOOGLE}"
+     "-DGOOGLE_PROTOBUF_ARCH_64_BIT"
+ )
++endif()
+ 
+ set_target_properties(${SHARED_TARGET} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
+ 
+@@ -97,7 +99,7 @@ target_include_directories(${STATIC_TARG
+     PRIVATE caffeWeightFactory
+     PRIVATE ../common
+     PRIVATE ${Protobuf_INCLUDE_DIR}
+-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/proto
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+ )
+ 
+ set_target_properties(${STATIC_TARGET}
+@@ -114,6 +116,7 @@ target_link_libraries(${STATIC_TARGET}
+     ${Protobuf_LIBRARY}
+ )
+ 
++if(BUILD_PROTOBUF)
+ # modify google namespace to avoid namespace collision.
+ set(GOOGLE google_private)
+ target_compile_definitions(${STATIC_TARGET}
+@@ -121,6 +124,7 @@ target_compile_definitions(${STATIC_TARG
+     "-Dgoogle=${GOOGLE}"
+     "-DGOOGLE_PROTOBUF_ARCH_64_BIT"
+ )
++endif()
+ 
+ set_target_properties(${STATIC_TARGET} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
+ 
+Index: git/parsers/onnx/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/onnx/CMakeLists.txt
++++ git/parsers/onnx/CMakeLists.txt
+@@ -76,7 +76,7 @@ endif()
+ if (NOT TARGET protobuf::libprotobuf)
+   FIND_PACKAGE(Protobuf REQUIRED)
+ else()
+-  set(PROTOBUF_LIB "protobuf::libprotobuf")
++  set(PROTOBUF_LIBRARY "protobuf::libprotobuf")
+ endif()
+ 
+ if(NOT TARGET onnx_proto)
+Index: git/parsers/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/CMakeLists.txt
++++ git/parsers/CMakeLists.txt
+@@ -21,8 +21,10 @@ add_custom_target(parsers DEPENDS
+ 
+ add_subdirectory(caffe)
+ 
+-add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
+-add_compile_options("-Dgoogle=google_private")
++if(BUILD_PROTOBUF)
++    add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
++    add_compile_options("-Dgoogle=google_private")
++endif()
+ set(TENSORRT_ROOT ${PROJECT_SOURCE_DIR})
+ set(TENSORRT_BUILD ${TRT_OUT_DIR} ${TRT_LIB_DIR})
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TRT_OUT_DIR})
+Index: git/plugin/CMakeLists.txt
+===================================================================
+--- git.orig/plugin/CMakeLists.txt
++++ git/plugin/CMakeLists.txt
+@@ -60,7 +60,7 @@ set(PLUGIN_LISTS
+     )
+ 
+ # Add BERT sources if ${BERT_GENCODES} was populated
+-if(BERT_GENCODES)
++if(DEFINED BERT_GENCODES)
+     set(BERT_CU_SOURCES)
+     set(PLUGIN_LISTS
+         ${PLUGIN_LISTS}
+@@ -83,10 +83,14 @@ endforeach(PLUGIN_ITER)
+ add_subdirectory(common)
+ 
+ # Set gencodes
+-set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${GENCODES})
++if(GENCODES)
++    set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${GENCODES})
++endif()
+ list(APPEND PLUGIN_SOURCES "${PLUGIN_CU_SOURCES}")
+ if (BERT_CU_SOURCES)
+-    set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${BERT_GENCODES})
++    if(BERT_GENCODES)
++        set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${BERT_GENCODES})
++    endif()
+     list(APPEND PLUGIN_SOURCES "${BERT_CU_SOURCES}")
+ endif()

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.0.1-1.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.0.1-1.bb
@@ -1,0 +1,50 @@
+DESCRIPTION = "NVIDIA TensorRT Plugins for deep learning"
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+LICENSE = "Apache-2.0 & BSD-3-Clause & MIT"
+LIC_FILES_CHKSUM = " \
+  file://LICENSE;md5=a55f7353e48c6734c10531db0b040177 \
+  file://third_party/cub/LICENSE.TXT;md5=20d1414b801e2a130d7d546685105508 \
+  file://parsers/onnx/third_party/onnx/LICENSE;md5=efff5c5110f124a1e2163814067b16e7 \
+  file://parsers/onnx/LICENSE;md5=e149467d209874a32715c20e9fdafac5 \
+"
+
+inherit cuda cmake container-runtime-csv
+
+SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
+SRCBRANCH = "master"
+SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
+    file://0001-CMakeLists.txt-fix-cross-compilation-issues.patch \
+"
+SRCREV = "eb5de99b523c76c2f3ae997855ad86d3a1e86a31"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "zlib libcublas cudnn cuda-cudart cuda-nvrtc protobuf protobuf-native tensorrt-core"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+CONTAINER_CSV_FILES = "${libdir}/*.so*"
+
+PACKAGECONFIG ??= " \
+    plugin \
+    parsers \
+"
+PACKAGECONFIG[plugin] = "-DBUILD_PLUGINS=ON,-DBUILD_PLUGINS=OFF,"
+PACKAGECONFIG[parsers] = "-DBUILD_PARSERS=ON,-DBUILD_PARSERS=OFF,"
+
+EXTRA_OECMAKE = "-DBUILD_SAMPLES=OFF -DSKIP_GPU_ARCHS=ON -DTRT_PLATFORM_ID="${TARGET_ARCH}" \
+  -DCUDA_VERSION="${CUDA_VERSION}" -DCUDA_NVCC_FLAGS="${CUDA_NVCC_FLAGS}" \
+  -DCUDA_INCLUDE_DIRS="${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}/include" \
+"
+
+LDFLAGS += "-Wl,--no-undefined"
+
+do_install:append() {
+    install -d ${D}${includedir}
+    install -m 0644 ${S}/include/NvInferPlugin.h ${D}${includedir}
+    install -m 0644 ${S}/include/NvInferPluginUtils.h ${D}${includedir}
+    install -m 0644 ${S}/include/NvOnnxConfig.h ${D}${includedir}  
+    install -m 0644 ${S}/parsers/onnx/NvOnnxParser.h ${D}${includedir}
+}
+
+RDEPENDS:${PN} += "tegra-libraries"

--- a/recipes-devtools/deepstream/deepstream-5.1_5.1.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-5.1_5.1.0-1.bb
@@ -21,7 +21,7 @@ PACKAGECONFIG[kafka] = ",,librdkafka"
 # NB: requires hiredis 1.0.0+
 PACKAGECONFIG[redis] = ",,hiredis"
 
-DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server tensorrt libnvvpi1 libvisionworks json-glib tegra-libraries"
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-rtsp-server tensorrt-core tensorrt-plugins libnvvpi1 libvisionworks json-glib tegra-libraries"
 
 S = "${WORKDIR}/${BPN}"
 B = "${WORKDIR}/build"

--- a/recipes-devtools/gie/tensorrt-core_8.0.1-1.bb
+++ b/recipes-devtools/gie/tensorrt-core_8.0.1-1.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "NVIDIA TensorRT Core (GPU Inference Engine) for deep learning"
+LICENSE = "Proprietary"
+
+inherit l4t_deb_pkgfeed container-runtime-csv
+
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+
+L4T_DEB_GROUP = "tensorrt"
+
+SRC_COMMON_DEBS = "\
+    libnvinfer8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer8_${PV}+cuda10.2_arm64.deb;name=lib;subdir=tensorrt \
+    libnvinfer-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=tensorrt \
+    libnvparsers8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvparsers8_${PV}+cuda10.2_arm64.deb;name=nvp;subdir=tensorrt \
+    libnvparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvparsers-dev_${PV}+cuda10.2_arm64.deb;name=nvpdev;subdir=tensorrt \
+"
+LIBSHA256SUM = "305c4482a315ceb59e514823b359fdeebfbdd5fa2124e277dd176589e2f49aea"
+DEVSHA256SUM = "f750c910a23107715dc2510d360725e46e9072079caacf3cec4255dd38bee849"
+NVPSHA256SUM = "34040352c9f44611928a7d6aa6a7f885b6506a7b3310a8b9fc0782a9ba42037a"
+NVPDEVSHA256SUM = "b09864c351aebf2200fb98f48dc68b4a75260bbcd01423bbf1633acdc115b9be"
+
+SRC_URI[lib.sha256sum] = "${LIBSHA256SUM}"
+SRC_URI[dev.sha256sum] = "${DEVSHA256SUM}"
+SRC_URI[nvp.sha256sum] = "${NVPSHA256SUM}"
+SRC_URI[nvpdev.sha256sum] = "${NVPDEVSHA256SUM}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=48;md5=3d6981c1227c404d42d710f96a875a1b"
+
+S = "${WORKDIR}/tensorrt"
+
+CONTAINER_CSV_FILES = "${libdir}/*.so*"
+
+do_configure() {
+    :
+}
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${includedir}
+    install -m 0644 ${S}/usr/include/aarch64-linux-gnu/*.h ${D}${includedir}
+    install -d ${D}${libdir}
+    cp --preserve=mode,timestamps,links --no-dereference ${S}/usr/lib/aarch64-linux-gnu/*.so* ${D}${libdir}
+}
+
+RDEPENDS:${PN} += "cudnn libcublas cuda-nvrtc tegra-libraries"
+INSANE_SKIP:${PN} = "already-stripped"
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-devtools/gie/tensorrt-plugins-prebuilt_8.0.1-1.bb
+++ b/recipes-devtools/gie/tensorrt-plugins-prebuilt_8.0.1-1.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "NVIDIA TensorRT (GPU Inference Engine) for deep learning"
+DESCRIPTION = "NVIDIA TensorRT Prebuilt Plugins for deep learning"
 LICENSE = "Proprietary"
 
 inherit l4t_deb_pkgfeed container-runtime-csv
@@ -8,11 +8,6 @@ HOMEPAGE = "http://developer.nvidia.com/tensorrt"
 L4T_DEB_GROUP = "tensorrt"
 
 SRC_COMMON_DEBS = "\
-    libnvinfer8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer8_${PV}+cuda10.2_arm64.deb;name=lib;subdir=tensorrt \
-    libnvinfer-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=tensorrt \
-    libnvinfer-samples_${PV}+cuda10.2_all.deb;downloadfilename=libnvinfer-samples_${PV}+cuda10.2_all.deb;name=samples;subdir=tensorrt \
-    libnvparsers8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvparsers8_${PV}+cuda10.2_arm64.deb;name=nvp;subdir=tensorrt \
-    libnvparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvparsers-dev_${PV}+cuda10.2_arm64.deb;name=nvpdev;subdir=tensorrt \
     libnvonnxparsers8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvonnxparsers8_${PV}+cuda10.2_arm64.deb;name=onnx;subdir=tensorrt \
     libnvonnxparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvonnxparsers-dev_${PV}+cuda10.2_arm64.deb;name=onnxdev;subdir=tensorrt \
     libnvinfer-plugin8_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer-plugin8_${PV}+cuda10.2_arm64.deb;name=plugin;subdir=tensorrt \
@@ -20,22 +15,12 @@ SRC_COMMON_DEBS = "\
     libnvinfer-bin_${PV}+cuda10.2_arm64.deb;downloadfilename=libnvinfer-bin_${PV}+cuda10.2_arm64.deb;name=bin;subdir=tensorrt \
 "
 
-LIBSHA256SUM = "305c4482a315ceb59e514823b359fdeebfbdd5fa2124e277dd176589e2f49aea"
-DEVSHA256SUM = "f750c910a23107715dc2510d360725e46e9072079caacf3cec4255dd38bee849"
-SAMPSHA256SUM = "6eadd053f8e840f17ee8ea5cde98b2b170b91a763cc5cf0bda5a8c59a4d5390d"
-NVPSHA256SUM = "34040352c9f44611928a7d6aa6a7f885b6506a7b3310a8b9fc0782a9ba42037a"
-NVPDEVSHA256SUM = "b09864c351aebf2200fb98f48dc68b4a75260bbcd01423bbf1633acdc115b9be"
 ONNXSHA256SUM = "8d4b0722515d91592e73dca2c43b798430bef4633b34d912324b53b63acf41ae"
 ONNXDEVSHA256SUM = "6f477ab54c4fd646ab9f65baed0157dca7ca29de6bc7f992f5285d8baa30b5eb"
 PLUGINSHA256SUM = "71435b08b97346e2b0f568332c3440b8f6c00b5198f83ab5935f161aae39f8d8"
 PLUGINDEVSHA256SUM = "4dabae4f5ea8f3eb54dbd36cf3dde3d038fae2a857529b869844b05cec77092a"
 BINSHA256SUM = "f4a98ac9086b4a195bcab26aca176a9db6b5a196ff42d3dfdb28a16d30e8a312"
 
-SRC_URI[lib.sha256sum] = "${LIBSHA256SUM}"
-SRC_URI[dev.sha256sum] = "${DEVSHA256SUM}"
-SRC_URI[samples.sha256sum] = "${SAMPSHA256SUM}"
-SRC_URI[nvp.sha256sum] = "${NVPSHA256SUM}"
-SRC_URI[nvpdev.sha256sum] = "${NVPDEVSHA256SUM}"
 SRC_URI[onnx.sha256sum] = "${ONNXSHA256SUM}"
 SRC_URI[onnxdev.sha256sum] = "${ONNXDEVSHA256SUM}"
 SRC_URI[plugin.sha256sum] = "${PLUGINSHA256SUM}"
@@ -44,11 +29,11 @@ SRC_URI[bin.sha256sum] = "${BINSHA256SUM}"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=48;md5=3d6981c1227c404d42d710f96a875a1b"
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInferPlugin.h;endline=48;md5=3d6981c1227c404d42d710f96a875a1b"
 
 S = "${WORKDIR}/tensorrt"
 
-DEPENDS = "libcublas cudnn cuda-cudart cuda-nvrtc libglvnd tegra-libraries"
+DEPENDS = "cuda-cudart cudnn tegra-libraries tensorrt-core"
 
 CONTAINER_CSV_FILES = "${libdir}/*.so* /usr/src/*"
 
@@ -57,28 +42,27 @@ do_configure() {
 }
 
 do_compile() {
-    find ${S}/usr/src/tensorrt -name '*.py' | xargs sed -i -r -e 's,^(\s*)print "(.*)$,\1print("\2),'
+    :
 }
 
 do_install() {
     install -d ${D}${includedir}
     install -m 0644 ${S}/usr/include/aarch64-linux-gnu/*.h ${D}${includedir}
     install -d ${D}${libdir}
-    tar -C ${S}/usr/lib/aarch64-linux-gnu -cf- . | tar -C ${D}${libdir}/ --no-same-owner -xf-
+    cp --preserve=mode,timestamps,links --no-dereference ${S}/usr/lib/aarch64-linux-gnu/*.so* ${D}${libdir}
     install -d ${D}${prefix}/src
     cp --preserve=mode,timestamps --recursive ${S}/usr/src/tensorrt ${D}${prefix}/src/
 }
-PACKAGES += "${PN}-samples"
-FILES:${PN} += "${prefix}/src/tensorrt/bin"
-FILES:${PN}-samples = "${prefix}/src"
 
-RDEPENDS:${PN} += "libstdc++ cudnn libcublas cuda-cudart cuda-nvrtc cuda-nvtx tegra-libraries libglvnd"
-RDEPENDS:${PN}-samples += "tegra-libraries bash python3 libglvnd cudnn cuda-cudart libcublas"
-RPROVIDES:${PN}-samples = "${PN}-examples"
+FILES:${PN} += "${prefix}/src/tensorrt/bin"
+
+RDEPENDS:${PN} += "tegra-libraries"
+PROVIDES = "tensorrt-plugins"
+RPROVIDES:${PN} = "tensorrt-plugins"
+RCONFLICTS:${PN} = "tensorrt-plugins"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
-INSANE_SKIP:${PN} = "textrel ldflags"
-INSANE_SKIP:${PN}-samples = "ldflags"
+
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-devtools/gie/tensorrt-samples/0001-Makefile-fix-cross-compilation-issues.patch
+++ b/recipes-devtools/gie/tensorrt-samples/0001-Makefile-fix-cross-compilation-issues.patch
@@ -1,0 +1,105 @@
+From f196aef19ab533c5aae1195698c1d27c3ffc43bc Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Tue, 21 Sep 2021 23:12:52 +0100
+Subject: [PATCH] Makefile: fix cross compilation issues
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+ Makefile.config | 29 +++++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/Makefile.config b/Makefile.config
+index 48c1a8d..70db6aa 100644
+--- a/Makefile.config
++++ b/Makefile.config
+@@ -5,6 +5,7 @@ DLSW_TRIPLE ?= x86_64-linux-gnu
+ SAFE_PDK ?= 0
+ CPP_STANDARD?=14
+ TARGET ?= $(shell uname -m)
++BUILD_TYPE ?= release
+ 
+ ifeq ($(CUDA_INSTALL_DIR),)
+   CUDA_INSTALL_DIR ?= /usr/local/cuda
+@@ -34,11 +35,11 @@ CUDNN_LIBDIR = lib64
+ ifeq ($(TARGET), aarch64)
+   ifeq ($(shell uname -m), aarch64)
+     CUDA_LIBDIR = lib64
+-    CC = g++
++    CXX ?= g++
+   else
+-    CC = aarch64-linux-gnu-g++
++    CXX ?= aarch64-linux-gnu-g++
+   endif
+-  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64 -ccbin $(CC)
++  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64 -ccbin $(CXX)
+ else ifeq ($(TARGET), x86_64)
+   CUDA_LIBDIR = lib64
+   CC = g++
+@@ -54,7 +55,7 @@ else ########
+   $(error Auto-detection of platform failed. Please specify one of the following arguments to make: TARGET=[aarch64|x86_64|qnx])
+ endif
+ 
+-CC_MAJOR_VER = $(shell $(CC) -dumpversion | sed -e "s/\..*//")
++CC_MAJOR_VER = $(shell $(CXX) -dumpversion | sed -e "s/\..*//")
+ ifeq (${CC_MAJOR_VER}, 4)
+     CPP_STANDARD := 11
+ endif
+@@ -111,7 +112,7 @@ endef
+ ifneq ($(USE_QCC),1)
+ # Usage: $(call make-depend,source-file,object-file,depend-file)
+ define make-depend
+-  $(AT)$(CC) -MM -MF $3 -MP -MT $2 $(COMMON_FLAGS) $1
++  $(AT)$(CXX) -MM -MF $3 -MP -MT $2 $(COMMON_FLAGS) $1
+ endef
+ # Usage: $(call make-cuda-depend,source-file,object-file,depend-file,flags)
+ define make-cuda-depend
+@@ -305,7 +306,15 @@ CFLAGSD = $(COMMON_FLAGS) -g
+ LFLAGS = $(COMMON_LD_FLAGS)
+ LFLAGSD = $(COMMON_LD_FLAGS)
+ 
+-all: debug release
++ifeq ($(BUILD_TYPE), release)
++  all: release
++else
++ifeq ($(BUILD_TYPE), debug)
++  all: debug
++else
++  all: debug release
++endif
++endif
+ 
+ release : $(OUTDIR)/$(OUTNAME_RELEASE)
+ 
+@@ -321,25 +330,25 @@ test_release:
+ 
+ $(OUTDIR)/$(OUTNAME_RELEASE) : $(OBJS) $(CUOBJS)
+ 	$(ECHO) Linking: $@
+-	$(AT)$(CC) -o $@ $(LFLAGS) -Wl,--start-group $(LIBS) $^ -Wl,--end-group
++	$(AT)$(CXX) -o $@ $(LFLAGS) -Wl,--start-group $(LIBS) $^ -Wl,--end-group
+ 
+ $(OUTDIR)/$(OUTNAME_DEBUG) : $(DOBJS) $(CUDOBJS)
+ 	$(ECHO) Linking: $@
+-	$(AT)$(CC) -o $@ $(LFLAGSD) -Wl,--start-group $(DLIBS) $^ -Wl,--end-group
++	$(AT)$(CXX) -o $@ $(LFLAGSD) -Wl,--start-group $(DLIBS) $^ -Wl,--end-group
+ 
+ $(OBJDIR)/%.o: %.cpp
+ 	$(AT)if [ ! -d $(OBJDIR) ]; then mkdir -p $(OBJDIR); fi
+ 	$(foreach XDIR,$(EXTRA_DIRECTORIES), if [ ! -d $(OBJDIR)/$(XDIR) ]; then mkdir -p $(OBJDIR)/$(XDIR); fi;) :
+ 	$(call make-depend,$<,$@,$(subst .o,.d,$@))
+ 	$(ECHO) Compiling: $<
+-	$(AT)$(CC) $(CFLAGS) -c -o $@ $<
++	$(AT)$(CXX) $(CFLAGS) -c -o $@ $<
+ 
+ $(DOBJDIR)/%.o: %.cpp
+ 	$(AT)if [ ! -d $(DOBJDIR) ]; then mkdir -p $(DOBJDIR); fi
+ 	$(foreach XDIR,$(EXTRA_DIRECTORIES), if [ ! -d $(OBJDIR)/$(XDIR) ]; then mkdir -p $(DOBJDIR)/$(XDIR); fi;) :
+ 	$(call make-depend,$<,$@,$(subst .o,.d,$@))
+ 	$(ECHO) Compiling: $<
+-	$(AT)$(CC) $(CFLAGSD) -c -o $@ $<
++	$(AT)$(CXX) $(CFLAGSD) -c -o $@ $<
+ 
+ ######################################################################### CU
+ $(OBJDIR)/%.o: %.cu
+-- 
+2.17.1
+

--- a/recipes-devtools/gie/tensorrt-samples_8.0.1-1.bb
+++ b/recipes-devtools/gie/tensorrt-samples_8.0.1-1.bb
@@ -1,0 +1,69 @@
+DESCRIPTION = "NVIDIA TensorRT Samples for deep learning"
+LICENSE = "Proprietary"
+
+inherit l4t_deb_pkgfeed cuda
+
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+
+L4T_DEB_GROUP = "tensorrt"
+
+SRC_COMMON_DEBS = "\
+    libnvinfer-samples_${PV}+cuda10.2_all.deb;downloadfilename=libnvinfer-samples_${PV}+cuda10.2_all.deb;name=samples;subdir=tensorrt \
+"
+
+SRC_URI:append = " file://0001-Makefile-fix-cross-compilation-issues.patch"
+
+SRC_URI[samples.sha256sum] = "6eadd053f8e840f17ee8ea5cde98b2b170b91a763cc5cf0bda5a8c59a4d5390d"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+LIC_FILES_CHKSUM = "file://../../../share/doc/libnvinfer-samples/copyright;md5=713c2de2adb0f371a903b9fe20431bab"
+
+S = "${WORKDIR}/tensorrt/usr/src/tensorrt/samples"
+
+DEPENDS = "cuda-cudart cudnn tegra-libraries tensorrt-core tensorrt-plugins libglvnd"
+
+EXTRA_OEMAKE = ' \
+    CUDA_INSTALL_DIR="${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}" \
+    CUDNN_INSTALL_DIR="${STAGING_DIR_HOST}/usr/lib" \ 
+    TRT_LIB_DIR="${STAGING_DIR_HOST}/usr/lib" \
+    TARGET="${TARGET_ARCH}" BUILD_TYPE="release" \
+'
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_configure() {
+    :
+}
+
+do_install() {
+    install -d ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_algorithm_selector ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_char_rnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_dynamic_reshape ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_fasterRCNN ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_googlenet ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_int8 ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_int8_api ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mlp ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mnist_api ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_nmt ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_onnx_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_reformat_free_io ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_ssd ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_faster_rcnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_mask_rcnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_plugin_v2_ext ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_ssd ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/trtexec ${D}${prefix}/src/tensorrt/bin
+
+    install -d ${D}${prefix}/src/tensorrt/data
+    cp -R --preserve=mode,timestamps ${S}/../data/* ${D}${prefix}/src/tensorrt/data
+}
+
+PACKAGES =+ "${PN}-trtexec"
+
+FILES:${PN} += "${prefix}/src/tensorrt/bin ${prefix}/src/tensorrt/data"
+FILES:${PN}-trtexec += "${prefix}/src/tensorrt/bin/trtexec"

--- a/recipes-multimedia/argus/tegra-mmapi-samples_32.6.1.bb
+++ b/recipes-multimedia/argus/tegra-mmapi-samples_32.6.1.bb
@@ -22,7 +22,7 @@ DEPENDS = "libdrm tegra-mmapi tegra-libraries virtual/egl virtual/libgles1 virtu
 inherit pkgconfig cuda python3native features_check
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[objdetect] = "HAVE_OPENCV=1 HAVE_TENSORRT=1,,tensorrt opencv"
+PACKAGECONFIG[objdetect] = "HAVE_OPENCV=1 HAVE_TENSORRT=1,,tensorrt-core tensorrt-plugins opencv"
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
In this PR: 

* Split tensorrt recipe to `tensorrt-core`, `tensorrt-plugins-prebuilt` and `tensorrt-samples` recipes.
* Add new recipe to build `tensorrt-plugins` from source.
* Update dependency list in recipes which depends on `tensorrt-core` and `tensorrt-plugins`.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>