### PR TITLE
Support virtual/dtb provider for out-of-tree dtb/dtbo

### DIFF
--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -10,6 +10,7 @@ inherit l4t-extlinux-config kernel-artifact-names
 
 KERNEL_ARGS ??= ""
 DTBFILE ?= "${@os.path.basename(d.getVar('KERNEL_DEVICETREE').split()[0])}"
+DEPLOY_DIR_DTB ?= "${@'${DEPLOY_DIR_IMAGE}/devicetree' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else '${DEPLOY_DIR_IMAGE}'}"
 
 # Need to handle:
 #  a) Kernel with no initrd/initramfs
@@ -20,6 +21,8 @@ def compute_dependencies(d):
     initramfs_image = d.getVar('INITRAMFS_IMAGE') or ''
     if initramfs_image != '' and (d.getVar('INITRAMFS_IMAGE_BUNDLE') or '') != '1':
         deps += " %s:do_image_complete" % initramfs_image
+    if d.getVar("PREFERRED_PROVIDER_virtual/dtb"):
+        deps += " virtual/dtb:do_deploy"
     return deps
 
 
@@ -41,7 +44,7 @@ do_compile() {
 	cp -L ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-${MACHINE}.bin ${B}/${KERNEL_IMAGETYPE}
     fi
     if [ -n "${UBOOT_EXTLINUX_FDT}" ]; then
-        cp -L ${DEPLOY_DIR_IMAGE}/${DTBFILE} ${B}/
+        cp -L ${DEPLOY_DIR_DTB}/${DTBFILE} ${B}/
     fi
 }
 do_compile[depends] += "${@compute_dependencies(d)}"


### PR DESCRIPTION
This set of changes accommodate out-of-tree device tree binaries generated by a provider of `virtual/dtb`. Overall, this enables consumers of meta-tegra to generate the main kernel dtbs and dtbos, as well as the dtbos that can be used by EFI, without patching the linux-tegra or EDK2 sources.

The approach was derived from conventions set forth in the meta `devicetree` bbclass and its handling by the `kernel-fitimage` class. The assumption is that these device tree binaries will be placed under the `${DEPLOYDIR}/devicetree` location during deploy, or in `/boot/devicetree` on install. These paths are not variable in the `devicetree` bbclass, and as such are not variable here, and their contents simply globbed.

To enable building a dtb that referenced nvidia's overlayed kernel device tree sources, I required a minor fix to the kernel sources so that the upstream includes would not be used. This PR stands alone, and we can cross that bridge subsequently.