### PR TITLE
linux-tegra: fix compilation when no dtb overlays are built

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -111,7 +111,7 @@ do_apply_devicetree_overlays[dirs] = "${B}"
 do_apply_devicetree_overlays[depends] += "dtc-native:do_populate_sysroot"
 
 do_install:append() {
-	for dtbo in arch/arm64/boot/dts/*.dtbo; do
+	for dtbo in $(find ${KERNEL_OUTPUT_DIR}/dts/*.dtbo); do
 		dtbo_base_name=`basename $dtbo .$dtbo_ext`
 		install -m 0644 $dtbo ${D}/${KERNEL_IMAGEDEST}/$dtbo_base_name
 	done


### PR DESCRIPTION
Compilation was failing with the following error:

| install: cannot stat 'arch/arm64/boot/dts/*.dtbo': No such file or directory

This change updates the for loop to use the find command to search
for device tree overlay files to install, as well as using the
KERNEL_OUTPUT_DIR variable as do install steps in kernel.bbclass

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>