### PR TITLE
external/qt5-layer: fix egldevice backend for L4T 32.7.1

### DIFF
--- a/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-Newer-Nvidia-libdrm-provide-device-instead-dri.patch
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-Newer-Nvidia-libdrm-provide-device-instead-dri.patch
@@ -1,0 +1,37 @@
+From e28a134e847eff8bc6a27ca7b0bdde424716497f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Pasi=20Pet=C3=A4j=C3=A4j=C3=A4rvi?= <pasi.petajajarvi@qt.io>
+Date: Tue, 30 Mar 2021 17:40:03 +0300
+Subject: [PATCH] eglfs: Newer Nvidia libdrm provide device instead driver
+ module name
+
+In newer Nvidia proprietary libdrm binaries display device name is
+actual device and not driver module name. Check which provided device
+name has been returned with EGL_DRM_DEVICE_FILE_EXT to choose correct
+function to open device.
+
+Pick-to: 5.15
+Fixes: QTBUG-91184
+Change-Id: I95f907dfa30057da0dca4ff32e0605c6bb10e0a5
+Reviewed-by: Laszlo Agocs <laszlo.agocs@qt.io>
+---
+ .../eglfs_kms_egldevice/qeglfskmsegldevice.cpp             | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevice.cpp b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevice.cpp
+index 81ce7e1d71..749750042c 100644
+--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevice.cpp
++++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevice.cpp
+@@ -58,7 +58,12 @@ bool QEglFSKmsEglDevice::open()
+ {
+     Q_ASSERT(fd() == -1);
+ 
+-    int fd = drmOpen(devicePath().toLocal8Bit().constData(), nullptr);
++    int fd = -1;
++
++    if (devicePath().compare("drm-nvdc") == 0)
++        fd = drmOpen(devicePath().toLocal8Bit().constData(), nullptr);
++    else
++        fd = qt_safe_open(devicePath().toLocal8Bit().constData(), O_RDWR);
+     if (Q_UNLIKELY(fd < 0))
+         qFatal("Could not open DRM (NV) device");
+ 

--- a/external/qt5-layer/recipes-qt/qt5/qtbase/0002-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase/0002-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
@@ -1,0 +1,121 @@
+From 21c76227755fd8820887997d2abec29d02045018 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kurt.kiefer@arthrex.com>
+Date: Thu, 14 Apr 2022 14:35:32 -0700
+Subject: [PATCH] eglfs: add a default framebuffer to NVIDIA eglstreams
+
+Newer versions of NVIDIA's DRM driver are rejecting the previously
+accepted but non-standard use of framebuffer_id -1 in order to set
+the output mode but not issue a page flip.
+
+This change adds a default framebuffer to the egldevice driver for
+use with the initial calls to set the CRTC mode and plane.
+---
+ .../qeglfskmsegldevicescreen.cpp              | 61 ++++++++++++++++++-
+ .../qeglfskmsegldevicescreen.h                |  3 +
+ 2 files changed, 62 insertions(+), 2 deletions(-)
+
+diff --git a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.cpp b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.cpp
+index 5a62e437c4..f65f675e0f 100644
+--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.cpp
++++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.cpp
+@@ -49,11 +49,68 @@ Q_DECLARE_LOGGING_CATEGORY(qLcEglfsKmsDebug)
+ 
+ QEglFSKmsEglDeviceScreen::QEglFSKmsEglDeviceScreen(QEglFSKmsDevice *device, const QKmsOutput &output)
+     : QEglFSKmsScreen(device, output)
++    , m_default_fb_handle(uint32_t(-1))
++    , m_default_fb_id(uint32_t(-1))
+ {
++    const int fd = device->fd();
++
++    struct drm_mode_create_dumb createRequest;
++    createRequest.width = output.size.width();
++    createRequest.height = output.size.height();
++    createRequest.bpp = 32;
++    createRequest.flags = 0;
++
++    qCDebug(qLcEglfsKmsDebug, "Creating dumb fb %dx%d", createRequest.width, createRequest.height);
++
++    int ret = drmIoctl(fd, DRM_IOCTL_MODE_CREATE_DUMB, &createRequest);
++    if (ret < 0) {
++        qFatal("Unable to create dumb buffer.\n");
++    }
++
++    m_default_fb_handle = createRequest.handle;
++
++    uint32_t handles[4] = { 0, 0, 0, 0 };
++    uint32_t pitches[4] = { 0, 0, 0, 0 };
++    uint32_t offsets[4] = { 0, 0, 0, 0 };
++
++    handles[0] = createRequest.handle;
++	pitches[0] = createRequest.pitch;
++	offsets[0] = 0;
++
++    ret = drmModeAddFB2(fd, createRequest.width, createRequest.height, DRM_FORMAT_ARGB8888, handles,
++			    pitches, offsets, &m_default_fb_id, 0);
++    if (ret) {
++        qErrnoWarning("Unable to add fb\n");
++    }
++
++    qCDebug(qLcEglfsKmsDebug, "Added dumb fb %dx%d handle:%u pitch:%d id:%u", createRequest.width, createRequest.height,
++        createRequest.handle, createRequest.pitch, m_default_fb_id);
+ }
+ 
+ QEglFSKmsEglDeviceScreen::~QEglFSKmsEglDeviceScreen()
+ {
++    int ret;
++    const int fd = device()->fd();
++
++    if (m_default_fb_id != uint32_t(-1)) {
++
++        ret = drmModeRmFB(fd, m_default_fb_id);
++        if (ret) {
++            qErrnoWarning("drmModeRmFB failed");
++        }
++    }
++
++    if (m_default_fb_handle != uint32_t(-1)) {
++
++        struct drm_mode_destroy_dumb destroyRequest;
++        destroyRequest.handle = m_default_fb_handle;
++
++        ret = drmIoctl(fd, DRM_IOCTL_MODE_DESTROY_DUMB, &destroyRequest);
++        if (ret) {
++            qErrnoWarning("DRM_IOCTL_MODE_DESTROY_DUMB failed");
++        }
++    }
++
+     const int remainingScreenCount = qGuiApp->screens().count();
+     qCDebug(qLcEglfsKmsDebug, "Screen dtor. Remaining screens: %d", remainingScreenCount);
+     if (!remainingScreenCount && !device()->screenConfig()->separateScreens())
+@@ -98,7 +155,7 @@ void QEglFSKmsEglDeviceScreen::waitForFlip()
+ 
+         qCDebug(qLcEglfsKmsDebug, "Setting mode");
+         int ret = drmModeSetCrtc(fd, op.crtc_id,
+-                                 uint32_t(-1), 0, 0,
++                                 m_default_fb_id, 0, 0,
+                                  &op.connector_id, 1,
+                                  &op.modes[op.mode]);
+         if (ret)
+@@ -110,7 +167,7 @@ void QEglFSKmsEglDeviceScreen::waitForFlip()
+ 
+         if (op.wants_forced_plane) {
+             qCDebug(qLcEglfsKmsDebug, "Setting plane %u", op.forced_plane_id);
+-            int ret = drmModeSetPlane(fd, op.forced_plane_id, op.crtc_id, uint32_t(-1), 0,
++            int ret = drmModeSetPlane(fd, op.forced_plane_id, op.crtc_id, m_default_fb_id, 0,
+                                       0, 0, w, h,
+                                       0 << 16, 0 << 16, op.size.width() << 16, op.size.height() << 16);
+             if (ret == -1)
+diff --git a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.h b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.h
+index 961398ba3e..0c2185f128 100644
+--- a/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.h
++++ b/src/plugins/platforms/eglfs/deviceintegration/eglfs_kms_egldevice/qeglfskmsegldevicescreen.h
+@@ -53,6 +53,9 @@ public:
+     QPlatformCursor *cursor() const override;
+ 
+     void waitForFlip() override;
++private:
++    uint32_t m_default_fb_handle;
++    uint32_t m_default_fb_id;
+ };
+ 
+ QT_END_NAMESPACE

--- a/external/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-eglfs-Newer-Nvidia-libdrm-provide-device-instead-dri.patch \
+            file://0002-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch \
+"
+
+PACKAGECONFIG:append:tegra = " kms"


### PR DESCRIPTION
This change adds two patches to support tegra devices in qt5 with
the L4T release 32.7.1. The newer version of L4T appears to unify
the capabilities of tegra-udrm and drm-nvdc drivers in the NVIDIA's
libdrm, and this enables us to more easily support Qt using either
method, but does require some fixups.

The first patch is a backport from newer versions of Qt which will
allow the egldevice backend to function with the tegra-udrm. It is
not strictly necessary, but is nice because then users don't have
to worry about removing this driver if they want to e.g. switch
between Weston and Qt.

The second patch adds a default framebuffer to the initial calls
to libdrm to set modes and planes. The default value of -1 that was
used by Qt before wouldn't have been valid for any other platform,
and now it is not valid for tegra either.

Fixes #956

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>