### PR TITLE
Build nvdisp-init from source

### DIFF
--- a/recipes-bsp/cboot/cboot-l4t.inc
+++ b/recipes-bsp/cboot/cboot-l4t.inc
@@ -1,0 +1,64 @@
+LICENSE = "MIT & BSD-2-Clause & BSD-3-Clause & Apache-2.0 & Zlib & Proprietary"
+LIC_FILES_CHKSUM = " \
+    file://bootloader/partner/t18x/cboot/target/init.c;endline=22;md5=59dc0a752bc93e442d4ec3de8b1d8614 \
+    file://bootloader/partner/t18x/cboot/kernel/semaphore.c;endline=15;md5=ff935df987c4efa30f6c5462f708f1a4 \
+    file://bootloader/partner/common/lib/external/mbedtls/bignum.c;endline=35;md5=84d5feb35adf77539b8a50b9497ea92a \
+    file://bootloader/partner/common/lib/external/asn1/asn1_decoder.c;endline=23;md5=3f072eb94ef35fa574edc8b2dd5931c1 \
+    file://bootloader/partner/common/lib/external/lz4/lz4.c;endline=33;md5=374dbaf7e07d3845e06cbab8589578e9 \
+    file://bootloader/partner/common/lib/external/mincrypt/sha.c;endline=34;md5=4a0fce84ffc9e3901a9fb2e2a290e7b8 \
+    file://bootloader/partner/common/lib/external/zlib/zlib.h;beginline=6;endline=23;md5=5377232268e952e9ef63bc555f7aa6c0 \
+    file://LICENSE.cboot.txt;md5=972762a86d83ebd2df0b07be8d084935 \
+"
+
+SRC_TARBALL ??= "INVALID"
+
+PROVIDES += "cboot"
+
+S = "${WORKDIR}/${BP}"
+B = "${WORKDIR}/build"
+
+TARGET_SOC ??= "INVALID"
+
+EXTRA_GLOBAL_DEFINES = "${PACKAGECONFIG_CONFARGS}"
+EXTRA_OEMAKE = 'TEGRA_TOP=${S} GLOBAL_CFLAGS="${CBOOT_CFLAGS}" CFLAGS= CPPFLAGS= LDFLAGS= PROJECT=${TARGET_SOC} TOOLCHAIN_PREFIX="${TARGET_PREFIX}" DEBUG=2 \
+                BUILDROOT="${B}" NV_TARGET_BOARD=t194ref NV_BUILD_SYSTEM_TYPE=l4t EXTRA_GLOBAL_DEFINES="${EXTRA_GLOBAL_DEFINES}"'
+
+CBOOT_PREFIX_MAP ?= "-fmacro-prefix-map=${WORKDIR}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
+CBOOT_CFLAGS ?= "${CBOOT_PREFIX_MAP}"
+CBOOT_BUILD_ARTIFACT ?= "build-${TARGET_SOC}/lk.bin"
+CBOOT_IMAGE ?= "cboot-${MACHINE}-${PV}-${PR}.bin"
+CBOOT_SYMLINK ?= "cboot-${MACHINE}.bin"
+
+inherit python3native deploy nopackages
+
+def cboot_version_number(d):
+    ver = d.getVar('PV').split('.')
+    return '%02d.%02d.%02d' % (int(ver[0]), int(ver[1]), int(ver[2]))
+
+CBOOT_VERSION ?= "${@cboot_version_number(d)}${TARGET_VENDOR}"
+
+do_configure() {
+    sed -i -r -e'/^BUILD_BRANCH/d' -e'/^BUILD_DATE/d' \
+              -e's,^(BUILD_VERSION :=).*,BUILD_VERSION := ${CBOOT_VERSION},' \
+        ${S}/bootloader/partner/t18x/cboot/build/version.mk
+}
+do_configure[cleandirs] = "${B}"
+
+do_compile() {
+    LIBGCC=`${CC} -print-libgcc-file-name`
+    oe_runmake -C ${S}/bootloader/partner/t18x/cboot LIBGCC="$LIBGCC"
+}
+
+do_install() {
+	:
+}
+
+do_deploy() {
+	install -d ${DEPLOYDIR}
+	install -m 0644 ${B}/${CBOOT_BUILD_ARTIFACT} ${DEPLOYDIR}/${CBOOT_IMAGE}
+	ln -sf ${CBOOT_IMAGE} ${DEPLOYDIR}/${CBOOT_SYMLINK}
+}
+
+addtask deploy before do_build after do_install
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/cboot/nvdisp-init/0001-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0001-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
@@ -1,0 +1,30 @@
+From 15503b672487ecf1ce2d19b0b48c1d29544b93c8 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Tue, 2 Feb 2021 09:43:51 -0800
+Subject: [PATCH 01/17] Drop mistaken global variable definition in sdmmc_defs
+
+which looks like it was meant to be a typedef, but the
+code actually uses the struct tag in all declarations,
+so dropping the type name is OK.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h b/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
+index 0130ad8..77e86fc 100644
+--- a/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
++++ b/bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h
+@@ -224,7 +224,7 @@ struct tegrabl_sdmmc {
+ 	bnum_t last_xfer_blocks;
+ 	void *last_xfer_buf;
+ 
+-} sdmmc_context_t;
++};
+ 
+ #define SDMMC_BLOCK_SIZE_LOG2			9U	/* 512 bytes */
+ 
+-- 
+2.34.1
+

