### PR TITLE
Source builds of nvcompositor

### DIFF
--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_35.1.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_35.1.0.bb
@@ -37,6 +37,7 @@ do_install() {
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvtee*
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvdrmvideo*
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvvidconv*
+    rm -f ${D}${libdir}/gstreamer-1.0/libgstnvcompositor*
 }
 
 FILES_SOLIBSDEV = ""

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0002-Skip-map-frame-in-pad-prepare-to-fix-spurious-warnin.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0002-Skip-map-frame-in-pad-prepare-to-fix-spurious-warnin.patch
@@ -1,0 +1,36 @@
+From 9ed04183d33d37ffe6eaa0e8f9a8696c0dcd3ddc Mon Sep 17 00:00:00 2001
+From: Kurt Kiefer <kekiefer@gmail.com>
+Date: Tue, 1 Nov 2022 10:47:26 -0700
+Subject: [PATCH] Skip map frame in pad prepare to fix spurious warnings
+
+When running with gstreamer message level WARN, the following
+message is repeated continuously:
+
+videoaggregator gstvideoaggregator.c:528:gst_video_aggregator_convert_pad_prepare_frame:<comp> Could not map input buffer
+
+This element doesn't need to have video data buffers mapped in
+order to do its job. In fact the video data buffers used internally
+don't contain video data at all, but instead the nvbuffer pointers,
+which are obtained differently.
+
+Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
+---
+ gstnvcompositor.c | 5 +----
+ 1 file changed, 1 insertion(+), 4 deletions(-)
+
+diff --git a/gstnvcompositor.c b/gstnvcompositor.c
+index 67965b5..26ea1c3 100644
+--- a/gstnvcompositor.c
++++ b/gstnvcompositor.c
+@@ -526,10 +526,7 @@ gst_nvcompositor_pad_prepare_frame (GstVideoAggregatorPad * pad,
+     GstVideoAggregator * vagg, GstBuffer * buffer,
+     GstVideoFrame * prepared_frame)
+ {
+-  return
+-      GST_VIDEO_AGGREGATOR_PAD_CLASS
+-      (gst_nvcompositor_pad_parent_class)->prepare_frame (pad, vagg, buffer,
+-      prepared_frame);
++  return TRUE;
+ }
+ 
+ /**

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor_1.20.5-r35.1.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor_1.20.5-r35.1.0.bb
@@ -10,7 +10,9 @@ require recipes-bsp/tegra-sources/tegra-sources-35.1.0.inc
 
 DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base virtual/egl tegra-mmapi tegra-libraries-multimedia-utils"
 
-SRC_URI += " file://0001-Update-makefile-for-OE-builds.patch"
+SRC_URI += " file://0001-Update-makefile-for-OE-builds.patch \
+             file://0002-Skip-map-frame-in-pad-prepare-to-fix-spurious-warnin.patch \
+"
 
 S = "${WORKDIR}/gst-nvcompositor"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-tegra_1.14.0-r35.1.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-tegra_1.14.0-r35.1.0.bb
@@ -3,6 +3,7 @@ LICENSE = "MIT"
 
 PLUGINS = "\
     gstreamer1.0-plugins-nvarguscamerasrc \
+    gstreamer1.0-plugins-nvcompositor \
     gstreamer1.0-plugins-nvdrmvideosink \
     gstreamer1.0-plugins-nveglgles \
     gstreamer1.0-plugins-nvjpeg \


### PR DESCRIPTION
nvcompositor emits a spurious warning message for every frame that goes through it. This typically goes unnoticed until GST_DEBUG is at least at the warn level, but besides being annoying it is doing unnecessary work.

This PR patches the nvcompositor to skip the extraneous mapping call, and sets up the gstreamer1.0-plugins-tegra collection to use the source build of the nvcompositor.