### PR TITLE
Updated LIC_FILES_CHKSUM to match current value

### DIFF
--- a/recipes-bsp/tools/tegra-eeprom-tool_git.bb
+++ b/recipes-bsp/tools/tegra-eeprom-tool_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Tegra ID EEPROM tools"
 HOMEPAGE = "https://github.com/OE4T/tegra-eeprom-tool"
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=c4bff80c7e9a90aa351e9062b5572544"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=22c98979a7dd9812d2455ff5dbc88771"
 
 DEPENDS = "libedit"
 


### PR DESCRIPTION
The license file was updated upstream and the MD5 checksum changed. I Know this branch is ancient but I am working on a project that targets this L4T release. It would make life a little easier to not have to modify `recipes-bsp/tools/tegra-eeprom-tool_git.bb` locally. 