--- a/recipes-bsp/cboot/nvdisp-init/0002-Convert-Python-scripts-to-Python3.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0002-Convert-Python-scripts-to-Python3.patch
@@ -1,0 +1,46 @@
+From a7be873804ac6a4f0d3be1af0169b904ad7fed88 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Wed, 22 Jan 2020 06:57:17 -0800
+Subject: [PATCH 02/17] Convert Python scripts to Python3
+
+---
+ bootloader/partner/t18x/cboot/build/get_branch_name.py    | 4 ++--
+ bootloader/partner/t18x/cboot/scripts/add_version_info.py | 4 ++--
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/bootloader/partner/t18x/cboot/build/get_branch_name.py b/bootloader/partner/t18x/cboot/build/get_branch_name.py
+index 5681de0..5cf4647 100755
+--- a/bootloader/partner/t18x/cboot/build/get_branch_name.py
++++ b/bootloader/partner/t18x/cboot/build/get_branch_name.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ # Copyright (c) 2018-2019, NVIDIA Corporation.  All rights reserved.
+ #
+@@ -21,5 +21,5 @@ projects = collection.getElementsByTagName("default")
+ 
+ for prj in projects:
+     if prj.getAttribute("remote") == "origin":
+-        print prj.getAttribute("revision")
++        print(prj.getAttribute("revision"))
+         break
+diff --git a/bootloader/partner/t18x/cboot/scripts/add_version_info.py b/bootloader/partner/t18x/cboot/scripts/add_version_info.py
+index 1c90bc5..19f0062 100755
+--- a/bootloader/partner/t18x/cboot/scripts/add_version_info.py
++++ b/bootloader/partner/t18x/cboot/scripts/add_version_info.py
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env python
++#!/usr/bin/env python3
+ 
+ ##########################################################################
+ # Usage : add_version_info.py <par1> [par2] ... <parN-1> <parN>
+@@ -40,4 +40,4 @@ if __name__ == "__main__":
+         version_string = '-'.join([str(item) for item in text])
+         sys.stdout.write('Appending version string: %s to %s\n' %
+                                         (version_string, binfile))
+-        f.write(struct.pack('%ds' % (length), version_string))
++        f.write(struct.pack('%ds' % (length), version_string.encode('utf-8')))
+-- 
+2.34.1
+

--- a/recipes-bsp/cboot/nvdisp-init/0003-macros.mk-fix-GNU-make-4.3-compatibility.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0003-macros.mk-fix-GNU-make-4.3-compatibility.patch
@@ -1,0 +1,31 @@
+From 5ed3d5fc3f3003f5f244ecdb9cc93bdbddc8bfcb Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Tue, 17 Nov 2020 05:12:29 -0800
+Subject: [PATCH 03/17] macros.mk: fix GNU make 4.3 compatibility
+
+Backport of lk upstream commit
+77f5dac5252a9c1a28baab6224431a06b475dba1.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/t18x/cboot/make/macros.mk | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/bootloader/partner/t18x/cboot/make/macros.mk b/bootloader/partner/t18x/cboot/make/macros.mk
+index b489007..c6165cd 100644
+--- a/bootloader/partner/t18x/cboot/make/macros.mk
++++ b/bootloader/partner/t18x/cboot/make/macros.mk
+@@ -11,8 +11,8 @@ LOCALIZE_DIR = $(subst $(abspath $(TEGRA_TOP))/,,$(abspath $(1)))
+ TOBUILDDIR = $(abspath $(addprefix $(BUILDDIR)/,$(call LOCALIZE_DIR,$(1))))
+ 
+ COMMA := ,
+-SPACE :=
+-SPACE +=
++E :=
++SPACE := $E $E
+ 
+ # test if two files are different, replacing the first
+ # with the second if so
+-- 
+2.34.1
+

--- a/recipes-bsp/cboot/nvdisp-init/0004-Restore-version-number-to-L4T-builds.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0004-Restore-version-number-to-L4T-builds.patch
@@ -1,0 +1,38 @@
+From 43ae1b6340c8e6ff7d218f0fb89132e89b2d7b63 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Wed, 18 Nov 2020 05:02:56 -0800
+Subject: [PATCH 04/17] Restore version number to L4T builds
+
+The stock makefiles omit the version number for L4T builds,
+since they default to using a git hash that isn't available
+in the L4T source distribution.
+
+Since we already patch the makefiles to construct a version
+number (from the L4T version), we can drop the conditional
+that omits it, so it's easier to tell what version of cboot
+is being used.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ bootloader/partner/t18x/cboot/make/build.mk | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/bootloader/partner/t18x/cboot/make/build.mk b/bootloader/partner/t18x/cboot/make/build.mk
+index 3053c7f..cd14f27 100644
+--- a/bootloader/partner/t18x/cboot/make/build.mk
++++ b/bootloader/partner/t18x/cboot/make/build.mk
+@@ -4,11 +4,7 @@ $(OUTBIN): $(OUTELF)
+ 	@echo generating image: $@
+ 	$(NOECHO)$(SIZE) $<
+ 	$(NOECHO)$(OBJCOPY) -O binary $< $@
+-ifeq ($(NV_BUILD_SYSTEM_TYPE),l4t)
+-	$(NOECHO)$(APPEND_VERSION) $(PROJECT) $(VERSION_MAX_LEN) $@
+-else
+ 	$(NOECHO)$(APPEND_VERSION) $(BUILD_VERSION) $(PROJECT) $(VERSION_MAX_LEN) $@
+-endif
+ 
+ $(OUTELF).hex: $(OUTELF)
+ 	@echo generating hex file: $@
+-- 
+2.34.1
+

