### PR TITLE
Remove "blacklist mttcan" from linux-tegra.bb

### DIFF
--- a/recipes-kernel/linux/linux-tegra_5.10.bb
+++ b/recipes-kernel/linux/linux-tegra_5.10.bb
@@ -176,12 +176,6 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""
 
-# XXX--
-#  L4T EA kit disables these kernel modules by default
-KERNEL_MODULE_PROBECONF = "mttcan"
-module_conf_mttcan = "blacklist mttcan"
-# --XXX
-
 # kernel.bbclass automatically adds a dependency on the intramfs image
 # even if INITRAMFS_IMAGE_BUNDLE is disabled.  This creates a circular
 # dependency for tegra builds, where we need to combine initramfs (as an


### PR DESCRIPTION
The module "mttcan" is disabled by default in linux-tegra.bb right now. I don't think it's a good idea for other kernels that derived from this bb file. If I want to let my kernel auto load `mttcan`. I must create something to remove it from blacklist. So I make this PR to enable mttcan by default. It will make this project more compatible. 