### PR TITLE
Add nv_update_verifier to all builds

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -45,7 +45,7 @@ UBOOT_EXTLINUX ?= ""
 TEGRA_ESSENTIAL_EXTRA_RDEPENDS ?= "${@'l4t-launcher-extlinux' if d.getVar('UBOOT_EXTLINUX') == '1' else ''}"
 MACHINE_FEATURES = "alsa usbhost pci rtc cuda ext2"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware ${TEGRA_ESSENTIAL_EXTRA_RDEPENDS}"
-MACHINE_EXTRA_RDEPENDS = "tegra-nvphs tegra-nvs-service tegra-nvsciipc tegra-nvstartup tegra-nvfancontrol tegra-configs-udev"
+MACHINE_EXTRA_RDEPENDS = "tegra-nvphs tegra-nvs-service tegra-nvsciipc tegra-nvstartup tegra-nvfancontrol tegra-configs-udev tegra-redundant-boot"
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-nvgpu \
 			   kernel-module-snd-hda-tegra kernel-module-snd-hda-codec-hdmi kernel-module-ina3221 \
                            kernel-module-tegra-bpmp-thermal kernel-module-spi-tegra114 kernel-module-ahci \

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_35.1.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot-base_35.1.0.bb
@@ -15,10 +15,9 @@ do_install() {
 	install -d ${D}/opt/ota_package
 }
 
-PACKAGES = "tegra-redundant-boot-nvbootctrl ${PN} ${PN}-dev"
-FILES:tegra-redundant-boot-nvbootctrl = "${sbindir}/nvbootctrl"
-FILES:${PN} += "/opt/ota_package"
-RDEPENDS:${PN} = "tegra-redundant-boot-nvbootctrl setup-nv-boot-control-service tegra-configs-bootloader util-linux-lsblk"
+PACKAGES = "tegra-redundant-boot-update-engine ${PN} ${PN}-dev"
+FILES:tegra-redundant-boot-update-engine = "${sbindir}/nv_update_engine ${sbindir}/nv_bootloader_payload_updater /opt/ota_package"
+RDEPENDS:${PN} = "setup-nv-boot-control-service tegra-configs-bootloader"
 INSANE_SKIP:${PN} = "ldflags"
-RDEPENDS:tegra-redundant-boot-nvbootctrl = "setup-nv-boot-control"
-INSANE_SKIP:tegra-redundant-boot-nvbootctrl = "ldflags"
+RDEPENDS:tegra-redundant-boot-update-engine = "${PN} util-linux-lsblk"
+INSANE_SKIP:tegra-redundant-boot-update-engine = "ldflags"

--- a/recipes-bsp/tegra-bup-payload/tegra-bup-payload_1.0.bb
+++ b/recipes-bsp/tegra-bup-payload/tegra-bup-payload_1.0.bb
@@ -27,7 +27,7 @@ ALLOW_EMPTY:${PN} = "1"
 
 do_install[depends] += "${@bup_dependency(d)}"
 FILES:${PN} = "/opt/ota_package/bl_update_payload"
-RDEPENDS:${PN} += "tegra-redundant-boot"
+RDEPENDS:${PN} += "tegra-redundant-boot-update-engine"
 # For UEFI build - remove once buildpaths issue is resolved there
 INSANE_SKIP:${PN} = "buildpaths"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Refactor the packaging the redundant-boot recipes, so we can include the `nv_update_verifier` service in all builds.

Fixes #1071