### PR TITLE
Fixup for  tensorrt 

### DIFF
--- a/recipes-devtools/gie/tensorrt-core_8.4.0-1.bb
+++ b/recipes-devtools/gie/tensorrt-core_8.4.0-1.bb
@@ -13,10 +13,10 @@ SRC_COMMON_DEBS = "\
     libnvparsers8_${PV}+cuda11.4_arm64.deb;downloadfilename=libnvparsers8_${PV}+cuda11.4_arm64.deb;name=nvp;subdir=tensorrt \
     libnvparsers-dev_${PV}+cuda11.4_arm64.deb;downloadfilename=libnvparsers-dev_${PV}+cuda11.4_arm64.deb;name=nvpdev;subdir=tensorrt \
 "
-LIBSHA256SUM = "1e1fb1f03c4c05ceb2cd1d33fdff15a11090812b5f51d0b028ad7d16058c6741"
-DEVSHA256SUM = "d1aadb326ce73f7b0c739e3eb2351ccdd358b066fbd3ed7d0eff65b2e362b6db"
-NVPSHA256SUM = "0412a6326abcf9a6389bfd933333724675867803b1efe3e4cdc20be9443a4a0d"
-NVPDEVSHA256SUM = "b06a5adab609b2975e56bef10d93690e9ee34939f86686af1b3e992b51512fe7"
+LIBSHA256SUM = "528e3a668962ab26d78047e401d5da7810b6d09cc8e14ad64420cf0acf77a6ea"
+DEVSHA256SUM = "a5da680fa77135982db8d9261e9deca10fa032266a51a711df355c85c73ffbdb"
+NVPSHA256SUM = "ceff97a7b37a478c38ff74c59bb32ec1e49b106c2e7c3bef8d80103f04cfd145"
+NVPDEVSHA256SUM = "f3281b12a1be13a600b15fe07700ba85c79254a82b0926ed9a72d6a290d905a7"
 
 SRC_URI[lib.sha256sum] = "${LIBSHA256SUM}"
 SRC_URI[dev.sha256sum] = "${DEVSHA256SUM}"
@@ -25,7 +25,7 @@ SRC_URI[nvpdev.sha256sum] = "${NVPDEVSHA256SUM}"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=48;md5=1243a04ad50f54138acd8a623c6d90cf"
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInfer.h;endline=11;md5=f099d2358ef8a23caa6cbf96136cac44"
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 

--- a/recipes-devtools/gie/tensorrt-plugins-prebuilt_8.4.0-1.bb
+++ b/recipes-devtools/gie/tensorrt-plugins-prebuilt_8.4.0-1.bb
@@ -14,10 +14,10 @@ SRC_COMMON_DEBS = "\
     libnvinfer-plugin-dev_${PV}+cuda11.4_arm64.deb;downloadfilename=libnvinfer-plugin-dev_${PV}+cuda11.4_arm64.deb;name=plugindev;subdir=tensorrt \
 "
 
-ONNXSHA256SUM = "419936472e8a9ff680696c9e41480441329e6170443f5740d72438da7a707637"
-ONNXDEVSHA256SUM = "0b7f26bb2b3ab000d1a5c715779dd82dd01a738dff9057a8b76183e703c98623"
-PLUGINSHA256SUM = "a740a9689ceec2d73de8e9193c96071a1b50d5da4f678f907afd928322ed4c67"
-PLUGINDEVSHA256SUM = "d72a876c2c4b37077d2eea5803cdcaa02396b1e9e7b0efbf11a8b215a3706f95"
+ONNXSHA256SUM = "87b19d8b95c7a1415d6e8e2a9e0fa9cecd628f1dc9569d6ae6d219702d17575c"
+ONNXDEVSHA256SUM = "5b2bba30c5a85689ccad5733092ff806043e2851be345508c014704c232a567a"
+PLUGINSHA256SUM = "cdc300b15801274cdf66db7738801d108922d69ad3c98a4d231992c702df2b9a"
+PLUGINDEVSHA256SUM = "8521ce42635e9d7827016f96f43e6e61679eec5e7bad547136f917ceae9fd583"
 
 SRC_URI[onnx.sha256sum] = "${ONNXSHA256SUM}"
 SRC_URI[onnxdev.sha256sum] = "${ONNXDEVSHA256SUM}"
@@ -28,7 +28,7 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
-LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInferPlugin.h;endline=48;md5=1243a04ad50f54138acd8a623c6d90cf"
+LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/NvInferPlugin.h;endline=11;md5=f099d2358ef8a23caa6cbf96136cac44"
 
 def extract_basever(d):
     ver = d.getVar('PV').split('-')[0]

