### PR TITLE
tar-l4t-workaround: fix up for current fetcher args

### DIFF
--- a/recipes-l4t-workarounds/tar/tar-l4t-workaround/tar-wrapper.sh
+++ b/recipes-l4t-workarounds/tar/tar-l4t-workaround/tar-wrapper.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# bitbake fetcher passes --no-same-owner -xpf <filename>
+# bitbake fetcher passes --extract --no-same-owner -p -f <filename>
 tarargs=
 extraarg=
 while [ $# -gt 0 ]; do
     case "$1" in
-	-x*f)
+	-f)
 	    tarargs="$tarargs $1 $2"
 	    if [ "$2" = "data.tar.zst" ]; then
 		tarargs="$tarargs -Iunzstd"


### PR DESCRIPTION
bitbake fetcher used to pass '--no-same-owner -xpf <filename>' but
now passes '--extract --no-same-owner -p -f <filename>'

Wrapper script updated to handle new arguments.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>