### PR TITLE
tegra234.inc: no need to add nvidia-drm and nvidia-modeset to the

### DIFF
--- a/conf/machine/include/tegra234.inc
+++ b/conf/machine/include/tegra234.inc
@@ -12,7 +12,7 @@ INITRAMFS_FSTYPES:append = "${@'' if d.getVar('INITRAMFS_IMAGE_BUNDLE') == '1' e
 
 SERIAL_CONSOLES ?= "115200;ttyTCU0"
 
-KERNEL_MODULE_AUTOLOAD ?= "nvgpu nvidia nvidia-drm nvidia-modeset"
+KERNEL_MODULE_AUTOLOAD ?= "nvgpu nvidia nvidia-drm"
 
 NVIDIA_CHIP = "0x23"
 
@@ -36,6 +36,3 @@ NVPOWER ?= "jetsonpower_t234"
 NVFANCONTROL ?= "nvfancontrol_p3701_0000"
 
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-nvidia kernel-module-nvidia-drm kernel-module-nvidia-modeset"
-
-KERNEL_MODULE_PROBECONF += "nvidia-drm"
-module_conf_nvidia-drm = "options nvidia-drm modeset=1"

--- a/recipes-graphics/wayland/weston_10.0.2.bbappend
+++ b/recipes-graphics/wayland/weston_10.0.2.bbappend
@@ -15,3 +15,4 @@ RDEPENDS:${PN}:append:tegra = " egl-wayland egl-gbm"
 EXTRA_OEMESON:append:tegra = " -Ddeprecated-wl-shell=true"
 
 RRECOMMENDS:${PN}:append:tegra = " kernel-module-tegra-udrm kernel-module-nvidia-drm"
+RRECOMMENDS:${PN}:append:tegra234 = " nvidia-drm-probeconf"

--- a/recipes-kernel/nvidia-drm-probeconf/nvidia-drm-probeconf/nvidia-drm.conf
+++ b/recipes-kernel/nvidia-drm-probeconf/nvidia-drm-probeconf/nvidia-drm.conf
@@ -1,0 +1,1 @@
+options nvidia-drm modeset=1

--- a/recipes-kernel/nvidia-drm-probeconf/nvidia-drm-probeconf_1.0.bb
+++ b/recipes-kernel/nvidia-drm-probeconf/nvidia-drm-probeconf_1.0.bb
@@ -1,0 +1,12 @@
+DESCRIPTION = "Adds a modprobe config for nvidia drm"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://nvidia-drm.conf"
+
+COMPATIBLE_MACHINE = "(tegra234)"
+
+do_install() {
+    install -d ${D}${sysconfdir}/modprobe.d
+    install -m 0644 ${WORKDIR}/nvidia-drm.conf ${D}${sysconfdir}/modprobe.d/
+}


### PR DESCRIPTION
KERNEL_MODULE_AUTOLOAD list.

This fixes the following issue

[    44.378] (II) NVIDIA(0): NVIDIA GPU Orin (nvgpu) (GA10B) at SoC (GPU-0)
[    44.378] (--) NVIDIA(0): Memory: 31269432 kBytes
[    44.378] (--) NVIDIA(0): VideoBIOS:
[    44.378] (EE) NVIDIA(GPU-0): Failed to acquire modesetting permission.
[    44.378] (EE) NVIDIA(0): Failing initialization of X screen

Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>