### PR TITLE
tegra-helper-scripts: correct generation of flashcmd.txt

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
@@ -256,7 +256,7 @@ if [ -n "$keyfile" ]; then
     if [ $bup_blob -eq 0 -a $no_flash -ne 0 ]; then
 	rm -f flashcmd.txt
 	echo "#!/bin/sh" > flashcmd.txt
-	echo "python3 $flashapp ${inst_args} --bl cboot.bin.signed --bct \"$(basename $sdramcfg_file .cfg).bct\" --odmdata $odmdata \
+	echo "python3 $flashappname ${inst_args} --bl cboot.bin.signed --bct \"$(basename $sdramcfg_file .cfg).bct\" --odmdata $odmdata \
 --bldtb \"${dtb_file}.signed\" --applet rcm_1_signed.rcm --cfg flash.xml --chip 0x21 \
 --cmd \"secureflash;reboot\" $binargs" > flashcmd.txt
 	chmod +x flashcmd.txt


### PR DESCRIPTION
by omitting the path to tegraflash.py.

Signed-off-by: Chad McQuillen <chad.mcquillen@lexmark.com>