### PR TITLE
bootlogo: use linear gamma to match nvdisp window settings in cboot

### DIFF
--- a/recipes-bsp/bootlogo/bootlogo.inc
+++ b/recipes-bsp/bootlogo/bootlogo.inc
@@ -13,7 +13,7 @@ cook_bitmaps() {
         local H=${size#*x}
         bbdebug 1 "Resizing ${SPLASH_GRAPHIC_FILENAME} to ${W}x${H} with background ${SPLASH_GRAPHIC_BACKGROUND}"
         # resize input with size reduction only, pad remaining about center with color
-        convert.im7 ${_input_file} -type truecolor -resize ${W}x${H}\> -gravity center -background ${SPLASH_GRAPHIC_BACKGROUND} -extent ${W}x${H} ${B}/logo-${H}.bmp
+        convert.im7 ${_input_file} -type truecolor -colorspace RGB -resize ${W}x${H}\> -gravity center -background ${SPLASH_GRAPHIC_BACKGROUND} -extent ${W}x${H} ${B}/logo-${H}.bmp
         LIST="${LIST}${B}/logo-${H}.bmp nvidia ${H};"
     done
 


### PR DESCRIPTION
The SOR settings in cboot apply gamma correction to the window
containing the bootlogo buffer. As such, either the window needs to
degamma the logo image, or the logo image must have a linear gamma.

This change does the latter, to keep limit the amount of patching
we're adding to cboot.

---

Note that this change only affects customizations to the bootlogo-custom recipe. The stock oe4t logo already cooks the bitmaps in a way that is compatible with cboot.