### PR TITLE
machine: jetson-nano-devkit: add new fab

### DIFF
--- a/conf/machine/jetson-nano-devkit.conf
+++ b/conf/machine/jetson-nano-devkit.conf
@@ -12,7 +12,7 @@ TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "200"
 TEGRA_BOARDSKU ?= "0000"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3448 and board=jetson-nano-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=100 fab=200 fab=300 fab=400 fab=401"
+TEGRA_BUPGEN_SPECS ?= "fab=100 fab=200 fab=300 fab=400 fab=401 fab=402"
 
 require conf/machine/include/tegra210.inc
 


### PR DESCRIPTION
Add new fab number to TEGRA_BUPGEN_SPECS in order to support mender
updates on newer boards.

Suggested-by: Matt Madison <matt@madison.systems>
Signed-off-by: Bartosz Golaszewski <brgl@bgdev.pl>