### PR TITLE
jetson-nano-devkit-emmc: add BUP support for FAB 401

### DIFF
--- a/conf/machine/jetson-nano-devkit-emmc.conf
+++ b/conf/machine/jetson-nano-devkit-emmc.conf
@@ -11,7 +11,7 @@ TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "400"
 TEGRA_BOARDSKU ?= "0002"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3448 and board=jetson-nano-devkit-emmc
-TEGRA_BUPGEN_SPECS ?= "fab=200 fab=300 fab=400"
+TEGRA_BUPGEN_SPECS ?= "fab=200 fab=300 fab=400 fab=401"
 
 require conf/machine/include/tegra210.inc
 


### PR DESCRIPTION
Jetson Nano devkit modules got a version bump, but the eMMC devkit was
missed in that update. In order to build compatible BUP payloads, this
fab must be added.

Signed-off-by: Matt Harvey <mharvey@miovision.com>

I wasn't sure which branch to put this in, so I put it in the one we're using. If it belongs somewhere else I can put up another request. We noticed this issue because we ran into some boards with this fab.