### PR TITLE
Fixes for sysvinit-based startup issues

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.init
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.init
@@ -4,9 +4,9 @@ DESC="OTA bootloader update verifier"
 
 case "$1" in
   start|restart)
-      while [ ! -e /dev/disk/by-partlabel/kernel ]; do sleep 1; done
-      sleep 2
+      echo -n "Running $DESC: "
       /usr/sbin/nvbootctrl verify < /dev/null
+      echo "[OK]"
       ;;
   stop)
       ;;

--- a/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.service
+++ b/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=OTA bootloader update verifier
-After=nvstartup.service dev-disk-by\x2dpartlabel-kernel.device
+After=nvstartup.service
 
 [Service]
 Type=simple

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
@@ -4,11 +4,13 @@ DESC="Set up redundant boot configuration"
 
 case "$1" in
   start|restart)
+      echo -n "Running $DESC: "
       mkdir -p -m0755 /run/nv_boot_control
       if ! mountpoint -q @ESPMOUNT@; then
 	  mount -t vfat /dev/disk/by-partlabel/esp @ESPMOUNT@
       fi
       @bindir@/setup-nv-boot-control
+      echo "[OK]"
       ;;
   stop)
       ;;

--- a/recipes-security/optee/optee-client_3.16.0-l4t-r35.1.0.bb
+++ b/recipes-security/optee/optee-client_3.16.0-l4t-r35.1.0.bb
@@ -42,7 +42,7 @@ do_install() {
     oe_runmake -C ${S} install DESTDIR="${D}"
     install -d ${D}${systemd_system_unitdir} ${D}${sysconfdir}/init.d
     install -m 0644 ${B}/tee-supplicant.service ${D}${systemd_system_unitdir}/
-    install -m 0755 ${B}/tee-supplicant.sh ${D}${sysconfdir}/init.d/
+    install -m 0755 ${B}/tee-supplicant.sh ${D}${sysconfdir}/init.d/tee-supplicant
 }
 
 SYSTEMD_SERVICE:${PN} = "tee-supplicant.service"


### PR DESCRIPTION
* Fix the installation of the optee supplicant init script to match the INITSCRIPT_NAME
* Drop the wait on the kernel partition for `nv_update_verifier`

Fixes #1110 
