### PR TITLE
mesa: libgbm: add rdepends on egl-gbm

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -2,7 +2,7 @@ EXTRA_OEMESON:append:tegra = " -Dglvnd=true"
 DEPENDS:append:tegra = " libglvnd"
 PROVIDES:tegra = "virtual/mesa virtual/libgbm"
 
-RDEPENDS:libgbm:append:tegra = " tegra-gbm-backend"
+RDEPENDS:libgbm:append:tegra = " tegra-gbm-backend egl-gbm"
 
 # Workaround for the do_install:append() present in the OE-Core recipe
 do_install:prepend:tegra() {


### PR DESCRIPTION
egl-gbm is required to use gbm along with egl on tegra devices.
This was an rdep on weston, but other generic gbm clients (like
kmscube) that want to use egl will need it as well. It's not
strictly required to make gbm itself work, but not being able to
initialize egl without it would be a common and unexpected surprise.

If a tegra platform is pulling in mesa to get libgbm, include this.

Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>