### PR TITLE
tegra-configs-alsa: install ALSA config files for tegra210

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-configs-alsa_32.6.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs-alsa_32.6.1.bb
@@ -28,6 +28,10 @@ do_install:append:tegra194() {
     install -m 0644 ${S}/usr/share/alsa/cards/jetson-xaviernx.conf ${D}${datadir}/alsa/cards/
     install -m 0644 ${S}/usr/share/alsa/cards/tegra-snd-t19x-.conf ${D}${datadir}/alsa/cards/
 }
+do_install:append:tegra210() {
+    install -m 0644 ${B}/usr/share/alsa/cards/tegra-hda.conf ${D}${datadir}/alsa/cards/
+    install -m 0644 ${B}/usr/share/alsa/cards/tegra-snd-t210r.conf ${D}${datadir}/alsa/cards/
+}
 
 FILES:${PN} = "${sysconfdir} ${datadir}/alsa"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
HDMI audio doesn't work with pulseaudio on the Jetson Nano devkit. This adds the missing ALSA configs.