### PR TITLE
tegra-common: always add tegraflash as it is the most used image

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -38,7 +38,7 @@ IMAGE_ROOTFS_ALIGNMENT ?= "4"
 TEGRA_BLBLOCKSIZE ?= "${@int(d.getVar('IMAGE_ROOTFS_ALIGNMENT')) * 1024}"
 EXTRA_IMAGECMD:ext4 ?= "-i 4096 -b 4096"
 IMAGE_CLASSES += "image_types_tegra"
-IMAGE_FSTYPES ?= "tegraflash"
+IMAGE_FSTYPES += "tegraflash"
 
 TEGRA_ESSENTIAL_EXTRA_RDEPENDS ??= ""
 MACHINE_FEATURES = "alsa usbhost pci rtc cuda ext2"


### PR DESCRIPTION
Using a weak default for that it is very sensitive and not take effect
in distros that uses other types.

Setting the IMAGE_FSTYPES with a weak default can also introduce circular
dependencies because the tegraflash is lost when something is set in
IMAGE_FSTYPES and adding this again using an append in disto config
add circular dependencies for example in tegra-espimage.

Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>