### PR TITLE
egl-wayland: use exactly 1.1.9 tag

### DIFF
--- a/recipes-graphics/wayland/egl-wayland_1.1.9.bb
+++ b/recipes-graphics/wayland/egl-wayland_1.1.9.bb
@@ -7,9 +7,8 @@ DEPENDS = "eglexternalplatform virtual/egl wayland wayland-protocols wayland-nat
 SRC_REPO = "github.com/NVIDIA/egl-wayland.git;protocol=https"
 SRCBRANCH = "master"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
-# tag 1.1.9 + 3 commits post-tag
-SRCREV = "582b2d345abaa0e313cf16c902e602084ea59551"
-PV .= "+3"
+# tag 1.1.9
+SRCREV = "cd0d19aa2742b1318527cabbcf279fb651c45d30"
 
 SRC_URI += " \
     file://0001-Fix-wayland-eglstream-protocols-pc-file.patch \


### PR DESCRIPTION
The +3 commits following the 1.1.9 tag all relate to adding a new
wl_drm interface, but there's no actual implementation in there yet.

The issue with these commits is that they expect the (closed) EGL
driver to support EGL_EXT_device_drm_render_node which the Tegra
one does not. This is workaround-able (check the drm device, and
find the associated render node by its symlink in /dev/dri/by-path),
but there's no reason to do this right now if wl_drm isn't working
yet anyway.

If we end up at 1.1.10 (or whatever is next), have an otherwise
working wl_drm implementation, but still don't have egl driver
support for this extension, we can patch.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>