### PR TITLE
arm-trusted-firmware: work around to fix ld.bfd warning when using bi…

### DIFF
--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
@@ -1,0 +1,37 @@
+From ca2609be9cb644ea09b6c56fe53ba91686315a08 Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ilies.chergui@gmail.com>
+Date: Fri, 26 Aug 2022 21:42:14 +0100
+Subject: [PATCH] workaround to fix ld.bfd warning (binutils version 2.39)
+
+l31.elf has a LOAD segment with RWX permissions
+
+Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 95c9075..60d7177 100644
+--- a/Makefile
++++ b/Makefile
+@@ -437,7 +437,7 @@ TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
+ # LD = gcc (used when GCC LTO is enabled)
+ else ifneq ($(findstring gcc,$(notdir $(LD))),)
+ # Pass ld options with Wl or Xlinker switches
+-TF_LDFLAGS		+=	-Wl,--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	-Wl,--gc-sections
+ ifeq ($(ENABLE_LTO),1)
+ 	ifeq (${ARCH},aarch64)
+@@ -454,7 +454,7 @@ TF_LDFLAGS		+=	$(subst --,-Xlinker --,$(TF_LDFLAGS_$(ARCH)))
+ 
+ # LD = gcc-ld (ld) or llvm-ld (ld.lld) or other
+ else
+-TF_LDFLAGS		+=	--fatal-warnings -O1
++TF_LDFLAGS		+=	-O1
+ TF_LDFLAGS		+=	--gc-sections
+ # ld.lld doesn't recognize the errata flags,
+ # therefore don't add those in that case
+-- 
+2.32.0
+

--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.5-l4t-r35.1.0.bb
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.5-l4t-r35.1.0.bb
@@ -1,5 +1,8 @@
 TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/public/atf_src.tbz2"
 require recipes-bsp/tegra-sources/tegra-sources-35.1.0.inc
+
+SRC_URI += "file://0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch"
+
 S = "${WORKDIR}/arm-trusted-firmware"
 
 def generate_build_string(d):


### PR DESCRIPTION
…nutils

version 2.39

aarch64-oe4t-linux-ld.bfd: warning: bl31.elf has a LOAD segment with RWX permissions

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>