### PR TITLE
qtbase: Fix correct SRC_URI for patches in kirkstone

### DIFF
--- a/external/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append:tegra = " file://0001-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch \
+SRC_URI:append:tegra = " file://0001-eglfs-Newer-Nvidia-libdrm-provide-device-instead-dri.patch \ 
+                         file://0002-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch \
 "
 
 PACKAGECONFIG:append:tegra = " kms"


### PR DESCRIPTION
The previous commit has a back porting problem. The version of qtbase needs 2 patches.

Signed-off-by: Claus Stovgaard <clst@ambu.com>