### PR TITLE
Fix the nv_bootloader_payload_updater tool - Master Branch

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-configs/nv-l4t-bootloader-config.sh
+++ b/recipes-bsp/tegra-binaries/tegra-configs/nv-l4t-bootloader-config.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This is just a stubbed out script required by the nv_bootloader_payload_updater to complete successfully.
+echo ""

--- a/recipes-bsp/tegra-binaries/tegra-configs_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs_32.7.1.bb
@@ -23,6 +23,7 @@ SRC_URI[x11.sha256sum] = "${X11SUM}"
 SRC_URI += "\
     file://0001-Patch-udev-rules-for-OE-use.patch \
     file://0002-Patch-nv.sh-script-for-OE-use.patch \
+    file://nv-l4t-bootloader-config.sh \
 "
 
 do_install() {
@@ -32,6 +33,9 @@ do_install() {
     install -m 0644 ${S}/etc/udev/rules.d/99-tegra-devices.rules ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/etc/udev/rules.d/99-tegra-mmc-ra.rules ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/etc/udev/rules.d/99-nv-l4t-usb-host-config.rules ${D}${sysconfdir}/udev/rules.d
+
+    install -d ${D}/opt/nvidia/l4t-bootloader-config
+    install -m 0755 ${WORKDIR}/nv-l4t-bootloader-config.sh ${D}/opt/nvidia/l4t-bootloader-config/nv-l4t-bootloader-config.sh
 
     install -d ${D}${sysconfdir}/X11
 
@@ -48,10 +52,12 @@ do_install:append:tegra210() {
     install -m 0644 ${S}/etc/X11/xorg.conf ${D}${sysconfdir}/X11/
 }
 
-PACKAGES = "${PN}-udev ${PN}-omx-tegra ${PN}-xorg ${PN}-nvstartup"
+PACKAGES = "${PN}-udev ${PN}-omx-tegra ${PN}-xorg ${PN}-nvstartup ${PN}-bootloader"
 FILES:${PN}-udev = "${sysconfdir}/udev/rules.d"
 FILES:${PN}-xorg = "${sysconfdir}/X11"
 FILES:${PN}-omx-tegra = "${sysconfdir}/enctune.conf"
 FILES:${PN}-nvstartup = "${sbindir}"
+FILES_${PN}-bootloader = "/opt/nvidia/l4t-bootloader-config/"
 RDEPENDS:${PN}-udev = "udev"
 RDEPENDS:${PN}-nvstartup = "bash"
+RDEPENDS_${PN}-bootloader = "bash"

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_32.7.1.bb
@@ -28,7 +28,7 @@ do_install:tegra210() {
 PACKAGES = "tegra-redundant-boot-nvbootctrl ${PN} ${PN}-dev"
 FILES:tegra-redundant-boot-nvbootctrl = "${sbindir}/nvbootctrl"
 FILES:${PN} += "/opt/ota_package"
-RDEPENDS:${PN} = "tegra-redundant-boot-nvbootctrl setup-nv-boot-control-service"
+RDEPENDS:${PN} = "tegra-redundant-boot-nvbootctrl setup-nv-boot-control-service tegra-configs-bootloader"
 RDEPENDS:${PN}:tegra210 = "setup-nv-boot-control-service python3-core"
 INSANE_SKIP:${PN} = "ldflags"
 RDEPENDS:tegra-redundant-boot-nvbootctrl = "setup-nv-boot-control"


### PR DESCRIPTION
The nv_bootloader_payload_updater tool is dependant on the
_/opt/nvidia/l4t-bootloader-config/nv-l4t-bootloader-config.sh_ being
present in the system to work. This update deploys this script as part
of a new tegra-configs-bootloader package.

Fixes #980 on the master branch

Signed-off-by: Mike Loder <mloder@miovision.com>