### PR TITLE
cuda-libraries: remove libcudla from native

### DIFF
--- a/recipes-devtools/cuda/cuda-libraries_11.4.14-1.bb
+++ b/recipes-devtools/cuda/cuda-libraries_11.4.14-1.bb
@@ -6,11 +6,13 @@ CUDA_COMPONENTS = " \
     cuda-nvrtc \
     libcublas \
     libcufft \
-    libcudla \
     libcurand \
     libcusolver \
     libcusparse \
     libnpp \
+"
+CUDA_COMPONENTS:append:class-target = " \
+    libcudla \
 "
 DEPENDS = "${CUDA_COMPONENTS}"
 


### PR DESCRIPTION
libcudla is only provided by NVidia for the target. Excluding it from the cuda-libraries-native package resolves the following compilation error:

    Nothing RPROVIDES 'libcudla-native'

Signed-off-by: Enguerrand de Ribaucourt <enguerrand.de-ribaucourt@savoirfairelinux.com>

Fixes #1105 