### PR TITLE
tegra-configs-alsa: enable default ALSA config overrides

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-configs-alsa_32.7.2.bb
+++ b/recipes-bsp/tegra-binaries/tegra-configs-alsa_32.7.2.bb
@@ -9,13 +9,14 @@ require tegra-debian-libraries-common.inc
 MAINSUM = "44fa43d9646d66b5c1bb28def9736c3d8cf7a3e21082fbf9017c63246e2b0ae1"
 MAINSUM:tegra210 = "a21c44851b287f0fde245f753fa7f591a2d84f125b111bbf54ae34d7c0f3b255"
 
-do_install() {
-    if [ -n "${TEGRA_AUDIO_DEVICE}" ]; then
-        install -d ${D}${sysconfdir}
-        install -m 0644 ${S}/etc/asound.conf.${TEGRA_AUDIO_DEVICE} ${D}${sysconfdir}/asound.conf
-    fi
+TEGRA_AUDIO_CONFIG ?= "${S}/etc/asound.conf.${TEGRA_AUDIO_DEVICE}"
 
-    install -d ${D}${datadir}/alsa/cards
+do_install() {
+    install -d ${D}${sysconfdir} ${D}${datadir}/alsa/cards
+
+    if [ -n "${TEGRA_AUDIO_CONFIG}" ]; then
+        install -m 0644 ${TEGRA_AUDIO_CONFIG} ${D}${sysconfdir}/asound.conf
+    fi
 }
 
 do_install:append:tegra186() {


### PR DESCRIPTION
The default asound.conf in L4T is only configured on the
Jetson Xavier NX for (card: tegra-hda-xnx, device id: 7).
Which is HDMI Audio Out. One can't hear audio over DP
unless the alsa config is updated to
(card: tegra-hda-xnx, device id: 3).

Commit:

-  Allows for default L4T provided alsa config to
   be overridden
- Adds in a custom alsa config that configures
  audio over both DP and HDMI. Only for machines
  jetson-xavier-nx-devkit-{emmc}

Signed-off-by: Vincent Davis Jr <vince@underview.tech>