### PR TITLE
tegra-firmware: Create a symlink for the acr_ucode.bin firmware

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-firmware_32.7.2.bb
+++ b/recipes-bsp/tegra-binaries/tegra-firmware_32.7.2.bb
@@ -29,6 +29,11 @@ do_install:append:tegra210() {
     done
 }
 
+do_install::append:tegra194() {
+    cd ${D}/lib/firmware/gv11b
+    ln -s acr_ucode_prod.bin acr_ucode.bin
+}
+
 PACKAGES = "${PN}-rtl8822 ${PN}-brcm ${PN}-tegra186-xusb ${PN}-tegra194-xusb ${PN}-tegra210-xusb ${PN}-tegra186 ${PN}-tegra194 ${PN}-tegra210 ${PN}-xusb ${PN}"
 FILES:${PN}-brcm = "${nonarch_base_libdir}/firmware/brcm ${nonarch_base_libdir}/firmware/bcm4354.hcd ${nonarch_base_libdir}/firmware/nv-*-Version"
 FILES:${PN}-rtl8822 = "${nonarch_base_libdir}/firmware/rtl8822*"


### PR DESCRIPTION
Using the Jetson Xavier NX, the firmware used for the gv11b is not loaded because it tries to load the file acr_ucode.bin and the only two files available are acr_ucode_dbg.bin and acr_ucode_prod.bin.

Here is the log of the error:
`[   23.011377] gk20a 17000000.gv11b: Direct firmware load for gv11b/acr_ucode.bin failed with error -2`

This patch creates a symlink from acr_ucode.bin to acr_ucode_prod.bin.