### PR TITLE
linux-tegra: update packaging RDEPENDS->RRECOMMENDS

### DIFF
--- a/recipes-kernel/linux/linux-tegra_4.9.bb
+++ b/recipes-kernel/linux/linux-tegra_4.9.bb
@@ -174,7 +174,7 @@ do_deploy[depends] += "${EXTRADEPLOYDEPS}"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-RDEPENDS:${KERNEL_PACKAGE_NAME}-base = "${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else '${KERNEL_PACKAGE_NAME}-image'}"
+RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = "${@'' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else '${KERNEL_PACKAGE_NAME}-image'}"
 
 # kernel.bbclass automatically adds a dependency on the intramfs image
 # even if INITRAMFS_IMAGE_BUNDLE is disabled.  This creates a circular


### PR DESCRIPTION
Upstream kernel.bbclass changed the inclusion of kernel image
artifacts from RDEPENDS to RRECOMMENDS.

Update this recipe accordingly.

Fixes #999

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>