### PR TITLE
tegra-mmapi-samples: add patch for encoder unit test sample

### DIFF
--- a/recipes-multimedia/argus/tegra-mmapi-samples/0010-samples-apply-fix-for-encoder-unit-test.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0010-samples-apply-fix-for-encoder-unit-test.patch
@@ -1,0 +1,77 @@
+From 940988ba215622cfc3c4521124026bcbbe244eeb Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 3 Oct 2022 04:28:28 -0700
+Subject: [PATCH] samples: apply fix for encoder unit test
+
+See dev forum post:
+https://forums.developer.nvidia.com/t/jetson-multimedia-api-35-1-0-encoder-unit-test-sample-failure/229588
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ .../encoder_unit_sample.cpp                   | 26 +------------------
+ 1 file changed, 1 insertion(+), 25 deletions(-)
+
+diff --git a/samples/unittest_samples/encoder_unit_sample/encoder_unit_sample.cpp b/samples/unittest_samples/encoder_unit_sample/encoder_unit_sample.cpp
+index 8af65f8..58182fb 100644
+--- a/samples/unittest_samples/encoder_unit_sample/encoder_unit_sample.cpp
++++ b/samples/unittest_samples/encoder_unit_sample/encoder_unit_sample.cpp
+@@ -809,14 +809,6 @@ encoder_process_blocking(context_t& ctx)
+                     break;
+                 }
+ 
+-                ret_val = NvBufSurfaceMap(nvbuf_surf, 0, j, NVBUF_MAP_READ_WRITE);
+-                if (ret_val)
+-                {
+-                    cerr << "NvBufSurfaceMap failed\n" << endl;
+-                    ctx.in_error = 1;
+-                    break;
+-                }
+-
+                 ret_val = NvBufSurfaceSyncForDevice(nvbuf_surf, 0, j);
+                 if (ret_val)
+                 {
+@@ -824,14 +816,6 @@ encoder_process_blocking(context_t& ctx)
+                     ctx.in_error = 1;
+                     break;
+                 }
+-
+-                ret_val = NvBufSurfaceUnMap(nvbuf_surf, 0, j);
+-                if (ret_val)
+-                {
+-                    cerr << "NvBufSurfaceUnMap failed\n" << endl;
+-                    ctx.in_error = 1;
+-                    break;
+-                }
+             }
+         }
+ 
+@@ -1154,17 +1138,9 @@ int main (int argc, char const *argv[])
+                 CHECK_ERROR(ret < 0,
+                     "Error while NvBufSurfaceFromFd at output plane", cleanup);
+ 
+-                ret = NvBufSurfaceMap(nvbuf_surf, 0, j, NVBUF_MAP_READ_WRITE);
+-                CHECK_ERROR(ret < 0,
+-                    "Error while NvBufSurfaceMap at output plane", cleanup);
+-
+                 ret = NvBufSurfaceSyncForDevice(nvbuf_surf, 0, j);
+                 CHECK_ERROR(ret < 0,
+                     "Error while NvBufSurfaceSyncForDevice at output plane", cleanup);
+-
+-                ret = NvBufSurfaceUnMap(nvbuf_surf, 0, j);
+-                CHECK_ERROR(ret < 0,
+-                    "Error while NvBufSurfaceUnMap at output plane", cleanup);
+             }
+         }
+ 
+@@ -1244,7 +1220,7 @@ cleanup:
+ 
+     if (ctx.in_error)
+     {
+-        cerr << "Encoder is in error << endl" << endl;
++        cerr << "Encoder is in error" << endl;
+     }
+ 
+     else
+-- 
+2.34.1
+

--- a/recipes-multimedia/argus/tegra-mmapi-samples_35.1.0.bb
+++ b/recipes-multimedia/argus/tegra-mmapi-samples_35.1.0.bb
@@ -10,6 +10,7 @@ SRC_URI += "\
     file://0007-trt_inference-use-smart-pointers-during-model-conver.patch \
     file://0008-frontend-add-option-to-set-timeout.patch \
     file://0009-camera_v4l2_cuda-add-option-for-setting-max-frame-co.patch \
+    file://0010-samples-apply-fix-for-encoder-unit-test.patch \
 "
 
 DEPENDS = "libdrm tegra-mmapi tegra-libraries-camera virtual/egl virtual/libgles1 virtual/libgles2 jpeg expat gstreamer1.0 glib-2.0 libv4l pango"


### PR DESCRIPTION
which fixes a problem with its buffer management. See: https://forums.developer.nvidia.com/t/jetson-multimedia-api-35-1-0-encoder-unit-test-sample-failure/229588

Fixes #1059