### PR TITLE
[tegra-libraries-multimedia-v4l / cuda-cudart] Add missing .so to nvidia docker pass-thorugh list.

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-v4l_32.6.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-v4l_32.6.1.bb
@@ -26,6 +26,11 @@ TEGRA_PLUGINS = "\
 SOC_SPECIFIC_PLUGINS = "libv4l2_nvcuvidvideocodec.so"
 SOC_SPECIFIC_PLUGINS:tegra210 = ""
 
+CONTAINER_CSV_FILES += " \
+    ${libdir}/libv4l/plugins-wrapped/*.so \
+    ${libdir}/libv4l/plugins/*.so \
+"
+
 do_install() {
     install_libraries
     install -d ${D}${libdir}/libv4l/plugins/ ${D}${libdir}/libv4l/plugins-wrapped/

--- a/recipes-devtools/cuda/cuda-cudart_10.2.300-1.bb
+++ b/recipes-devtools/cuda/cuda-cudart_10.2.300-1.bb
@@ -8,7 +8,9 @@ DEVSUM = "d37a94a3fb858db2cf41cde1bcbe1042b9a66d4fd3fd30882805a478523acb18"
 DEVSUM:x86-64 = "c006853dec4b26871edaa859a7bcff15aed39142dc5a529262793594a8646e28"
 
 inherit container-runtime-csv siteinfo
-CONTAINER_CSV_FILES = "${sysconfdir}/ld.so.conf.d/cuda-${CUDA_VERSION_DASHED}.conf"
+CONTAINER_CSV_FILES += " \
+    ${sysconfdir}/ld.so.conf.d/cuda-${CUDA_VERSION_DASHED}.conf \
+"
 
 do_compile:append() {
     echo "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}" > ${B}/cuda-${CUDA_VERSION_DASHED}.conf


### PR DESCRIPTION
The following libraries were not mounted into the docker containers:
- /usr/local/cuda-10.2/lib/libcudart.so.10.2.300
- /usr/lib/libv4l/plugins-wrapped/libv4l2_nvvidconv.so

which caused gstreamer to fail when loading plugins that depend on the libraries above.