### PR TITLE
Fix APT upgrade conflicts with the tegra-libraries

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-camera_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-camera_32.7.1.bb
@@ -71,3 +71,8 @@ FILES_${PN}-nvtunerd = "${sbindir}/nvtunerd"
 RDEPENDS_${PN} = "tegra-argus-daemon"
 
 CONTAINER_CSV_FILES_append = "${@bb.utils.contains('PACKAGECONFIG', 'x11', ' ${libdir}/libv4l/plugins/*', '', d)}"
+
+# This package includes files that were moved from tegra-libraries, tegra-libraries-argus, tegra-libraries-libv4l-plugins
+#  so we need to mark them as conflicts to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries tegra-libraries-argus tegra-libraries-libv4l-plugins"
+RCONFLICTS_${PN} = "tegra-libraries tegra-libraries-argus tegra-libraries-libv4l-plugins"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-core_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-core_32.7.1.bb
@@ -38,3 +38,8 @@ SOC_SPECIFIC_LIBS_tegra210 = ""
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 RRECOMMENDS_${PN} = "kernel-module-nvgpu"
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-cuda_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-cuda_32.7.1.bb
@@ -27,3 +27,8 @@ do_install() {
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 RRECOMMENDS_${PN} = "kernel-module-nvgpu"
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-eglcore_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-eglcore_32.7.1.bb
@@ -23,6 +23,9 @@ do_install() {
 }
 
 pkg_postinst_${PN}() {
+    # Delete old library file / symlink if it exists so the symlink command below does not fail.
+    rm -f $D/usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
+
     # argus and scf libraries hard-coded to use this path
     install -d $D/usr/lib/aarch64-linux-gnu/tegra-egl
     ln $D${libdir}/libEGL_nvidia.so.0 $D/usr/lib/aarch64-linux-gnu/tegra-egl/
@@ -31,3 +34,8 @@ pkg_postinst_${PN}() {
 FILES_${PN} += "${datadir}/glvnd/egl_vendor.d"
 CONTAINER_CSV_FILES += "${datadir}/glvnd/egl_vendor.d/*"
 CONTAINER_CSV_EXTRA = "lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0"
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-glescore_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-glescore_32.7.1.bb
@@ -12,3 +12,8 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
     tegra-egl/libGLESv1_CM_nvidia.so.1 \
     tegra-egl/libGLESv2_nvidia.so.2 \
 "
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_32.7.1.bb
@@ -16,3 +16,8 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
     tegra/libGLX_nvidia.so.0 \
     tegra/libnvidia-glcore.so.${L4T_VERSION} \
 "
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-utils_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-utils_32.7.1.bb
@@ -22,3 +22,8 @@ do_install() {
 	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so
     done
 }
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-v4l_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-v4l_32.7.1.bb
@@ -44,3 +44,8 @@ FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 FILES_${PN} += "${libdir}/libv4l"
 RDEPENDS_${PN} = "libv4l2-nvvidconv-wrapper"
+
+# This package includes files that were moved from tegra-libraries and tegra-libraries-libv4l-plugins so we need to mark
+# them as conflicts to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries tegra-libraries-libv4l-plugins"
+RCONFLICTS_${PN} = "tegra-libraries tegra-libraries-libv4l-plugins"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia_32.7.1.bb
@@ -58,3 +58,8 @@ FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 FILES_${PN}-osd = "${libdir}/libnvosd*"
 RDEPENDS_${PN}-osd = "liberation-fonts"
+
+# This package includes files that were moved from tegra-libraries and tegra-libraries-libnvosd so we need to mark
+# them as conflicts to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries tegra-libraries-libnvosd"
+RCONFLICTS_${PN} = "tegra-libraries tegra-libraries-libnvosd"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-omx_32.7.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-omx_32.7.1.bb
@@ -19,3 +19,8 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
 
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
+
+# This package includes files that were moved from tegra-libraries so we need to mark it as a conflict
+# to have a successful apt upgrade.
+RREPLACES_${PN} = "tegra-libraries"
+RCONFLICTS_${PN} = "tegra-libraries"


### PR DESCRIPTION
The tegra-libraries we all split in to their own recipes however they
conflict with the old tegra-libraries packages when upgrading. This
marks the previous package dependencies as conflicts so they are removed
on an upgrade.

Signed-off-by: Mike Loder <mloder@miovision.com>

_NOTE: I only have a PR for the Dunfell branch as I don't have a setup for the new master yocto with the updated syntax._