### PR TITLE
jetson-agx-orin-devkit: include wifi support by default

### DIFF
--- a/conf/machine/include/devkit-wifi.inc
+++ b/conf/machine/include/devkit-wifi.inc
@@ -1,0 +1,3 @@
+MACHINE_FEATURES += "wifi bluetooth"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtk-btusb kernel-module-rtl8822ce tegra-firmware-rtl8822"
+TEGRA_BT_SUPPORT_PACKAGE ?= ""

--- a/conf/machine/include/xavier-nx.inc
+++ b/conf/machine/include/xavier-nx.inc
@@ -16,10 +16,6 @@ require conf/machine/include/tegra194.inc
 KERNEL_DEVICETREE ?= "tegra194-p3668-all-p3509-0000.dtb"
 KERNEL_ARGS ?= "console=ttyTCU0,115200 console=tty0 fbcon=map:0"
 
-MACHINE_FEATURES += "wifi bluetooth"
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtk-btusb kernel-module-rtl8822ce tegra-firmware-rtl8822"
-TEGRA_BT_SUPPORT_PACKAGE = ""
-
 EMMC_DEVSECT_SIZE ?= "512"
 BOOTPART_SIZE ?= ""
 BOOTPART_LIMIT ?= "10485760"

--- a/conf/machine/jetson-agx-orin-devkit.conf
+++ b/conf/machine/jetson-agx-orin-devkit.conf
@@ -33,3 +33,7 @@ tegra234-p3737-camera-e3331-overlay.dtbo,\
 tegra234-p3737-camera-e3333-overlay.dtbo,\
 tegra234-p3737-camera-imx185-overlay.dtbo,\
 tegra234-p3737-camera-imx390-overlay.dtbo"
+
+MACHINE_FEATURES += "wifi bluetooth"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtk-btusb kernel-module-rtl8822ce tegra-firmware-rtl8822"
+TEGRA_BT_SUPPORT_PACKAGE ?= ""

--- a/conf/machine/jetson-agx-orin-devkit.conf
+++ b/conf/machine/jetson-agx-orin-devkit.conf
@@ -3,6 +3,7 @@
 #@DESCRIPTION: Nvidia Jetson Orin dev board
 
 require conf/machine/include/tegra234.inc
+require conf/machine/include/devkit-wifi.inc
 
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3701 and board=jetson-agx-orin-devkit
 TEGRA_BUPGEN_SPECS ?= "fab=TS4;boardsku=0000;boardrev="
@@ -33,7 +34,3 @@ tegra234-p3737-camera-e3331-overlay.dtbo,\
 tegra234-p3737-camera-e3333-overlay.dtbo,\
 tegra234-p3737-camera-imx185-overlay.dtbo,\
 tegra234-p3737-camera-imx390-overlay.dtbo"
-
-MACHINE_FEATURES += "wifi bluetooth"
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtk-btusb kernel-module-rtl8822ce tegra-firmware-rtl8822"
-TEGRA_BT_SUPPORT_PACKAGE ?= ""

--- a/conf/machine/jetson-xavier-nx-devkit-emmc.conf
+++ b/conf/machine/jetson-xavier-nx-devkit-emmc.conf
@@ -11,6 +11,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0001;boardrev= \
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
 require conf/machine/include/xavier-nx.inc
+require conf/machine/include/devkit-wifi.inc
 
 EMMC_SIZE ?= "15758000128"
 PARTITION_LAYOUT_TEMPLATE ?= "flash_t194_uefi_spi_emmc_p3668.xml"

--- a/conf/machine/jetson-xavier-nx-devkit.conf
+++ b/conf/machine/jetson-xavier-nx-devkit.conf
@@ -11,6 +11,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0000;boardrev= \
 IMAGE_ROOTFS_ALIGNMENT ?= "1024"
 
 require conf/machine/include/xavier-nx.inc
+require conf/machine/include/devkit-wifi.inc
 
 EMMC_SIZE ?= ""
 PARTITION_LAYOUT_TEMPLATE ?= "flash_t194_uefi_spi_sd_p3668.xml"


### PR DESCRIPTION
Similar to the xavier nx devkit, the agx orin devkit includes a
rtl8822ce m.2 pcie wifi+bluetooth radio.

This change adds by default the necessary bits to enable it.

Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>