--- a/recipes-bsp/cboot/nvdisp-init/0005-nvdisp-init.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0005-nvdisp-init.patch
@@ -1,0 +1,612 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+
+--- a/bootloader/partner/common/drivers/pmic/max77620/tegrabl_pmic_max77620.c
++++ b/bootloader/partner/common/drivers/pmic/max77620/tegrabl_pmic_max77620.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2016-2017, NVIDIA CORPORATION.  All rights reserved.
++ * Copyright (c) 2016-2022, NVIDIA CORPORATION.  All rights reserved.
+  *
+  * NVIDIA CORPORATION and its licensors retain all intellectual property
+  * and proprietary rights in and to this software, related documentation
+@@ -658,11 +658,12 @@
+ 	}
+ 
+ 	/* Set fdt offset */
++	//TCW Note: node name in newer DTB is "/bpmp/i2c/spmic", was "/bpmp_i2c/spmic" 
+ 	internal_node_offset = 0;
+ 	if (TEGRABL_NO_ERROR != tegrabl_dt_get_node_with_path(
+-									fdt, "/bpmp_i2c/spmic",
+-									&internal_node_offset)) {
+-		pr_error("Cannot find DT node for 'bpmp_i2c' (pmic max77620)\n");
++					fdt, "/bpmp/i2c/spmic",		//tcw
++					&internal_node_offset)) {
++		pr_error("Cannot find DT node for 'bpmp/i2c' (pmic max77620)\n");
+ 		goto fail;
+ 	}
+ 
+--- a/bootloader/partner/common/drivers/qspi/tegrabl_qspi.c
++++ b/bootloader/partner/common/drivers/qspi/tegrabl_qspi.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2015-2019, NVIDIA CORPORATION.  All rights reserved.
++ * Copyright (c) 2015-2022, NVIDIA CORPORATION.  All rights reserved.
+  *
+  * NVIDIA CORPORATION and its licensors retain all intellectual property
+  * and proprietary rights in and to this software, related documentation
+@@ -143,6 +143,19 @@
+ 	uint32_t rate = 0U;
+ 	uint32_t flag = 0U;
+ 	bool is_pllc4 = false;
++
++	//TCW Print out some clock data, force 133MHZ
++	//This allows XNX to init QSPI correctly and find all partitions, etc.
++	pr_info("%s: qparams clk_src = %u, clk_div = %d, clk_src_freq = %u, interface_freq = %u\n",
++		__func__, qparams->clk_src, qparams->clk_div,
++		qparams->clk_src_freq, qparams->interface_freq);
++
++	if (qparams->interface_freq < 133000000U) {
++		qparams->interface_freq = 133000000U;
++		pr_info("%s: FORCING INTERFACE_FREQ TO %u!!\n", __func__, qparams->interface_freq);
++	}
++	//TCW ends
++
+ 	switch (qparams->clk_src) {
+ 	case 0:
+ 		/* handling this case to keep it backward compatible */
+@@ -356,8 +369,11 @@
+ 		return err;
+ 	}
+ 
+-	pr_trace("tx_clk_tap_delay : %u\n", qparams->trimmer1_val);
+-	pr_trace("rx_clk_tap_delay : %u\n", qparams->trimmer2_val);
++	//TCW RX Clock tap delay s/b 0x10, I can't find where it s/b set.
++	//Force it here
++	qparams->trimmer2_val = 16;
++	pr_info("tx_clk_tap_delay : %u\n", qparams->trimmer1_val);
++	pr_info("rx_clk_tap_delay : %u\n", qparams->trimmer2_val);
+ 
+ 	/* Program trimmer values based on params */
+ 	reg =
+--- a/bootloader/partner/common/drivers/usbh/tegrabl_xusbh_fw.c
++++ b/bootloader/partner/common/drivers/usbh/tegrabl_xusbh_fw.c
+@@ -1,4 +1,4 @@
+-/* Copyright (c) 2018-2021 NVIDIA Corporation.  All rights reserved.
++/* Copyright (c) 2018-2022 NVIDIA Corporation.  All rights reserved.
+  *
+  * NVIDIA Corporation and its licensors retain all intellectual property
+  * and proprietary rights in and to this software and related documentation
+@@ -144,9 +144,10 @@
+ {
+ 	tegrabl_error_t err = TEGRABL_NO_ERROR;
+ 	char partition_name[TEGRABL_GPT_MAX_PARTITION_NAME + 1];
+-	uint32_t active_slot = BOOT_SLOT_A;
+ 	struct tegrabl_partition part;
+-
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	uint32_t active_slot = BOOT_SLOT_A;
++#endif	//tcw
+ 	strcpy(partition_name, "xusb-fw");
+ #if defined(CONFIG_ENABLE_A_B_SLOT)
+ 	err = tegrabl_a_b_get_active_slot(NULL, &active_slot);
+@@ -190,7 +191,6 @@
+ 	uint8_t *fw_data;
+ 	uint64_t fw_base;
+ 	char partition_name[TEGRABL_GPT_MAX_PARTITION_NAME + 1];
+-	uint32_t active_slot = BOOT_SLOT_A;
+ 	dma_addr_t dma_buf;
+ 	uint32_t reg_val;
+ 	uint32_t code_tag_blocks;
+@@ -198,6 +198,9 @@
+ 	uint32_t timeout;
+ 	uint32_t part_size;
+ 	char *buffer;
++#if defined(CONFIG_ENABLE_A_B_SLOT)
++	uint32_t active_slot = BOOT_SLOT_A;
++#endif	//tcw
+ 
+ 	/* ARU reset..this is done in kernel code */
+ 	NV_WRITE32(NV_ADDRESS_MAP_XUSB_HOST_CFG_BASE + 0x42c, 0x1);
+--- a/bootloader/partner/common/lib/linuxboot/extlinux_boot.c
++++ b/bootloader/partner/common/lib/linuxboot/extlinux_boot.c
+@@ -1,5 +1,5 @@
+ /**
+- * Copyright (c) 2019-2021, NVIDIA Corporation.  All Rights Reserved.
++ * Copyright (c) 2019-2022, NVIDIA Corporation.  All Rights Reserved.
+  *
+  * NVIDIA Corporation and its licensors retain all intellectual property and
+  * proprietary rights in and to this software and related documentation.  Any
+@@ -373,12 +373,12 @@
+ 											uint32_t *load_size,
+ 											bool *loaded_from_rootfs)
+ {
+-	uint32_t sigheader_size = 0;
+ 	uint32_t file_size;
+ 	void *load_addr;
+ 	tegrabl_error_t err = TEGRABL_NO_ERROR;
+ 
+ #if defined(CONFIG_ENABLE_SECURE_BOOT)
++	uint32_t sigheader_size = 0;			//tcw move down here
+ 	char sig_file_path[FS_MAX_PATH_LEN];
+ 	uint32_t sig_file_size;
+ 	bool fail_flag = false;
+--- a/bootloader/partner/common/lib/linuxboot/rules.mk
++++ b/bootloader/partner/common/lib/linuxboot/rules.mk
+@@ -25,16 +25,17 @@
+ 	$(LOCAL_DIR)/../../../t18x/cboot/lib/lwip/include
+ 
+ MODULE_DEPS += \
++	$(LOCAL_DIR)/../../../t18x/common/lib/partitionloader \
+ 	$(LOCAL_DIR)/../libfdt \
+ 	$(LOCAL_DIR)/../devicetree \
+-	$(LOCAL_DIR)/../board_info \
+-	$(LOCAL_DIR)/../plugin_manager \
+-	$(LOCAL_DIR)/../external/libufdt \
+-	$(LOCAL_DIR)/../odmdata \
+-	$(LOCAL_DIR)/../../../t18x/common/lib/partitionloader \
+ 	$(LOCAL_DIR)/../decompress \
++	$(LOCAL_DIR)/../odmdata \
++	$(LOCAL_DIR)/../board_info \
+ 	$(LOCAL_DIR)/../file_manager
+ 
++#	$(LOCAL_DIR)/../plugin_manager \
++#	$(LOCAL_DIR)/../external/libufdt \
++
+ ifneq ($(filter t18x, $(TARGET_FAMILY)),)
+ MODULE_DEPS += \
+ 	$(LOCAL_DIR)/../a_b_boot
+@@ -46,18 +47,20 @@
+ 
+ MODULE_SRCS += \
+ 	$(LOCAL_DIR)/cmdline.c \
+-	$(LOCAL_DIR)/dtb_update.c \
+-	$(LOCAL_DIR)/dtb_overlay.c \
+ 	$(LOCAL_DIR)/../../../$(TARGET_FAMILY)/common/lib/linuxboot/$(TARGET)/linuxboot_helper.c \
+ 	$(LOCAL_DIR)/linuxboot_utils.c \
+ 	$(LOCAL_DIR)/fixed_boot.c \
+ 	$(LOCAL_DIR)/linux_load.c
+ 
++#	$(LOCAL_DIR)/dtb_update.c \
++#	$(LOCAL_DIR)/dtb_overlay.c \
++
+ ifneq ($(filter t19x, $(TARGET_FAMILY)),)
+ MODULE_SRCS += \
+-	$(LOCAL_DIR)/removable_boot.c \
+-	$(LOCAL_DIR)/net_boot.c \
+ 	$(LOCAL_DIR)/extlinux_boot.c
+ endif
+ 
++#	$(LOCAL_DIR)/removable_boot.c \
++#	$(LOCAL_DIR)/net_boot.c \
++
+ include make/module.mk
+--- a/bootloader/partner/common/lib/partition_manager/tegrabl_partition_manager.c
++++ b/bootloader/partner/common/lib/partition_manager/tegrabl_partition_manager.c
+@@ -141,7 +141,7 @@
+ 	}
+ 
+ 	if (partition_info == NULL) {
+-		pr_debug("Cannot find partition %s\n", partition_name);
++		pr_error("Cannot find partition %s\n", partition_name);
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NOT_FOUND, AUX_INFO_PARTITION_NOT_FOUND);
+ 		(void)memset(partition, 0x0, sizeof(*partition));
+ 		goto fail;
+@@ -314,7 +314,7 @@
+ 	partition_info = partition->partition_info;
+ 
+ 	if (partition_info == NULL) {
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		goto fail;
+ 	}
+ 
+@@ -345,7 +345,7 @@
+ 
+ 	if ((partition_info == NULL) || (partition->block_device == NULL)) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NOT_INITIALIZED, 2);
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		goto fail;
+ 	}
+ 
+@@ -380,7 +380,7 @@
+ 
+ 	if ((partition_info == NULL) || (partition->block_device == NULL)) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NOT_INITIALIZED, 3);
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		goto fail;
+ 	}
+ 
+@@ -389,7 +389,7 @@
+ 
+ 	if (partition_info->total_size < (num_bytes + partition->offset)) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_OVERFLOW, 0);
+-		pr_debug("Cannot write beyond partition boundary for %s\n",
++		pr_error("Cannot write beyond partition boundary for %s\n",
+ 				 partition_info->name);
+ 		goto fail;
+ 	}
+@@ -426,7 +426,7 @@
+ 
+ 	if (partition_info == NULL) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NOT_INITIALIZED, 4);
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		goto fail;
+ 	}
+ 
+@@ -500,7 +500,7 @@
+ 
+ 	if ((partition_info == NULL) || (partition->block_device == NULL)) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NOT_INITIALIZED, 5);
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		goto fail;
+ 	}
+ 
+@@ -571,13 +571,13 @@
+ 	partition_info = partition->partition_info;
+ 
+ 	if ((partition_info == NULL) || (partition->block_device == NULL)) {
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		err = TEGRABL_ERROR(TEGRABL_ERR_INVALID, 8);
+ 		goto fail;
+ 	}
+ 
+ 	if (partition_info->num_sectors < (start_sector + num_sectors)) {
+-		pr_debug("Cannot read beyond partition boundary for %s\n",
++		pr_error("Cannot read beyond partition boundary for %s\n",
+ 				 partition_info->name);
+ 		err = TEGRABL_ERROR(TEGRABL_ERR_INVALID, 9);
+ 		goto fail;
+@@ -625,13 +625,13 @@
+ 	partition_info = partition->partition_info;
+ 
+ 	if ((partition_info == NULL) || (partition->block_device == NULL)) {
+-		pr_debug("Partition handle is not initialized appropriately.\n");
++		pr_error("Partition handle is not initialized appropriately.\n");
+ 		err = TEGRABL_ERROR(TEGRABL_ERR_INVALID, 12);
+ 		goto fail;
+ 	}
+ 
+ 	if (partition_info->num_sectors < (start_sector + num_sectors)) {
+-		pr_debug("Cannot write beyond partition boundary for %s\n",
++		pr_error("Cannot write beyond partition boundary for %s\n",
+ 				 partition_info->name);
+ 		err = TEGRABL_ERROR(TEGRABL_ERR_INVALID, 13);
+ 		goto fail;
+@@ -694,7 +694,7 @@
+ 				storage_info = tegrabl_malloc(sizeof(*storage_info));
+ 				if (storage_info == NULL) {
+ 					error = TEGRABL_ERROR(TEGRABL_ERR_NO_MEMORY, 0);
+-					pr_debug("Failed to allocate memory for storage info\n");
++					pr_error("Failed to allocate memory for storage info\n");
+ 					goto fail;
+ 				}
+ 				storage_info->partitions = partitions;
+@@ -718,7 +718,7 @@
+ 		dev->published = (error == TEGRABL_NO_ERROR);
+ 
+ 		if (TEGRABL_NO_ERROR != error) {
+-			pr_debug("Failed to publish %08x\n", dev->device_id);
++			pr_error("Failed to publish %08x\n", dev->device_id);
+ 		}
+ 	}
+ 
+@@ -741,7 +741,7 @@
+ 
+ 		if (storage_list == NULL) {
+ 			error = TEGRABL_ERROR(TEGRABL_ERR_NOT_INITIALIZED, 0);
+-			pr_debug("Partition manager might not be initialized.\n");
++			pr_error("Partition manager might not be initialized.\n");
+ 			goto fail;
+ 		}
+ 
+@@ -773,7 +773,7 @@
+ 
+ 	if (storage_list == NULL) {
+ 		error = TEGRABL_ERROR(TEGRABL_ERR_NO_MEMORY, 1);
+-		pr_debug("Failed to allocate memory for storage info list.\n");
++		pr_error("Failed to allocate memory for storage info list.\n");
+ 		goto fail;
+ 	}
+ 
+--- a/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c
++++ b/bootloader/partner/t18x/cboot/app/kernel_boot/kernel_boot.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2016-2021, NVIDIA Corporation.	All Rights Reserved.
++ * Copyright (c) 2016-2022, NVIDIA Corporation.	All Rights Reserved.
+  *
+  * NVIDIA Corporation and its licensors retain all intellectual property and
+  * proprietary rights in and to this software and related documentation.  Any
+@@ -51,7 +51,7 @@
+ 
+ #define LOCAL_TRACE 0
+ 
+-#if defined(CONFIG_ENABLE_DISPLAY)
++#if defined(CONFIG_ENABLE_DISPLAY) && defined(CONFIG_ENABLE_NVBLOB)
+ static tegrabl_error_t display_boot_logo(void)
+ {
+ 	struct tegrabl_image_info image;
+@@ -77,12 +77,16 @@
+ }
+ #endif
+ 
++//tcw Start of UEFI code in combo nvdisp-init+UEFI binary
++extern uintptr_t uefi_start;
++
+ tegrabl_error_t load_and_boot_kernel(struct tegrabl_kernel_bin *kernel)
+ {
+ 	void *kernel_entry_point = NULL;
+ 	void *kernel_dtb = NULL;
+ 	void (*kernel_entry)(uint64_t x0, uint64_t x1, uint64_t x2,
+ 						 uint64_t x3);
++#if defined(CONFIG_ENABLE_KERNEL_BOOT)				//tcw Skip!
+ 	tegrabl_error_t err = TEGRABL_NO_ERROR;
+ 	struct tegrabl_kernel_load_callbacks callbacks;
+ 
+@@ -95,8 +99,9 @@
+ 	kernel->load_from_storage = true;
+ 
+ 	err = tegrabl_load_kernel_and_dtb(kernel, &kernel_entry_point,
+-						  &kernel_dtb, &callbacks, NULL, 0);
+-
++				  &kernel_dtb, &callbacks, NULL, 0);
++#endif	//tcw KERNEL_BOOT
++#if defined(CONFIG_ENABLE_A_B_SLOT)
+ 	/*
+ 	 * Update smd if a/b retry counter changed
+ 	 * The slot priorities are rotated here too,
+@@ -110,12 +115,12 @@
+ 		tegrabl_reset();
+ 		return err;
+ 	}
+-
++#endif	// ENABLE_A_B_SLOT
+ #if defined(CONFIG_OS_IS_ANDROID)
+ 	tegrabl_send_tos_param();
+ #endif
+ 
+-#if defined(CONFIG_ENABLE_DISPLAY)
++#if defined(CONFIG_ENABLE_DISPLAY) && defined(CONFIG_ENABLE_NVBLOB)
+ 	err = display_boot_logo();
+ 	if (err != TEGRABL_NO_ERROR)
+ 		pr_warn("Boot logo display failed...\n");
+@@ -125,7 +130,8 @@
+ 	tegrabl_profiler_record("kernel_boot exit", 0, DETAILED);
+ #endif
+ 
+-	pr_info("Kernel EP: %p, DTB: %p\n", kernel_entry_point, kernel_dtb);
++	//tcw after boot logo, jump to UEFI binary entry point ...
++	kernel_entry_point = (void *)uefi_start;
+ 
+ 	platform_uninit();
+ 
+@@ -135,6 +141,9 @@
+ 	 * as device accesses when the MMU is off, and device memory doesn't
+ 	 * support unaligned accesses.
+ 	 */
++#ifdef	DEBUG
++	pr_info("%s: Jumping to UEFI @ %p ...\n", __func__, kernel_entry_point);
++#endif
+ 	kernel_entry = (void *)kernel_entry_point;
+ 	kernel_entry((uint64_t)kernel_dtb, 0, 0, 0);
+ 
+--- a/bootloader/partner/t18x/cboot/platform/t194/l4t.mk
++++ b/bootloader/partner/t18x/cboot/platform/t194/l4t.mk
+@@ -1,5 +1,5 @@
+ #
+-# Copyright (c) 2017-2021, NVIDIA CORPORATION.  All rights reserved.
++# Copyright (c) 2017-2022, NVIDIA CORPORATION.  All rights reserved.
+ #
+ # NVIDIA CORPORATION and its licensors retain all intellectual property
+ # and proprietary rights in and to this software and related documentation
+@@ -11,22 +11,8 @@
+ # Add any needed GLOBAL_DEFINES here
+ GLOBAL_DEFINES += \
+ 	CONFIG_OS_IS_L4T=1 \
+-	CONFIG_ENABLE_BOOT_DEVICE_SELECT=1 \
+-	CONFIG_ENABLE_SDCARD=1 \
+-	CONFIG_ENABLE_USB_MS=1 \
+-	CONFIG_ENABLE_USB_SD_BOOT=1 \
+-	CONFIG_ENABLE_NVME_BOOT=1 \
+-	CONFIG_ENABLE_ETHERNET_BOOT=1 \
+-	CONFIG_ENABLE_SECURE_BOOT=1 \
+ 	CONFIG_ENABLE_DISPLAY=1 \
+-	CONFIG_ENABLE_SHELL=1 \
+-	CONFIG_ENABLE_L4T_RECOVERY=1 \
+-	CONFIG_ENABLE_EXTLINUX_BOOT=1
+-
+-MODULE_DEPS +=	\
+-	lib/lwip \
+-	lib/console
++	CONFIG_ENABLE_NVDISP_INIT=1 \
++	CONFIG_NVDISP_SIZE=0x60000 \
++	CONFIG_NVDISP_UEFI_SIZE=0x300000
+ 
+-MODULE_DEPS += \
+-	$(LOCAL_DIR)/../../../../common/drivers/eqos \
+-	$(LOCAL_DIR)/../../../../common/drivers/phy
+--- a/bootloader/partner/t18x/cboot/platform/t194/platform.c
++++ b/bootloader/partner/t18x/cboot/platform/t194/platform.c
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2020, NVIDIA CORPORATION.  All rights reserved.
++ * Copyright (c) 2017-2022, NVIDIA CORPORATION.  All rights reserved.
+  *
+  * NVIDIA CORPORATION and its licensors retain all intellectual property
+  * and proprietary rights in and to this software, related documentation
+@@ -95,6 +95,12 @@
+ extern int __version_start;
+ 
+ extern int _end;
++
++#ifdef CONFIG_ENABLE_NVDISP_INIT
++extern int _start;
++uintptr_t uefi_start;
++#endif
++
+ struct tboot_cpubl_params *boot_params;
+ 
+ #define CPUBL_PARAMS_SIZE	(64 * 1024LLU)
+@@ -346,9 +352,13 @@
+ 		tegrabl_debug_deinit();
+ 	}
+ 
+-
++#if defined(CONFIG_ENABLE_NVDISP_INIT)
++	pr_info("Welcome to NVDisp-Init\n");
++	pr_info("NVDisp-Init version: %s\n", (char *) &__version_start);
++#else
+ 	pr_info("Welcome to Cboot\n");
+ 	pr_info("Cboot Version: %s\n", (char *) &__version_start);
++#endif
+ 	pr_info("CPU-BL Params @ %p\n", boot_params);
+ 
+ 	for (carveout = 0; carveout < CARVEOUT_NUM; carveout++) {
+@@ -553,7 +563,9 @@
+ #if defined(CONFIG_DT_SUPPORT)
+ 	void *bl_dtb = NULL;
+ #endif
++#if defined(CONFIG_ENABLE_CBO_FILE)		//tcw
+ 	bool is_cbo_read = true;
++#endif						//tcw
+ 	bool hang_up = false;
+ 
+ #if defined(CONFIG_ENABLE_STAGED_SCRUBBING)
+@@ -618,6 +630,8 @@
+ 		pr_error("GPIO driver init failed\n");
+ 		goto fail;
+ 	}
++#endif
++#if defined(CONFIG_ENABLE_GPIO_TCA9539)			//tcw
+ 	err = tegrabl_tca9539_init();
+ 	if (err != TEGRABL_NO_ERROR) {
+ 		pr_error("GPIO TCA9539 driver init failed\n");
+@@ -626,7 +640,7 @@
+ 		 * goto fail;
+ 		 */
+ 	}
+-#endif
++#endif		//tcw
+ 
+ 	err = platform_init_power();
+ 	if (TEGRABL_NO_ERROR != err) {
+@@ -668,7 +682,7 @@
+ 		pr_warn("display init failed\n");
+ 	}
+ #endif
+-
++#if defined(CONFIG_ENABLE_CBO_FILE)		//tcw
+ 	pr_info("Load in CBoot Boot Options partition and parse it\n");
+ 	err = tegrabl_read_cbo(CBO_PARTITION);
+ 	if (err != TEGRABL_NO_ERROR) {
+@@ -677,7 +691,7 @@
+ 	}
+ 
+ 	(void)tegrabl_cbo_parse_info(is_cbo_read);
+-
++#endif	//tcw
+ #if defined(CONFIG_ENABLE_SHELL)
+ 	enter_shell_upon_user_request();
+ #endif
+@@ -696,6 +710,14 @@
+ 	size_t heap_size;
+ 
+ 	heap_start = (uintptr_t)&_end;
++
++#ifdef CONFIG_ENABLE_NVDISP_INIT
++	pr_debug("_start=0x%zx\n", (uintptr_t)&_start);
++	uefi_start = (uintptr_t)&_start + CONFIG_NVDISP_SIZE;
++	pr_debug("uefi_start=0x%zx\n", (uintptr_t)uefi_start);
++	heap_start = uefi_start + CONFIG_NVDISP_UEFI_SIZE;
++#endif
++
+ 	heap_end = boot_params->cpubl_carveout_safe_end_offset;
+ 	heap_size = heap_end - heap_start;
+ 
+--- a/bootloader/partner/t18x/cboot/platform/t194/rules.mk
++++ b/bootloader/partner/t18x/cboot/platform/t194/rules.mk
+@@ -44,25 +44,13 @@
+ 	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/soc/$(TARGET)/ccplex_nvg \
+ 	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/soc/$(TARGET)/ccplex_cache \
+ 	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/drivers/soc/$(TARGET)/clocks \
+-	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/soc/t194/qual_engine \
+ 	$(LOCAL_DIR)/../../../../common/lib/ipc \
+ 	$(LOCAL_DIR)/../../../../common/lib/blockdev \
+ 	$(LOCAL_DIR)/../../../../common/lib/tegrabl_error \
+-	$(LOCAL_DIR)/../../../../common/drivers/sdmmc \
+-	$(LOCAL_DIR)/../../../../common/drivers/sata \
+-	$(LOCAL_DIR)/../../../../common/drivers/spi \
+-	$(LOCAL_DIR)/../../../../common/drivers/ufs \
+ 	$(LOCAL_DIR)/../../../../common/drivers/gpcdma \
+-	$(LOCAL_DIR)/../../../../common/drivers/qspi \
+-	$(LOCAL_DIR)/../../../../common/drivers/qspi_flash \
+ 	$(LOCAL_DIR)/../../../../common/drivers/i2c \
+ 	$(LOCAL_DIR)/../../../../common/drivers/i2c_dev \
+-	$(LOCAL_DIR)/../../../../common/drivers/eeprom \
+-	$(LOCAL_DIR)/../../../../common/drivers/usbh \
+-	$(LOCAL_DIR)/../../../../common/drivers/usb/storage \
+-	$(LOCAL_DIR)/../../../../common/drivers/pcie \
+-	$(LOCAL_DIR)/../../../../common/drivers/nvme \
+-	$(LOCAL_DIR)/../../../../common/lib/eeprom_manager \
++	$(LOCAL_DIR)/../../../../common/drivers/sdmmc \
+ 	$(LOCAL_DIR)/../../../../common/arch/arm64 \
+ 	$(LOCAL_DIR)/../../../../t18x/common/lib/mce \
+ 	$(LOCAL_DIR)/../../../../common/lib/psci \
+@@ -71,12 +59,11 @@
+ 	$(LOCAL_DIR)/../../../../common/drivers/pmic/max77620 \
+ 	$(LOCAL_DIR)/../../../../common/drivers/regulator \
+ 	$(LOCAL_DIR)/../../../../common/drivers/gpio \
+-	$(LOCAL_DIR)/../../../../common/drivers/keyboard \
+ 	$(LOCAL_DIR)/../../../../common/drivers/comb_uart \
+-	$(LOCAL_DIR)/../../../../common/lib/a_b_boot \
+ 	$(LOCAL_DIR)/../../../../common/drivers/pwm \
+ 	$(LOCAL_DIR)/../../../../common/drivers/display \
+-	$(LOCAL_DIR)/../../../../common/lib/cbo \
++	$(LOCAL_DIR)/../../../../common/drivers/qspi \
++	$(LOCAL_DIR)/../../../../common/drivers/qspi_flash \
+ 	$(LOCAL_DIR)/../../../../$(TARGET_FAMILY)/common/lib/device_prod
+ 
+ ifeq ($(filter t19x, $(TARGET_FAMILY)),)
+@@ -109,29 +96,17 @@
+ 	CONFIG_MULTICORE_SUPPORT=1 \
+ 	CONFIG_ENABLE_EMMC=1 \
+ 	CONFIG_ENABLE_QSPI=1 \
+-	CONFIG_ENABLE_SATA=1 \
+-	CONFIG_ENABLE_UFS=1 \
+-	CONFIG_ENABLE_UFS_HS_MODE=1 \
+-	CONFIG_ENABLE_UFS_USE_CAR=1 \
+-	CONFIG_ENABLE_UFS_SKIP_PMC_IMPL=1 \
+-	CONFIG_ENABLE_NVBLOB=1 \
+ 	CONFIG_WDT_PERIOD_IN_EXECUTION=100 \
+ 	CONFIG_ENABLE_WDT=1 \
+-	CONFIG_ENABLE_EEPROM=1 \
+-	CONFIG_ENABLE_PLUGIN_MANAGER=1 \
+ 	CONFIG_ENABLE_I2C=1 \
+ 	CONFIG_POWER_I2C_BPMPFW=1 \
+ 	CONFIG_ENABLE_GPIO=1 \
+ 	CONFIG_ENABLE_GPIO_DT_BASED=1 \
+ 	CONFIG_ENABLE_PMIC_MAX20024=1 \
+-	CONFIG_ENABLE_A_B_SLOT=1 \
+ 	CONFIG_ENABLE_SDMMC_64_BIT_SUPPORT=1 \
+ 	CONFIG_ENABLE_DPAUX=1 \
+ 	CONFIG_ENABLE_PWM=1 \
+-	CONFIG_ENABLE_BL_DTB_OVERRIDE=1 \
+ 	CONFIG_ENABLE_DEVICE_PROD=1 \
+-	CONFIG_ENABLE_STAGED_SCRUBBING=1 \
+-	CONFIG_ENABLE_WAR_CBOOT_STAGED_SCRUBBING=1 \
+ 	CONFIG_SKIP_GPCDMA_RESET=1 \
+ 	CONFIG_DEBUG_LOGLEVEL=TEGRABL_LOG_INFO
+ 

