### PR TITLE
perf: update bbappend

### DIFF
--- a/recipes-kernel/perf/perf.bbappend
+++ b/recipes-kernel/perf/perf.bbappend
@@ -1,8 +1,4 @@
-def kernel_disable_features(d):
-    if bb.utils.vercmp_string(d.getVar('KERNEL_VERSION'), '4.17') < 0:
-        # python3 is not supported until 4.17, so do not allow scripting
-        return "scripting"
-    else:
-        return ""
-
-PACKAGECONFIG:remove:tegra = "${@kernel_disable_features(d)}"
+PACKAGECONFIG:tegra ?= "tui libunwind"
+# Need to enable -fcommon on C compilations and disable POSIX yacc
+# mode in bison
+EXTRA_OEMAKE:append:tegra = " EXTRA_CFLAGS='-ldw -fcommon' YFLAGS='--file-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}'"


### PR DESCRIPTION
* Remove the KERNEL_VERSION-based logic for PACKAGECONFIG,
  since the kernel version isn't known at parse time, and
  just disable scripting for tegra platforms by default

* Fix build issues by appending to EXTRA_OECMAKE to override
  EXTRA_CFLAGS to add -fcommon and YFLAGS to remove the -y
  flag

Signed-off-by: Matt Madison <matt@madison.systems>