### PR TITLE
libglvnd: add libxcb-glx runtime dependency

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_35.1.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-glxcore_35.1.0.bb
@@ -15,3 +15,5 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
     tegra/libGLX_nvidia.so.0 \
     tegra/libnvidia-glcore.so.${L4T_VERSION} \
 "
+
+RDEPENDS:${PN} = "libxcb-glx"


### PR DESCRIPTION
This fixes Vulkan support with X11 (tested with `vulkaninfo` tool in addition to other Vulkan-enabled apps).