--- a/recipes-bsp/cboot/nvdisp-init_32.7.2.bb
+++ b/recipes-bsp/cboot/nvdisp-init_32.7.2.bb
@@ -1,0 +1,28 @@
+DESCRIPTION = "nvdisp-init based on cboot bootloader for Tegra194"
+
+L4T_VERSION = "${PV}"
+L4T_BSP_NAME = "sources/T186"
+inherit l4t_bsp
+
+SRC_URI = "${L4T_URI_BASE}/cboot_src_t19x.tbz2;downloadfilename=cboot_src_t19x-${PV}.tbz2;subdir=${BP} \
+           file://0001-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch \
+           file://0002-Convert-Python-scripts-to-Python3.patch \
+           file://0003-macros.mk-fix-GNU-make-4.3-compatibility.patch \
+           file://0004-Restore-version-number-to-L4T-builds.patch \
+           file://0005-nvdisp-init.patch \
+           "
+
+
+SRC_URI[sha256sum] = "76e1105810bd5827facea9547e25bcc7a9cd4e1dda56a2b1c19c687b65c27f93"
+
+DEPENDS += "coreutils-native"
+TARGET_SOC = "t194"
+COMPATIBLE_MACHINE = "(tegra194)"
+PROVIDES += "nvdisp-init"
+CBOOT_SYMLINK = "nvdisp-init.bin"
+
+require cboot-l4t.inc
+
+do_compile:append() {
+    truncate --size=393216 ${B}/${CBOOT_BUILD_ARTIFACT}
+}

