### PR TITLE
tegra-helper-scripts: correct generation of flashcmd.txt

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra210-flash-helper.sh
@@ -231,7 +231,7 @@ if [ -n "$keyfile" ]; then
     if [ $no_flash -ne 0 ]; then
 	rm -f flashcmd.txt
 	echo "#!/bin/sh" > flashcmd.txt
-	echo "python3 $flashapp --bl cboot.bin.signed --bct \"$(basename $sdramcfg_file .cfg).bct\" --odmdata $odmdata \
+	echo "python3 $flashappname --bl cboot.bin.signed --bct \"$(basename $sdramcfg_file .cfg).bct\" --odmdata $odmdata \
 --bldtb \"${dtb_file}.signed\" --applet rcm_1_signed.rcm --cfg flash.xml --chip 0x21 \
 --cmd \"secureflash;reboot\" $binargs" > flashcmd.txt
 	chmod +x flashcmd.txt


### PR DESCRIPTION
by omitting the path to tegraflash.py.

Signed-off-by: Chad McQuillen chad.mcquillen@lexmark.com