### PR TITLE
jetson-nano-devkit: add BUP support for FAB 401

### DIFF
--- a/conf/machine/jetson-nano-devkit.conf
+++ b/conf/machine/jetson-nano-devkit.conf
@@ -12,7 +12,7 @@ TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "200"
 TEGRA_BOARDSKU ?= "0000"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3448 and board=jetson-nano-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=100 fab=200 fab=300 fab=400"
+TEGRA_BUPGEN_SPECS ?= "fab=100 fab=200 fab=300 fab=400 fab=401"
 
 require conf/machine/include/tegra210.inc
 


### PR DESCRIPTION
Jetson Nano devkit modules got a version bump, so to make sure that we
can build compatible BUP payloads, add that FAB to the list of specs is
needed.

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>