### PR TITLE
tegra-libraries-winsys: add missing L4T_DEB_TRANSLATED_BPN

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-winsys_32.6.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-winsys_32.6.1.bb
@@ -1,5 +1,7 @@
 L4T_DEB_COPYRIGHT_MD5 = "ce4d36df31e6cc73581fd2a25d16834e"
 
+L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-3d-core"
+
 require tegra-debian-libraries-common.inc
 
 MAINSUM = "c6b3b72a3abbc8f88013d4447e9570465573f2f85ee79b2f1d7cdfc2ccbf669d"


### PR DESCRIPTION
Fixes #861 