### PR TITLE
jetson-tx2-devkit: kernel internal wireless regdb is disable by default

### DIFF
--- a/conf/machine/jetson-tx2-devkit.conf
+++ b/conf/machine/jetson-tx2-devkit.conf
@@ -29,3 +29,6 @@ TEGRA_BOARDREV ?= ""
 TEGRA_CHIPREV ?= "0"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3310 and board=jetson-tx2-devkit
 TEGRA_BUPGEN_SPECS ?= "fab=B00 fab=B02 fab=C04 fab=D00 fab=D01 fab=D02"
+
+# By default wireless regdb is disable
+KERNEL_INTERNAL_WIRELESS_REGDB ?= "0"


### PR DESCRIPTION
Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>