### PR TITLE
gstreamer1.0-plugins-nveglgles: fix builds without x11

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0002-Fix-builds-without-x11.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0002-Fix-builds-without-x11.patch
@@ -1,0 +1,25 @@
+From f8603aa8b513452ea5a8c196557b8ac6ad770915 Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kurt.kiefer@arthrex.com>
+Date: Tue, 23 Aug 2022 10:17:08 -0700
+Subject: [PATCH] Fix builds without x11
+
+Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>
+---
+ gst-egl/ext/eglgles/gsteglglessink.c | 2 ++
+ 1 file changed, 2 additions(+)
+
+diff --git a/ext/eglgles/gsteglglessink.c b/ext/eglgles/gsteglglessink.c
+index 87ee57a..6713923 100644
+--- a/ext/eglgles/gsteglglessink.c
++++ b/ext/eglgles/gsteglglessink.c
+@@ -107,8 +107,10 @@
+ #include <gst/video/gstvideopool.h>
+ #include <gst/video/videooverlay.h>
+
++#ifdef USE_EGL_X11
+ #include <X11/Xlib.h>
++#endif
+
+ #include "gstegladaptation.h"
+ #include "video_platform_wrapper.h"
+ 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r35.1.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r35.1.0.bb
@@ -8,7 +8,9 @@ TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/public/gstegl_src.tbz2"
 
 require recipes-bsp/tegra-sources/tegra-sources-35.1.0.inc
 
-SRC_URI += " file://0001-Makefile-fixes-for-OE-builds.patch"
+SRC_URI += " file://0001-Makefile-fixes-for-OE-builds.patch \
+             file://0002-Fix-builds-without-x11.patch \
+"
 
 DEPENDS = "tegra-mmapi gstreamer1.0 glib-2.0-native gstreamer1.0-plugins-base virtual/egl virtual/libgles2 cuda-cudart cuda-driver"
 


### PR DESCRIPTION
Wayland only builds won't have the x11 header files, so only pick
up this header if we expect to have it.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>