--- a/recipes-bsp/uefi/edk2-firmware-tegra_35.1.0.bb
+++ b/recipes-bsp/uefi/edk2-firmware-tegra_35.1.0.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://License.txt;md5=2b415520383f7964e96700ae12b4570a"
 LIC_FILES_CHKSUM += "file://../edk2-platforms/License.txt;md5=2b415520383f7964e96700ae12b4570a"
 LIC_FILES_CHKSUM += "file://../edk2-nvidia-non-osi/Silicon/NVIDIA/Drivers/NvGopDriver/NOTICE.nvgop-chips-platform.efi;md5=549bbaa72578510a18ba3c324465027c"
 
-DEPENDS += "dtc-native tegra-bootfiles"
+DEPENDS += "dtc-native nvdisp-init"
 
 EDK2_SRC_URI = "gitsm://github.com/NVIDIA/edk2.git;protocol=https;branch=rel-35-edk2-stable-202205"
 EDK2_PLATFORMS_SRC_URI = "git://github.com/NVIDIA/edk2-platforms.git;protocol=https;branch=rel-35-upstream-20220208"
@@ -59,7 +59,7 @@ PACKAGES_PATH = "${@nvidia_edk2_packages_path(d)}"
 
 EDK2_BIN_NAME = "uefi_jetson.bin"
 NVDISPLAY_INIT_DEFAULT = ""
-NVDISPLAY_INIT_DEFAULT:tegra194 = "${STAGING_DATADIR}/tegraflash/nvdisp-init.bin"
+NVDISPLAY_INIT_DEFAULT:tegra194 = "${DEPLOY_DIR_IMAGE}/nvdisp-init.bin"
 NVDISPLAY_INIT ?= "${NVDISPLAY_INIT_DEFAULT}"
 EDK2_EXTRA_BUILD = '-D "BUILDID_STRING=v${PV}" -D "BUILD_DATE_TIME=${@format_build_date(d)}" -D "BUILD_PROJECT_TYPE=EDK2" -D "GENFW_FLAGS=--zero"'
 


### PR DESCRIPTION
nvdisp-init is a pre-loader that is glued on before the efi firmware to set up a graphical framebuffer on t194 platforms. It's distributed as a patch to the previously released version of cboot, and a prebuilt binary.

This change adds a recipe to build nvdisp-init from source, and uses it by default for the edk2-firmware-tegra source build. The prebuilt efi binaries use the prebuilt nvdisp-init binary from the jetpack release.