### PR TITLE
cuda-target-environment: Set CUDA_ARCHITECTURES correct

### DIFF
--- a/recipes-devtools/cuda/cuda-target-environment_1.0.bb
+++ b/recipes-devtools/cuda/cuda-target-environment_1.0.bb
@@ -21,7 +21,7 @@ def arch_flags(d):
 do_compile() {
     sed -e"s!@CUDA_NVCC_ARCH_FLAGS@!${CUDA_NVCC_ARCH_FLAGS}!" \
 	-e"s!@ARCHFLAGS@!${@arch_flags(d)}!" \
-	-e"s!@CUDA_ARCHITECTURES@!${CUDA_ARCHITECTURE}!" \
+	-e"s!@CUDA_ARCHITECTURES@!${CUDA_ARCHITECTURES}!" \
 	-e"s!@COMPILER_CMD@!${COMPILER_CMD}!" ${S}/cuda_target.sh.in > ${B}/cuda_target.sh
 }
 


### PR DESCRIPTION
A small spelling error - E.g. CUDA_ARCHITECTURE vs CUDA_ARCHITECTURES Without this fix the exported CUDA_ARCHITECTURES environment variable is blank, and you can see it in the cuda_target.sh

Signed-off-by: Claus Stovgaard <claus.stovgaard@gmail.com>