### PR TITLE
ds-tlt: Add recipe for tlt samples and custom parser

### DIFF
--- a/recipes-devtools/deepstream/deepstream-tlt-apps_3.0.bb
+++ b/recipes-devtools/deepstream/deepstream-tlt-apps_3.0.bb
@@ -1,0 +1,37 @@
+DESCRIPTION = "NVIDIA Transfer Learning Toolkit sample applications"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE.md;md5=dbef1fb16cd9e5c5249a8e0c5e639fb0"
+
+DEPENDS = " deepstream-5.0"
+
+SRC_URI = "git://github.com/NVIDIA-AI-IOT/deepstream_tao_apps.git;branch=release/tlt3.0"
+SRCREV = "16405b1a725a888cf6473cdd4fd0cb7effbf393f"
+
+S = "${WORKDIR}/git"
+
+inherit pkgconfig cuda
+
+TARGET_LDFLAGS += " -L${RECIPE_SYSROOT}/opt/nvidia/deepstream/deepstream-5.0/lib"
+EXTRA_OEMAKE += " CC='${CXX}' CUDA_VER=${CUDA_VERSION}"
+
+TARGET_CC_ARCH += "${LDFLAGS}"
+
+TLT_SAMPLES_PATH = "${bindir}/tlt_samples"
+
+do_install () {
+    install -d ${D}${libdir}
+    install -m 0755 ${S}/post_processor/libnvds_infercustomparser_tlt.so ${D}${libdir}/libnvds_infercustomparser_tlt.so.${PV}
+
+    install -d ${D}${TLT_SAMPLES_PATH}
+    install -m 0755 ${S}/apps/tlt_detection/ds-tlt-detection ${D}${TLT_SAMPLES_PATH}
+    install -m 0755 ${S}/apps/tlt_segmentation/ds-tlt-segmentation ${D}${TLT_SAMPLES_PATH}
+    install -m 0755 ${S}/apps/tlt_classifier/ds-tlt-classifier ${D}${TLT_SAMPLES_PATH}
+}
+
+PACKAGES += "${PN}-samples ${PN}-custom-parser"
+FILES_${PN} = ""
+ALLOW_EMPTY_${PN} = "1"
+FILES_${PN}-custom-parser = "${libdir}"
+FILES_${PN}-samples = "${TLT_SAMPLES_PATH}"
+RDEPENDS_${PN} += "${PN}-samples ${PN}-custom-parser"
+RDEPENDS_${PN}-samples += "deepstream-5.0"


### PR DESCRIPTION
This PR adds a recipe that builds several deepstream tlt sample apps as well as the `libnvds_infercustomparser_tlt.so` custom parser library from NVIDIA's https://github.com/NVIDIA-AI-IOT/deepstream_tao_apps repository.

What I really care about here is the `libnvds_infercustomparser_tlt.so` library to build custom bounding box parsers (see the build instructions [here](https://docs.nvidia.com/metropolis/TLT/tlt-user-guide/text/object_detection/yolo_v4.html#prerequisites-for-yolov4-model)), but I figured since I'm already pulling from this repo it would be more appropriate to build everything in the repo (meaning the tlt sample apps as well).

I also separated the samples and custom parser into separate packages so that the custom parser can be built by itself if desired.

I'm opening this PR as a draft for now as I'm finishing up some testing, but please let me know if you have any feedback. I'm targeting the `dunfell-l4t-r32.4.3` branch since that's what my image is based on, but I can also open another PR targeting the master branch once this one gets approved.