### PR TITLE
dunfell-l4t-r32.4.3 - Build Tensorrt Plugins from source

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -28,6 +28,7 @@ PREFERRED_PROVIDER_virtual/libgles2 = "libglvnd"
 PREFERRED_PROVIDER_virtual/libgl = "libglvnd"
 PREFERRED_PROVIDER_libv4l = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
 PREFERRED_PROVIDER_v4l-utils = "${@'v4l-utils' if 'openembedded-layer' in d.getVar('BBFILE_COLLECTIONS').split() else 'libv4l2-minimal'}"
+PREFERRED_PROVIDER_tensorrt-plugins ?= "tensorrt-plugins-prebuilt"
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 TEGRA_BLBLOCKSIZE ?= "${@int(d.getVar('IMAGE_ROOTFS_ALIGNMENT')) * 1024}"

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
@@ -1,0 +1,214 @@
+From 856bfb6202058c406f6cfb47b4a2b89826a5e8c4 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Thu, 16 Sep 2021 22:44:16 +0100
+Subject: [PATCH] CMakeLists.txt: fix cross compilation issues.
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ CMakeLists.txt | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+Index: git/CMakeLists.txt
+===================================================================
+--- git.orig/CMakeLists.txt
++++ git/CMakeLists.txt
+@@ -56,12 +56,16 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_T
+ option(BUILD_PLUGINS "Build TensorRT plugin" ON)
+ option(BUILD_PARSERS "Build TensorRT parsers" ON)
+ option(BUILD_SAMPLES "Build TensorRT samples" ON)
++option(BUILD_PROTOBUF "Build internal copy of protobuf" OFF)
+
+ set(CMAKE_CXX_STANDARD 11)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+ set(CMAKE_CXX_EXTENSIONS OFF)
+ set(CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss")
+
++# otherwise the installation directories are empty by default
++include(GNUInstallDirs)
++
+ ############################################################################################
+ # Cross-compilation settings
+
+@@ -96,7 +100,11 @@ message(STATUS "Protobuf version set to
+ find_package(Threads REQUIRED)
+ if (BUILD_PLUGINS OR BUILD_PARSERS)
+     include(third_party/zlib.cmake)
+-    include(third_party/protobuf.cmake)
++    if (BUILD_PROTOBUF)
++        include(third_party/protobuf.cmake)
++    else()
++        find_package(Protobuf REQUIRED)
++    endif()
+ endif()
+ if(NOT CUB_ROOT_DIR)
+     set(CUB_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/cub CACHE STRING "directory of CUB installation")
+@@ -111,27 +119,30 @@ include_directories(
+     ${CUDA_INCLUDE_DIRS}
+     ${CUDNN_ROOT_DIR}/include
+ )
++
+ find_library(CUDNN_LIB cudnn HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} ${CUDNN_ROOT_DIR} PATH_SUFFIXES lib64 lib)
++    ${CUDA_TOOLKIT_TARGET_DIR} ${CUDNN_ROOT_DIR} PATH_SUFFIXES lib64 lib)
+ find_library(CUBLAS_LIB cublas HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
++    ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+ find_library(CUBLASLT_LIB cublasLt HINTS
+-    ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
+-if(BUILD_PARSERS)
++    ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib64 lib lib/stubs)
++if(BUILD_PROTOBUF)
+     configure_protobuf(${PROTOBUF_VERSION})
+ endif()
+-
+ find_library_create_target(nvinfer nvinfer SHARED ${TRT_LIB_DIR})
+ find_library_create_target(nvuffparser nvparsers SHARED ${TRT_LIB_DIR})
+
+-find_library(CUDART_LIB cudart HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib64)
++find_library(CUDART_LIB cudart HINTS ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib lib64)
+ find_library(RT_LIB rt)
+
+ set(CUDA_LIBRARIES ${CUDART_LIB})
+
+ ############################################################################################
+ # CUDA targets
+-
++if (SKIP_GPU_ARCHS)
++    set(GENCODES "")
++    set(BERT_GENCODES "")
++else()
+ if (DEFINED GPU_ARCHS)
+   message(STATUS "GPU_ARCHS defined as ${GPU_ARCHS}. Generating CUDA code for SM ${GPU_ARCHS}")
+   separate_arguments(GPU_ARCHS)
+@@ -165,6 +176,7 @@ set(GENCODES "${GENCODES} -gencode arch=
+ if (${LATEST_SM} GREATER_EQUAL 70)
+     set(BERT_GENCODES "${BERT_GENCODES} -gencode arch=compute_${LATEST_SM},code=compute_${LATEST_SM}")
+ endif()
++endif()
+ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wno-deprecated-declarations")
+
+ ############################################################################################
+@@ -177,6 +189,8 @@ else()
+ endif()
+
+ if(BUILD_PARSERS)
++    set(BUILD_LIBRARY_ONLY 1)
++    set(TENSORRT_LIBRARY_INFER_PLUGIN "nvinfer_plugin")
+     add_subdirectory(parsers)
+ else()
+     find_library_create_target(nvcaffeparser nvparsers SHARED ${TRT_OUT_DIR} ${TRT_LIB_DIR})
+Index: git/parsers/caffe/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/caffe/CMakeLists.txt
++++ git/parsers/caffe/CMakeLists.txt
+@@ -47,7 +47,7 @@ target_include_directories(${SHARED_TARG
+     PRIVATE caffeWeightFactory
+     PRIVATE ../common
+     PRIVATE ${Protobuf_INCLUDE_DIR}
+-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/proto
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+ )
+
+ set_target_properties(${SHARED_TARGET} 
+@@ -65,6 +65,7 @@ target_link_libraries(${SHARED_TARGET}
+     nvinfer
+ )
+
++if(BUILD_PROTOBUF)
+ # modify google namespace to avoid namespace collision.
+ set(GOOGLE google_private)
+ target_compile_definitions(${SHARED_TARGET}
+@@ -72,6 +73,7 @@ target_compile_definitions(${SHARED_TARG
+     "-Dgoogle=${GOOGLE}"
+     "-DGOOGLE_PROTOBUF_ARCH_64_BIT"
+ )
++endif()
+
+ set_target_properties(${SHARED_TARGET} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
+
+@@ -97,7 +99,7 @@ target_include_directories(${STATIC_TARG
+     PRIVATE caffeWeightFactory
+     PRIVATE ../common
+     PRIVATE ${Protobuf_INCLUDE_DIR}
+-    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/proto
++    PRIVATE ${CMAKE_CURRENT_BINARY_DIR}
+ )
+
+ set_target_properties(${STATIC_TARGET} 
+@@ -114,6 +116,7 @@ target_link_libraries(${STATIC_TARGET}
+     ${Protobuf_LIBRARY}
+ )
+
++if(BUILD_PROTOBUF)
+ # modify google namespace to avoid namespace collision.
+ set(GOOGLE google_private)
+ target_compile_definitions(${STATIC_TARGET}
+@@ -121,6 +124,7 @@ target_compile_definitions(${STATIC_TARG
+     "-Dgoogle=${GOOGLE}"
+     "-DGOOGLE_PROTOBUF_ARCH_64_BIT"
+ )
++endif()
+
+ set_target_properties(${STATIC_TARGET} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
+
+Index: git/parsers/onnx/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/onnx/CMakeLists.txt
++++ git/parsers/onnx/CMakeLists.txt
+@@ -88,7 +88,7 @@ endif()
+ if (NOT TARGET protobuf::libprotobuf)
+   FIND_PACKAGE(Protobuf REQUIRED)
+ else()
+-  set(PROTOBUF_LIB "protobuf::libprotobuf")
++  set(PROTOBUF_LIBRARY "protobuf::libprotobuf")
+ endif()
+
+ if(NOT TARGET onnx_proto)
+Index: git/parsers/CMakeLists.txt
+===================================================================
+--- git.orig/parsers/CMakeLists.txt
++++ git/parsers/CMakeLists.txt
+@@ -21,8 +21,10 @@ add_custom_target(parsers DEPENDS
+
+ add_subdirectory(caffe)
+
+-add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
+-add_compile_options("-Dgoogle=google_private")
++if(BUILD_PROTOBUF)
++    add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
++    add_compile_options("-Dgoogle=google_private")
++endif()
+ set(TENSORRT_ROOT ${PROJECT_SOURCE_DIR})
+ set(TENSORRT_BUILD ${TRT_OUT_DIR} ${TRT_LIB_DIR})
+ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TRT_OUT_DIR})
+Index: git/plugin/CMakeLists.txt
+===================================================================
+--- git.orig/plugin/CMakeLists.txt
++++ git/plugin/CMakeLists.txt
+@@ -56,7 +56,7 @@ set(PLUGIN_LISTS
+     )
+
+ # Add BERT sources if ${BERT_GENCODES} was populated
+-if(BERT_GENCODES)
++if(DEFINED BERT_GENCODES)
+     set(BERT_CU_SOURCES)
+     set(PLUGIN_LISTS
+         ${PLUGIN_LISTS}
+@@ -79,10 +79,14 @@ endforeach(PLUGIN_ITER)
+ add_subdirectory(common)
+
+ # Set gencodes
+-set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${GENCODES})
++if(GENCODES)
++    set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${GENCODES})
++endif()
+ list(APPEND PLUGIN_SOURCES "${PLUGIN_CU_SOURCES}")
+ if (BERT_CU_SOURCES)
+-    set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${BERT_GENCODES})
++    if(BERT_GENCODES)
++        set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS ${BERT_GENCODES})
++    endif()
+     list(APPEND PLUGIN_SOURCES "${BERT_CU_SOURCES}")
+ endif()
+

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-Remove-constexpr.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-Remove-constexpr.patch
@@ -1,0 +1,33 @@
+From 68d377d985c0d39773146e1c0cbb7f697ce0514d Mon Sep 17 00:00:00 2001
+From: Bryan Cisneros <bcisneros@sighthound.com>
+Date: Tue, 21 Sep 2021 17:04:15 -0600
+Subject: [PATCH] Remove constexpr
+
+---
+ parsers/onnx/builtin_op_importers.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+Index: git/parsers/onnx/builtin_op_importers.cpp
+===================================================================
+--- git.orig/parsers/onnx/builtin_op_importers.cpp
++++ git/parsers/onnx/builtin_op_importers.cpp
+@@ -1008,7 +1008,7 @@ DEFINE_BUILTIN_OP_IMPORTER(Gemm)
+         inputASqueezed = squeeze->getOutput(0);
+     }
+
+-    constexpr auto getMatrixOp = [](const nvinfer1::ITensor& input, bool transpose) {
++    const auto getMatrixOp = [](const nvinfer1::ITensor& input, bool transpose) {
+         if (input.getDimensions().nbDims == 1)
+         {
+             return nvinfer1::MatrixOperation::kVECTOR;
+@@ -1998,7 +1998,7 @@ DEFINE_BUILTIN_OP_IMPORTER(MatMul)
+
+     broadcastTensors(ctx, inputA, inputB);
+
+-    constexpr auto getMatrixOp = [](const nvinfer1::ITensor& input) {
++    const auto getMatrixOp = [](const nvinfer1::ITensor& input) {
+         return (input.getDimensions().nbDims == 1) ? nvinfer1::MatrixOperation::kVECTOR
+                                                    : nvinfer1::MatrixOperation::kNONE;
+     };
+--
+2.33.0

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_7.1.3-1.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_7.1.3-1.bb
@@ -1,0 +1,51 @@
+DESCRIPTION = "NVIDIA TensorRT Plugins for deep learning"
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+LICENSE = "Apache-2.0 & BSD-3-Clause & MIT"
+LIC_FILES_CHKSUM = " \
+  file://LICENSE;md5=b43e4a60a0643023327e7caf2dbf8663 \
+  file://third_party/cub/LICENSE.TXT;md5=20d1414b801e2a130d7d546685105508 \
+  file://parsers/onnx/third_party/onnx/LICENSE;md5=efff5c5110f124a1e2163814067b16e7 \
+  file://parsers/onnx/LICENSE;md5=73b35773827cb985bfc6c085ed8d2394 \
+"
+
+inherit cuda cmake container-runtime-csv
+
+SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
+SRCBRANCH = "master"
+SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
+    file://0001-CMakeLists.txt-fix-cross-compilation-issues.patch \
+    file://0002-Remove-constexpr.patch \
+"
+SRCREV = "9a9cae75e7155b2114454f37ccc49eca9d3352dc"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += "zlib libcublas cudnn cuda-cudart cuda-nvrtc protobuf protobuf-native tensorrt-core"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+CONTAINER_CSV_FILES = "${libdir}/*.so*"
+
+PACKAGECONFIG ??= " \
+    plugin \
+    parsers \
+"
+PACKAGECONFIG[plugin] = "-DBUILD_PLUGINS=ON,-DBUILD_PLUGINS=OFF,"
+PACKAGECONFIG[parsers] = "-DBUILD_PARSERS=ON,-DBUILD_PARSERS=OFF,"
+
+EXTRA_OECMAKE = "-DBUILD_SAMPLES=OFF -DSKIP_GPU_ARCHS=ON -DTRT_PLATFORM_ID="${TARGET_ARCH}" \
+  -DCUDA_VERSION="${CUDA_VERSION}" -DCUDA_NVCC_FLAGS="${CUDA_NVCC_FLAGS}" \
+  -DCUDA_INCLUDE_DIRS="${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}/include" \
+"
+
+LDFLAGS += "-Wl,--no-undefined"
+
+do_install_append() {
+    install -d ${D}${includedir}
+    install -m 0644 ${S}/include/NvInferPlugin.h ${D}${includedir}
+    install -m 0644 ${S}/include/NvInferPluginUtils.h ${D}${includedir}
+    install -m 0644 ${S}/include/NvOnnxConfig.h ${D}${includedir}  
+    install -m 0644 ${S}/parsers/onnx/NvOnnxParser.h ${D}${includedir}
+}
+
+RDEPENDS_${PN} += "tegra-libraries"

--- a/recipes-devtools/deepstream/deepstream-5.0_5.0.0-1.bb
+++ b/recipes-devtools/deepstream/deepstream-5.0_5.0.0-1.bb
@@ -15,7 +15,7 @@ SRC_URI[sha256sum] = "a7a7015515883ac88c7587c7a2acfcf78510e539b84b702afd05f4f330
 COMPATIBLE_MACHINE = "(tegra)"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-rtsp-server tensorrt cudnn libcublas cuda-cudart tegra-libraries"
+DEPENDS = "gstreamer1.0 gstreamer1.0-rtsp-server tensorrt-core tensorrt-plugins cudnn libcublas cuda-cudart tegra-libraries"
 
 S = "${WORKDIR}/${BPN}"
 B = "${WORKDIR}/build"

--- a/recipes-devtools/gie/tensorrt-core_7.1.3-1.bb
+++ b/recipes-devtools/gie/tensorrt-core_7.1.3-1.bb
@@ -1,0 +1,62 @@
+DESCRIPTION = "NVIDIA TensorRT Core (GPU Inference Engine) for deep learning"
+LICENSE = "Proprietary"
+
+inherit l4t_deb_pkgfeed container-runtime-csv
+
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+
+PREFIX = "NoDLA-"
+PREFIX_tegra194 = "DLA-"
+
+L4T_DEB_GROUP = "tensorrt"
+
+SRC_SOC_DEBS = "\
+    libnvinfer7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer7_${PV}+cuda10.2_arm64.deb;name=lib;subdir=tensorrt \
+    libnvinfer-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=tensorrt \
+    libnvparsers7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvparsers7_${PV}+cuda10.2_arm64.deb;name=nvp;subdir=tensorrt \
+    libnvparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvparsers-dev_${PV}+cuda10.2_arm64.deb;name=nvpdev;subdir=tensorrt \
+"
+
+LIBSHA256SUM = "88636112a84fde159cce5b6eed11907bc98ddef02e88310c788a5462b88293be"
+DEVSHA256SUM = "436e0832560e1c5b2a5377c1f9679ae1bf60649e5c0537a81c77baed53066633"
+NVPSHA256SUM = "5477aeb1898d55182de02c3861f3576338ab01f2b71c776cb3fff5707e8e7758"
+NVPDEVSHA256SUM = "0554c20ce85cfa0675f77df2539c34cecdeed9cf0402989c3404ab6e158f39aa"
+
+LIBSHA256SUM_tegra194 = "6f6b0e27339ff352f975c65842f4b315db8b341ae5c7d92545c2fe8b3a727ce3"
+DEVSHA256SUM_tegra194 = "b494da5c43360bd20b832854c766b4d4e3cfecdfbd73bef8d96c4ce9ae7f022c"
+NVPSHA256SUM_tegra194 = "65db2ae0f5d7dbb452306823ac4b6ea27386a5650db337c7fa50969f3d9d3cea"
+NVPDEVSHA256SUM_tegra194 = "dc48c0dc44ff69246f3062a480e9d5ac8f72f5bc798bdfad401ebbcb9912e475"
+
+SRC_URI[lib.sha256sum] = "${LIBSHA256SUM}"
+SRC_URI[dev.sha256sum] = "${DEVSHA256SUM}"
+SRC_URI[nvp.sha256sum] = "${NVPSHA256SUM}"
+SRC_URI[nvpdev.sha256sum] = "${NVPDEVSHA256SUM}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=48;md5=59218f2f10ab9e4132dda76c59e80fa1"
+
+S = "${WORKDIR}/tensorrt"
+
+CONTAINER_CSV_FILES = "${libdir}/*.so*"
+
+DEPENDS = "cudnn libcublas cuda-nvrtc tegra-libraries virtual/egl"
+
+do_configure() {
+    :
+}
+
+do_compile() {
+    :
+}
+
+do_install() {
+    install -d ${D}${includedir}
+    install -m 0644 ${S}/usr/include/aarch64-linux-gnu/*.h ${D}${includedir}
+    install -d ${D}${libdir}
+    cp --preserve=mode,timestamps,links --no-dereference ${S}/usr/lib/aarch64-linux-gnu/*.so* ${D}${libdir}
+}
+
+INSANE_SKIP_${PN} = "already-stripped ldflags"
+PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+PACKAGE_ARCH_tegra194 = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-devtools/gie/tensorrt-plugins-prebuilt_7.1.3-1.bb
+++ b/recipes-devtools/gie/tensorrt-plugins-prebuilt_7.1.3-1.bb
@@ -1,4 +1,4 @@
-DESCRIPTION = "NVIDIA TensorRT (GPU Inference Engine) for deep learning"
+DESCRIPTION = "NVIDIA TensorRT Prebuilt Plugins for deep learning"
 LICENSE = "Proprietary"
 
 inherit l4t_deb_pkgfeed container-runtime-csv
@@ -11,11 +11,6 @@ PREFIX_tegra194 = "DLA-"
 L4T_DEB_GROUP = "tensorrt"
 
 SRC_SOC_DEBS = "\
-    libnvinfer7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer7_${PV}+cuda10.2_arm64.deb;name=lib;subdir=tensorrt \
-    libnvinfer-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer-dev_${PV}+cuda10.2_arm64.deb;name=dev;subdir=tensorrt \
-    libnvinfer-samples_${PV}+cuda10.2_all.deb;downloadfilename=${PREFIX}libnvinfer-samples_${PV}+cuda10.2_all.deb;name=samples;subdir=tensorrt \
-    libnvparsers7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvparsers7_${PV}+cuda10.2_arm64.deb;name=nvp;subdir=tensorrt \
-    libnvparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvparsers-dev_${PV}+cuda10.2_arm64.deb;name=nvpdev;subdir=tensorrt \
     libnvonnxparsers7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvonnxparsers7_${PV}+cuda10.2_arm64.deb;name=onnx;subdir=tensorrt \
     libnvonnxparsers-dev_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvonnxparsers-dev_${PV}+cuda10.2_arm64.deb;name=onnxdev;subdir=tensorrt \
     libnvinfer-plugin7_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer-plugin7_${PV}+cuda10.2_arm64.deb;name=plugin;subdir=tensorrt \
@@ -23,33 +18,18 @@ SRC_SOC_DEBS = "\
     libnvinfer-bin_${PV}+cuda10.2_arm64.deb;downloadfilename=${PREFIX}libnvinfer-bin_${PV}+cuda10.2_arm64.deb;name=bin;subdir=tensorrt \
 "
 
-LIBSHA256SUM = "88636112a84fde159cce5b6eed11907bc98ddef02e88310c788a5462b88293be"
-DEVSHA256SUM = "436e0832560e1c5b2a5377c1f9679ae1bf60649e5c0537a81c77baed53066633"
-SAMPSHA256SUM = "3a5162474cce7e191d78703b196bc8bdd5a6908d7537200194f1e80d72cf45a0"
-NVPSHA256SUM = "5477aeb1898d55182de02c3861f3576338ab01f2b71c776cb3fff5707e8e7758"
-NVPDEVSHA256SUM = "0554c20ce85cfa0675f77df2539c34cecdeed9cf0402989c3404ab6e158f39aa"
 ONNXSHA256SUM = "e00ed2bff48de16ca275ce322fbc881b5bbd4a1521fd7f685d56cfb30136039a"
 ONNXDEVSHA256SUM = "8c18ffac6b9118491248e14000cb72638268ce4f3698522a478cac6dd4631c34"
 PLUGINSHA256SUM = "a57ea8b4757fa4592c6ba1555bc07045909b553a493c0bde8c8b23c74cf082b4"
 PLUGINDEVSHA256SUM = "94820301980118e34cc1ab99570d3a7a13b96f4811828908b63bf638b4252edd"
 BINSHA256SUM = "94927076974c59ae45b0c56300387816b8fa03d397d1503d8633e7989b4a20f6"
 
-LIBSHA256SUM_tegra194 = "6f6b0e27339ff352f975c65842f4b315db8b341ae5c7d92545c2fe8b3a727ce3"
-DEVSHA256SUM_tegra194 = "b494da5c43360bd20b832854c766b4d4e3cfecdfbd73bef8d96c4ce9ae7f022c"
-SAMPSHA256SUM_tegra194 = "87d32bb231c19717c4690e05c770eb51d3d5ad4bea8fbd0ee46ba4d1a386ad9f"
-NVPSHA256SUM_tegra194 = "65db2ae0f5d7dbb452306823ac4b6ea27386a5650db337c7fa50969f3d9d3cea"
-NVPDEVSHA256SUM_tegra194 = "dc48c0dc44ff69246f3062a480e9d5ac8f72f5bc798bdfad401ebbcb9912e475"
 ONNXSHA256SUM_tegra194 = "26109c58e8eab9dc746fb3fc39cc39bf5a8bf2d61a27b5d9e7aa035fc0b97b4c"
 ONNXDEVSHA256SUM_tegra194 = "52783ca7245171eb83c623a08851c0cfdc659696272b2edf6dfe3503ae9bc49b"
 PLUGINSHA256SUM_tegra194 = "680c7849542dca1cac68fc94f7474f31446cf093b6e6df1d7bab8c24a6122aa3"
 PLUGINDEVSHA256SUM_tegra194 = "bac84671b2990b8110d4f2ac69b4a29cf230346db37a902d1f47cf7a9be4601e"
 BINSHA256SUM_tegra194 = "56275d8cba17be877af063db49ecb7b6e02bed5f8d387b1182a6a7ec2cabee2a"
 
-SRC_URI[lib.sha256sum] = "${LIBSHA256SUM}"
-SRC_URI[dev.sha256sum] = "${DEVSHA256SUM}"
-SRC_URI[samples.sha256sum] = "${SAMPSHA256SUM}"
-SRC_URI[nvp.sha256sum] = "${NVPSHA256SUM}"
-SRC_URI[nvpdev.sha256sum] = "${NVPDEVSHA256SUM}"
 SRC_URI[onnx.sha256sum] = "${ONNXSHA256SUM}"
 SRC_URI[onnxdev.sha256sum] = "${ONNXDEVSHA256SUM}"
 SRC_URI[plugin.sha256sum] = "${PLUGINSHA256SUM}"
@@ -58,12 +38,11 @@ SRC_URI[bin.sha256sum] = "${BINSHA256SUM}"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=48;md5=59218f2f10ab9e4132dda76c59e80fa1"
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInferPlugin.h;endline=48;md5=59218f2f10ab9e4132dda76c59e80fa1"
 
 S = "${WORKDIR}/tensorrt"
 
-DEPENDS = "libcublas cudnn cuda-cudart cuda-nvrtc libglvnd"
-DEPENDS_append_tegra194 = " tegra-libraries"
+DEPENDS = "cuda-cudart cudnn tegra-libraries tensorrt-core"
 
 CONTAINER_CSV_FILES = "${libdir}/*.so* /usr/src/*"
 
@@ -72,29 +51,28 @@ do_configure() {
 }
 
 do_compile() {
-    find ${S}/usr/src/tensorrt -name '*.py' | xargs sed -i -r -e 's,^(\s*)print "(.*)$,\1print("\2),'
+    :
 }
 
 do_install() {
     install -d ${D}${includedir}
     install -m 0644 ${S}/usr/include/aarch64-linux-gnu/*.h ${D}${includedir}
     install -d ${D}${libdir}
-    tar -C ${S}/usr/lib/aarch64-linux-gnu -cf- . | tar -C ${D}${libdir}/ --no-same-owner -xf-
+    cp --preserve=mode,timestamps,links --no-dereference ${S}/usr/lib/aarch64-linux-gnu/*.so* ${D}${libdir}
     install -d ${D}${prefix}/src
     cp --preserve=mode,timestamps --recursive ${S}/usr/src/tensorrt ${D}${prefix}/src/
 }
-PACKAGES += "${PN}-samples"
-FILES_${PN} += "${prefix}/src/tensorrt/bin"
-FILES_${PN}-samples = "${prefix}/src"
 
-RDEPENDS_${PN} += "libstdc++ cudnn libcublas cuda-cudart cuda-nvrtc cuda-nvtx tegra-libraries libglvnd"
-RDEPENDS_${PN}-samples += "tegra-libraries bash python3 libglvnd cudnn cuda-cudart libcublas"
-RPROVIDES_${PN}-samples = "${PN}-examples"
+FILES_${PN} += "${prefix}/src/tensorrt/bin"
+
+RDEPENDS_${PN} += "tegra-libraries libcublas cuda-nvrtc"
+PROVIDES = "tensorrt-plugins"
+RPROVIDES_${PN} = "tensorrt-plugins"
+RCONFLICTS_${PN} = "tensorrt-plugins"
 
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
-INSANE_SKIP_${PN} = "textrel ldflags"
-INSANE_SKIP_${PN}-samples = "ldflags"
+
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"
 PACKAGE_ARCH_tegra194 = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-devtools/gie/tensorrt-samples/0001-Makefile-fix-cross-compilation-issues.patch
+++ b/recipes-devtools/gie/tensorrt-samples/0001-Makefile-fix-cross-compilation-issues.patch
@@ -1,0 +1,100 @@
+From 2fb0ba399055414cf23c32e5e38abaf064dbdc19 Mon Sep 17 00:00:00 2001
+From: Bryan Cisneros <bcisneros@sighthound.com>
+Date: Sat, 25 Sep 2021 21:26:28 -0600
+Subject: [PATCH] Makefile: fix cross compilation issues
+
+Signed-off-by: Bryan Cisneros <bcisneros@sighthound.com>
+---
+ Makefile.config | 27 ++++++++++++++++++---------
+ 1 file changed, 18 insertions(+), 9 deletions(-)
+
+diff --git a/Makefile.config b/Makefile.config
+index a2a5ca8..19fe755 100644
+--- a/Makefile.config
++++ b/Makefile.config
+@@ -4,6 +4,7 @@ CUBLAS_TRIPLE ?= x86_64-linux-gnu
+ DLSW_TRIPLE ?= x86_64-linux-gnu
+ SAFE_PDK ?= 0
+ TARGET ?= $(shell uname -m)
++BUILD_TYPE ?= release
+
+ ifeq ($(CUDA_INSTALL_DIR),)
+   CUDA_INSTALL_DIR ?= /usr/local/cuda
+@@ -33,11 +34,11 @@ CUDNN_LIBDIR = lib64
+ ifeq ($(TARGET), aarch64)
+   ifeq ($(shell uname -m), aarch64)
+     CUDA_LIBDIR = lib64
+-    CC = g++
++    CXX ?= g++
+   else
+-    CC = aarch64-linux-gnu-g++
++    CXX ?= aarch64-linux-gnu-g++
+   endif
+-  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64 -ccbin $(CC)
++  CUCC = $(CUDA_INSTALL_DIR)/bin/nvcc -m64 -ccbin $(CXX)
+ else ifeq ($(TARGET), x86_64)
+   CUDA_LIBDIR = lib64
+   CC = g++
+@@ -90,7 +91,7 @@ endef
+ ifneq ($(USE_QCC),1)
+ # Usage: $(call make-depend,source-file,object-file,depend-file)
+ define make-depend
+-  $(AT)$(CC) -MM -MF $3 -MP -MT $2 $(COMMON_FLAGS) $1
++  $(AT)$(CXX) -MM -MF $3 -MP -MT $2 $(COMMON_FLAGS) $1
+ endef
+ # Usage: $(call make-cuda-depend,source-file,object-file,depend-file,flags)
+ define make-cuda-depend
+@@ -265,7 +266,15 @@ CFLAGSD = $(COMMON_FLAGS) -g
+ LFLAGS = $(COMMON_LD_FLAGS)
+ LFLAGSD = $(COMMON_LD_FLAGS)
+
+-all: debug release
++ifeq ($(BUILD_TYPE), release)
++  all: release
++else
++ifeq ($(BUILD_TYPE), debug)
++  all: debug
++else
++  all: debug release
++endif
++endif
+
+ release : $(OUTDIR)/$(OUTNAME_RELEASE)
+
+@@ -292,13 +301,13 @@ $(OUTDIR)/$(OUTNAME_DEBUG) : $(DOBJS) $(CUDOBJS)
+ else
+ $(OUTDIR)/$(OUTNAME_RELEASE) : $(OBJS) $(CUOBJS)
+	$(ECHO) Linking: $@
+-	$(AT)$(CC) -o $@ $^ $(LFLAGS) -Wl,--start-group $(LIBS) -Wl,--end-group
++	$(AT)$(CXX) -o $@ $^ $(LFLAGS) -Wl,--start-group $(LIBS) -Wl,--end-group
+	# Copy every EXTRA_FILE of this sample to bin dir
+	$(foreach EXTRA_FILE,$(EXTRA_FILES), cp -f $(EXTRA_FILE) $(OUTDIR)/$(EXTRA_FILE); )
+
+ $(OUTDIR)/$(OUTNAME_DEBUG) : $(DOBJS) $(CUDOBJS)
+	$(ECHO) Linking: $@
+-	$(AT)$(CC) -o $@ $^ $(LFLAGSD) -Wl,--start-group $(DLIBS) -Wl,--end-group
++	$(AT)$(CXX) -o $@ $^ $(LFLAGSD) -Wl,--start-group $(DLIBS) -Wl,--end-group
+ endif
+
+ $(OBJDIR)/%.o: %.cpp
+@@ -306,14 +315,14 @@ $(OBJDIR)/%.o: %.cpp
+	$(foreach XDIR,$(EXTRA_DIRECTORIES), if [ ! -d $(OBJDIR)/$(XDIR) ]; then mkdir -p $(OBJDIR)/$(XDIR); fi;) :
+	$(call make-depend,$<,$@,$(subst .o,.d,$@))
+	$(ECHO) Compiling: $<
+-	$(AT)$(CC) $(CFLAGS) -c -o $@ $<
++	$(AT)$(CXX) $(CFLAGS) -c -o $@ $<
+
+ $(DOBJDIR)/%.o: %.cpp
+	$(AT)if [ ! -d $(DOBJDIR) ]; then mkdir -p $(DOBJDIR); fi
+	$(foreach XDIR,$(EXTRA_DIRECTORIES), if [ ! -d $(OBJDIR)/$(XDIR) ]; then mkdir -p $(DOBJDIR)/$(XDIR); fi;) :
+	$(call make-depend,$<,$@,$(subst .o,.d,$@))
+	$(ECHO) Compiling: $<
+-	$(AT)$(CC) $(CFLAGSD) -c -o $@ $<
++	$(AT)$(CXX) $(CFLAGSD) -c -o $@ $<
+
+ ######################################################################### CU
+ $(OBJDIR)/%.o: %.cu
+--
+2.33.0
+
+

--- a/recipes-devtools/gie/tensorrt-samples_7.1.3-1.bb
+++ b/recipes-devtools/gie/tensorrt-samples_7.1.3-1.bb
@@ -1,0 +1,74 @@
+DESCRIPTION = "NVIDIA TensorRT Samples for deep learning"
+LICENSE = "Proprietary"
+
+inherit l4t_deb_pkgfeed cuda
+
+HOMEPAGE = "http://developer.nvidia.com/tensorrt"
+
+PREFIX = "NoDLA-"
+PREFIX_tegra194 = "DLA-"
+
+L4T_DEB_GROUP = "tensorrt"
+
+SRC_SOC_DEBS = "\
+    libnvinfer-samples_${PV}+cuda10.2_all.deb;downloadfilename=${PREFIX}libnvinfer-samples_${PV}+cuda10.2_all.deb;name=samples;subdir=tensorrt \
+"
+
+SRC_URI_append = " file://0001-Makefile-fix-cross-compilation-issues.patch"
+
+SAMPSHA256SUM = "3a5162474cce7e191d78703b196bc8bdd5a6908d7537200194f1e80d72cf45a0"
+SAMSHA256SUM_tegra194 = "87d32bb231c19717c4690e05c770eb51d3d5ad4bea8fbd0ee46ba4d1a386ad9f"
+SRC_URI[samples.sha256sum] = "${SAMPSHA256SUM}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+LIC_FILES_CHKSUM = "file://../../../share/doc/libnvinfer-samples/copyright;md5=ea60fab79a29c78a6958fc75552ffdc0"
+
+S = "${WORKDIR}/tensorrt/usr/src/tensorrt/samples"
+
+DEPENDS = "cuda-cudart cudnn tegra-libraries tensorrt-core tensorrt-plugins libglvnd"
+
+EXTRA_OEMAKE = ' \
+    CUDA_INSTALL_DIR="${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}" \
+    CUDNN_INSTALL_DIR="${STAGING_DIR_HOST}/usr/lib" \ 
+    TRT_LIB_DIR="${STAGING_DIR_HOST}/usr/lib" \
+    TARGET="${TARGET_ARCH}" BUILD_TYPE="release" \
+'
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+do_configure() {
+    :
+}
+
+do_install() {
+    install -d ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_algorithm_selector ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_char_rnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_dynamic_reshape ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_fasterRCNN ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_googlenet ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_int8 ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_int8_api ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mlp ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_mnist_api ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_nmt ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_onnx_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_reformat_free_io ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_ssd ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_faster_rcnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_mask_rcnn ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_mnist ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_plugin_v2_ext ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/sample_uff_ssd ${D}${prefix}/src/tensorrt/bin
+    install -m 0755 ${S}/../bin/trtexec ${D}${prefix}/src/tensorrt/bin
+
+    install -d ${D}${prefix}/src/tensorrt/data
+    cp -R --preserve=mode,timestamps ${S}/../data/* ${D}${prefix}/src/tensorrt/data
+}
+
+PACKAGES =+ "${PN}-trtexec"
+
+FILES_${PN} += "${prefix}/src/tensorrt/bin ${prefix}/src/tensorrt/data"
+FILES_${PN}-trtexec += "${prefix}/src/tensorrt/bin/trtexec"

--- a/recipes-multimedia/argus/tegra-mmapi-samples_32.4.3.bb
+++ b/recipes-multimedia/argus/tegra-mmapi-samples_32.4.3.bb
@@ -21,7 +21,7 @@ DEPENDS = "libdrm tegra-mmapi tegra-libraries virtual/egl virtual/libgles1 virtu
 inherit pkgconfig cuda python3native features_check
 
 PACKAGECONFIG ??= ""
-PACKAGECONFIG[objdetect] = "HAVE_OPENCV=1 HAVE_TENSORRT=1,,tensorrt opencv"
+PACKAGECONFIG[objdetect] = "HAVE_OPENCV=1 HAVE_TENSORRT=1,,tensorrt-core tensorrt-plugins opencv"
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
This PR is a backport of @ichergui's PR https://github.com/OE4T/meta-tegra/pull/799 into the `dunfel-l4t-r32.4.3` branch. It accomplishes the following:

 - Split the tensorrt recipe into two recipes (`tensorrt-core` and `tensorrt-plugins-prebuilt`)
 - Add a new recipe to build `tensorrt-plugins` from source
 - Update dependency list in recipes which depend on `tensorrt-core` and `tensorrt-plugins`