### PR TITLE
tensorrt-plugins: fix build issues when using protobuf version 3.18.x

### DIFF
--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-Tensorrt-fix-build-issues-when-using-protobuf-versio.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-Tensorrt-fix-build-issues-when-using-protobuf-versio.patch
@@ -1,0 +1,107 @@
+From 20661dca581f062be369e92c3c55e94d92c9839f Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Sun, 26 Sep 2021 17:41:54 +0100
+Subject: [PATCH] Tensorrt: fix build issues when using protobuf version 3.18.x
+
+This is mondatory because of the following commit:
+
+https://github.com/protocolbuffers/protobuf/pull/8794
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+Index: git/parsers/caffe/caffeParser/caffeParser.cpp
+===================================================================
+--- git.orig/parsers/caffe/caffeParser/caffeParser.cpp
++++ git/parsers/caffe/caffeParser/caffeParser.cpp
+@@ -327,7 +327,7 @@ const IBlobNameToTensor* CaffeParser::pa
+         mModel = std::unique_ptr<trtcaffe::NetParameter>(new trtcaffe::NetParameter);
+         google::protobuf::io::ArrayInputStream modelStream(modelBuffer, modelLength);
+         google::protobuf::io::CodedInputStream codedModelStream(&modelStream);
+-        codedModelStream.SetTotalBytesLimit(modelLength, -1);
++        codedModelStream.SetTotalBytesLimit(modelLength);
+ 
+         if (!mModel->ParseFromCodedStream(&codedModelStream))
+         {
+@@ -624,7 +624,7 @@ IBinaryProtoBlob* CaffeParser::parseBina
+ 
+     IstreamInputStream rawInput(&stream);
+     CodedInputStream codedInput(&rawInput);
+-    codedInput.SetTotalBytesLimit(INT_MAX, -1);
++    codedInput.SetTotalBytesLimit(INT_MAX);
+ 
+     trtcaffe::BlobProto blob;
+     bool ok = blob.ParseFromCodedStream(&codedInput);
+Index: git/parsers/caffe/caffeParser/readProto.h
+===================================================================
+--- git.orig/parsers/caffe/caffeParser/readProto.h
++++ git/parsers/caffe/caffeParser/readProto.h
+@@ -48,7 +48,7 @@ bool readBinaryProto(trtcaffe::NetParame
+ 
+     IstreamInputStream rawInput(&stream);
+     CodedInputStream codedInput(&rawInput);
+-    codedInput.SetTotalBytesLimit(int(bufSize), -1);
++    codedInput.SetTotalBytesLimit(int(bufSize));
+ 
+     bool ok = net->ParseFromCodedStream(&codedInput);
+     stream.close();
+Index: git/parsers/onnx/ModelImporter.cpp
+===================================================================
+--- git.orig/parsers/onnx/ModelImporter.cpp
++++ git/parsers/onnx/ModelImporter.cpp
+@@ -285,7 +285,7 @@ Status deserialize_onnx_model(void const
+     {
+         google::protobuf::io::CodedInputStream coded_input(&raw_input);
+         // Note: This WARs the very low default size limit (64MB)
+-        coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max(), std::numeric_limits<int>::max() / 4);
++        coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max());
+         ASSERT( (model->ParseFromCodedStream(&coded_input)) && "Failed to parse the ONNX model.", ErrorCode::kMODEL_DESERIALIZE_FAILED);
+     }
+     return Status::success();
+@@ -302,7 +302,7 @@ Status deserialize_onnx_model(int fd, bo
+     {
+         google::protobuf::io::CodedInputStream coded_input(&raw_input);
+         // Note: This WARs the very low default size limit (64MB)
+-        coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max(), std::numeric_limits<int>::max() / 4);
++        coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max());
+         ASSERT( (model->ParseFromCodedStream(&coded_input)) && "Failed to parse the ONNX model.", ErrorCode::kMODEL_DESERIALIZE_FAILED);
+     }
+     return Status::success();
+Index: git/parsers/onnx/common.hpp
+===================================================================
+--- git.orig/parsers/onnx/common.hpp
++++ git/parsers/onnx/common.hpp
+@@ -68,8 +68,7 @@ namespace common
+     raw_input.SetCloseOnDelete(true);
+     google::protobuf::io::CodedInputStream coded_input(&raw_input);
+     // Note: This WARs the very low default size limit (64MB)
+-    coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max(),
+-                                   std::numeric_limits<int>::max()/4);
++    coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max());
+     return msg->ParseFromCodedStream(&coded_input);
+   }
+ 
+Index: git/parsers/onnx/onnx_utils.hpp
+===================================================================
+--- git.orig/parsers/onnx/onnx_utils.hpp
++++ git/parsers/onnx/onnx_utils.hpp
+@@ -118,7 +118,7 @@ inline bool ParseFromFile_WAR(google::pr
+ 
+     google::protobuf::io::CodedInputStream coded_input(&rawInput);
+     // Note: This WARs the very low default size limit (64MB)
+-    coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max(), std::numeric_limits<int>::max() / 4);
++    coded_input.SetTotalBytesLimit(std::numeric_limits<int>::max());
+     return msg->ParseFromCodedStream(&coded_input);
+ }
+ 
+Index: git/parsers/onnx/third_party/onnx/onnx/proto_utils.h
+===================================================================
+--- git.orig/parsers/onnx/third_party/onnx/onnx/proto_utils.h
++++ git/parsers/onnx/third_party/onnx/onnx/proto_utils.h
+@@ -31,7 +31,7 @@ bool ParseProtoFromBytes(Proto* proto, c
+   // respectively.
+   ::google::protobuf::io::ArrayInputStream input_stream(buffer, static_cast<int>(length));
+   ::google::protobuf::io::CodedInputStream coded_stream(&input_stream);
+-  coded_stream.SetTotalBytesLimit((2048LL << 20) - 1, 512LL << 20);
++  coded_stream.SetTotalBytesLimit((2048LL << 20) - 1);
+   return proto->ParseFromCodedStream(&coded_stream);
+ }

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.0.1-1.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.0.1-1.bb
@@ -14,6 +14,7 @@ SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
 SRCBRANCH = "master"
 SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
     file://0001-CMakeLists.txt-fix-cross-compilation-issues.patch \
+    file://0002-Tensorrt-fix-build-issues-when-using-protobuf-versio.patch \
 "
 SRCREV = "eb5de99b523c76c2f3ae997855ad86d3a1e86a31"
 


### PR DESCRIPTION
This is needed because of upgrade version of protobuf from 3.17.x to 3.18.x
in meta-openembedded

https://git.openembedded.org/meta-openembedded/commit/?id=d7d9597348534b9d93dd7ed8ef49fa2b5c33969d

For more details, deprecated version of SetTotalBytesLimit API was removed
in PR #8794 (https://github.com/protocolbuffers/protobuf/pull/8794)

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>