### PR TITLE
haveged: reintroduce systemd service

### DIFF
--- a/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.service
+++ b/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Entropy Daemon based on the HAVEGE algorithm
+
+[Service]
+Type=forking
+PIDFile=/run/haveged.pid
+Before=systemd-random-seed.service
+ExecStart=@SBIN_DIR@/haveged -w 1024 -v 1
+
+[Install]
+WantedBy=multi-user.target

--- a/external/openembedded-layer/recipes-extended/haveged/haveged_%.bbappend
+++ b/external/openembedded-layer/recipes-extended/haveged/haveged_%.bbappend
@@ -1,0 +1,19 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+inherit ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)}
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "haveged.service"
+
+# Based on init.d/service.redhat from 1.9.14
+# https://raw.githubusercontent.com/jirka-h/haveged/v1.9.14/init.d/service.redhat
+SRC_URI += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'file://haveged.service', '', d)}"
+
+do_install:append() {
+    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
+	install -d ${D}${systemd_system_unitdir}
+	install -m 755 ${WORKDIR}/haveged.service ${D}${systemd_system_unitdir}/haveged.service
+	sed -i -e "s,@SBIN_DIR@,${sbindir},g" ${D}${systemd_system_unitdir}/haveged.service
+    fi
+}
+
+PACKAGE_ARCH:tegra = "${TEGRA_PKGARCH}"


### PR DESCRIPTION
Upstream meta-oe dropped the systemd service since it is no longer
needed in Linux kernel > 5.6. But we are still on 4.9.y so we need it.

Based on https://raw.githubusercontent.com/jirka-h/haveged/v1.9.14/init.d/service.redhat

Signed-off-by: Tim Orling <tim.orling@konsulko.com>