### PR TITLE
external/virtualization-layer: fix libnvidia-container-tools git issue

### DIFF
--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.9.0.bb
@@ -62,7 +62,7 @@ def build_date(d):
 
 # We need to link with libelf, otherwise we need to
 # include bmake-native which does not exist at the moment.
-EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
+EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes COMPILER=${@d.getVar('CC').split()[0]} REVISION=${SRCREV_libnvidia} ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
 
 CFLAGS_prepend = " -I=/usr/include/tirpc "
 


### PR DESCRIPTION
The latest git release adds ownership checks on the git tree when
a git command is invoked from pseudo context, so when the
makefiles are processed during the do_install task, an error is
reported.

Fix this by adding a REVISION variable setting to EXTRA_OEMAKE, and
also include a COMPILER setting to override shell callout to
extract the compiler path.

The following changes were already done to dunfell, and other
dunfell-* branches.

The original fix created by Matt Madison <matt@madison.systems>

Signed-off-by: Konstantin Selyunin <selyunin.k.v.@gmail.com>