--- a/recipes-devtools/gie/tensorrt-samples.inc
+++ b/recipes-devtools/gie/tensorrt-samples.inc
@@ -12,7 +12,7 @@ SRC_COMMON_DEBS = "\
 
 SRC_URI:append = " file://0001-Makefile-fix-cross-compilation-issues.patch"
 
-SRC_URI[samples.sha256sum] = "6c516418ce485baa626de3dd2e46a502beda3a4c3eddcaa916106c03693ed6e7"
+SRC_URI[samples.sha256sum] = "b41432c30b45dc3155f342cc5140026fc4a495b247507ad1f1f2e2fdde537649"
 
 COMPATIBLE_MACHINE = "(tegra)"
 

--- a/recipes-devtools/gie/tensorrt-samples_8.4.0-1.bb
+++ b/recipes-devtools/gie/tensorrt-samples_8.4.0-1.bb
@@ -14,7 +14,6 @@ do_install() {
     install -m 0755 ${S}/../bin/sample_io_formats ${D}${prefix}/src/tensorrt/bin
     install -m 0755 ${S}/../bin/sample_mnist ${D}${prefix}/src/tensorrt/bin
     install -m 0755 ${S}/../bin/sample_mnist_api ${D}${prefix}/src/tensorrt/bin
-    install -m 0755 ${S}/../bin/sample_nmt ${D}${prefix}/src/tensorrt/bin
     install -m 0755 ${S}/../bin/sample_onnx_mnist ${D}${prefix}/src/tensorrt/bin
     install -m 0755 ${S}/../bin/sample_ssd ${D}${prefix}/src/tensorrt/bin
     install -m 0755 ${S}/../bin/sample_uff_faster_rcnn ${D}${prefix}/src/tensorrt/bin

--- a/recipes-devtools/gie/tensorrt-trtexec-prebuilt_8.4.0-1.bb
+++ b/recipes-devtools/gie/tensorrt-trtexec-prebuilt_8.4.0-1.bb
@@ -11,7 +11,7 @@ SRC_COMMON_DEBS = "\
     libnvinfer-bin_${PV}+cuda11.4_arm64.deb;downloadfilename=libnvinfer-bin_${PV}+cuda11.4_arm64.deb;name=bin;subdir=tensorrt \
 "
 
-BINSHA256SUM = "3fdf9d374e6c6b9745089a60482f4ba15375aa7e32dd71927344d2ac64549424"
+BINSHA256SUM = "5039040ea8769d929b693cead9a92d5f250fba8dbcf3f43d19f88bdd7068ae43"
 
 SRC_URI[bin.sha256sum] = "${BINSHA256SUM}"
 


### PR DESCRIPTION
* Using `Jetson xavier AGX` and running `run-tensorrt-tests`
* Here is the results:
```
[03/11/2022-14:57:03] [I] === Performance summary ===
[03/11/2022-14:57:03] [I] Throughput: 41087.7 qps
[03/11/2022-14:57:03] [I] Latency: min = 0.387207 ms, max = 0.447357 ms, mean = 0.402238 ms, median = 0.401947 ms, percentile(99%) = 0.420288 ms
[03/11/2022-14:57:03] [I] Enqueue Time: min = 0.0830078 ms, max = 0.229004 ms, mean = 0.090497 ms, median = 0.0871582 ms, percentile(99%) = 0.126099 ms
[03/11/2022-14:57:03] [I] H2D Latency: min = 0.00622559 ms, max = 0.0571899 ms, mean = 0.0104126 ms, median = 0.00952148 ms, percentile(99%) = 0.0272217 ms
[03/11/2022-14:57:03] [I] GPU Compute Time: min = 0.375977 ms, max = 0.403564 ms, mean = 0.388221 ms, median = 0.388443 ms, percentile(99%) = 0.393188 ms
[03/11/2022-14:57:03] [I] D2H Latency: min = 0.00195312 ms, max = 0.00537109 ms, mean = 0.00360451 ms, median = 0.00366211 ms, percentile(99%) = 0.00488281 ms
[03/11/2022-14:57:03] [I] Total Host Walltime: 3.00119 s
[03/11/2022-14:57:03] [I] Total GPU Compute Time: 2.99202 s
[03/11/2022-14:57:03] [I] Explanations of the performance metrics are printed in the verbose logs.
[03/11/2022-14:57:03] [I] 
&&&& PASSED TensorRT.trtexec [TensorRT v8400] # trtexec --loadEngine=mnist16.trt --batch=16
=== PASS:  trtexec ===
Tests run:     12
Tests passed:  11
Tests skipped: 1
Tests failed:  0
root@jetson-agx-xavier-devkit:~#
```