### PR TITLE
change: use initramfs link name for tegra_kernel_image

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -44,7 +44,7 @@ def tegra_kernel_image(d):
         return '${DEPLOY_DIR_IMAGE}/${IMAGE_UBOOT}-${MACHINE}.bin'
     if d.getVar('INITRAMFS_IMAGE'):
         if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
-            img = '${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.cboot'
+            img = '${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-{INITRAMFS_LINK_NAME}.cboot'
         else:
             img = '${DEPLOY_DIR_IMAGE}/${INITRD_IMAGE}-${MACHINE}.cboot'
         return img


### PR DESCRIPTION
This change leverages the INITRAMFS_LINK_NAME to 'dynamically' build
the image name returned from tegra_kernel_image method during tegra_flash
building.

This helps avoid build failures if a custom INITRAMFS_LINK_NAME is used
to generate a bundled kernel and ramdisk image.

By default, INITRAMFS_LINK_NAME expands to
```
INITRAMFS_LINK_NAME ?= "initramfs-${KERNEL_ARTIFACT_LINK_NAME}"
```
which would yield:
```
KERNEL_ARTIFACT_LINK_NAME ?= "${MACHINE}"
```
resulting in no change to default behavior.

Signed-off-by: Kevin Vanden Berge <kvandenberge@gmail.com>