### PR TITLE
Adding COMPATIBLE_SPEC support for BUP payloads

### DIFF
--- a/conf/machine/include/tegra210.inc
+++ b/conf/machine/include/tegra210.inc
@@ -43,8 +43,6 @@ TEGRA_FAB ?= "100"
 TEGRA_BOARDSKU ?= ""
 TEGRA_BOARDREV ?= ""
 TEGRA_CHIPREV ?= "0"
-# Extracted from l4t_generate_soc_bup.sh for BOARDID=2180 and board=jetson-tx1-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=100 fab=410"
 
 PARTITION_LAYOUT_EXTERNAL ?= "external_layout.xml"
 BOOT_PARTITIONS_ON_EMMC = "1"

--- a/conf/machine/jetson-agx-xavier-devkit.conf
+++ b/conf/machine/jetson-agx-xavier-devkit.conf
@@ -5,9 +5,8 @@
 require conf/machine/include/tegra194.inc
 
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=2888 and board=jetson-agx-xavier-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0001;boardrev=H.0 \
-                       fab=400;boardsku=0001;boardrev=J.0 \
-                       fab=400;boardsku=0001;boardrev=L.0 \
+TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0001;boardrev=D.0 \
+                       fab=400;boardsku=0001;boardrev=E.0 \
                        fab=400;boardsku=0004;boardrev= \
 		       fab=402;boardsku=0005;boardrev="
 

--- a/conf/machine/jetson-nano-2gb-devkit.conf
+++ b/conf/machine/jetson-nano-2gb-devkit.conf
@@ -10,7 +10,7 @@ NVPMODEL ?= "nvpmodel_t210_jetson-nano"
 TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "400"
 TEGRA_BOARDSKU ?= "0003"
-TEGRA_BUPGEN_SPECS ?= "fab=400"
+TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0003"
 
 require conf/machine/include/tegra210.inc
 

--- a/conf/machine/jetson-nano-devkit-emmc.conf
+++ b/conf/machine/jetson-nano-devkit-emmc.conf
@@ -11,7 +11,8 @@ TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "400"
 TEGRA_BOARDSKU ?= "0002"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3448 and board=jetson-nano-devkit-emmc
-TEGRA_BUPGEN_SPECS ?= "fab=200 fab=300 fab=400 fab=401"
+TEGRA_BUPGEN_SPECS ?= "fab=200;boardsku=0002 \
+		       fab=300;boardsku=0002"
 
 require conf/machine/include/tegra210.inc
 

--- a/conf/machine/jetson-nano-devkit.conf
+++ b/conf/machine/jetson-nano-devkit.conf
@@ -11,7 +11,10 @@ TEGRA_BOARDID ?= "3448"
 TEGRA_FAB ?= "200"
 TEGRA_BOARDSKU ?= "0000"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3448 and board=jetson-nano-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=100 fab=200 fab=300 fab=400 fab=401 fab=402"
+TEGRA_BUPGEN_SPECS ?= "fab=000;boardsku=0000 \
+		       fab=100;boardsku=0000 \
+		       fab=200;boardsku=0000 \
+		       fab=300;boardsku=0000"
 
 require conf/machine/include/tegra210.inc
 

--- a/conf/machine/jetson-tx1-devkit.conf
+++ b/conf/machine/jetson-tx1-devkit.conf
@@ -4,6 +4,9 @@
 
 KERNEL_ARGS ?= "console=ttyS0,115200 console=tty0 fbcon=map:0 net.ifnames=0 sdhci_tegra.en_boot_part_access=1"
 
+# Extracted from l4t_generate_soc_bup.sh for BOARDID=2180 and board=jetson-tx1-devkit
+TEGRA_BUPGEN_SPECS ?= "fab=100"
+
 require conf/machine/include/tegra210.inc
 
 MACHINE_EXTRA_RRECOMMENDS += "tegra-firmware-brcm kernel-module-bcmdhd kernel-module-ov5693"

--- a/conf/machine/jetson-tx2-devkit.conf
+++ b/conf/machine/jetson-tx2-devkit.conf
@@ -28,4 +28,4 @@ TEGRA_BOARDSKU ?= ""
 TEGRA_BOARDREV ?= ""
 TEGRA_CHIPREV ?= "0"
 # Extracted from l4t_generate_soc_bup.sh for BOARDID=3310 and board=jetson-tx2-devkit
-TEGRA_BUPGEN_SPECS ?= "fab=B00 fab=B02 fab=C04 fab=D00 fab=D01 fab=D02"
+TEGRA_BUPGEN_SPECS ?= "fab=B00 fab=B01"

--- a/conf/machine/jetson-xavier-nx-devkit-emmc.conf
+++ b/conf/machine/jetson-xavier-nx-devkit-emmc.conf
@@ -5,10 +5,7 @@
 
 TEGRA_BOARDSKU ?= "0001"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0001;boardrev= \
-		       fab=200;boardsku=0001;boardrev= \
-		       fab=300;boardsku=0001;boardrev= \
-		       fab=301;boardsku=0001;boardrev= \
-		       fab=301;boardsku=0003;boardrev="
+		       fab=301;boardsku=0001;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
 require conf/machine/include/xavier-nx.inc

--- a/conf/machine/jetson-xavier-nx-devkit.conf
+++ b/conf/machine/jetson-xavier-nx-devkit.conf
@@ -5,8 +5,6 @@
 
 TEGRA_BOARDSKU ?= "0000"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0000;boardrev= \
-		       fab=200;boardsku=0000;boardrev= \
-		       fab=300;boardsku=0000;boardrev= \
 		       fab=301;boardsku=0000;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "1024"
 

--- a/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_32.7.2.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_32.7.2.bb
@@ -7,20 +7,20 @@ OTABOOTDEV ??= "/dev/mmcblk0boot0"
 OTAGPTDEV ??= "/dev/mmcblk0boot1"
 
 do_compile() {
-	:
+	cat > ${B}/nv_boot_control.template <<EOF
+TNSPEC @TNSPEC@
+COMPATIBLE_SPEC @COMPATIBLE_SPEC@
+TEGRA_CHIPID ${NVIDIA_CHIP}
+TEGRA_OTA_BOOT_DEVICE ${OTABOOTDEV}
+TEGRA_OTA_GPT_DEVICE ${OTAGPTDEV}
+EOF
+
 }
 
 do_install() {
 	install -d ${D}${sysconfdir}
-	sed -e 's,^TNSPEC.*$,TNSPEC @TNSPEC@,' \
-	    -e '/TEGRA_CHIPID/d' -e '/TEGRA_OTA_BOOT_DEVICE/d' -e '/TEGRA_OTA_GPT_DEVICE/d' \
-	    -e '$ a TEGRA_CHIPID ${NVIDIA_CHIP}' \
-	    -e '$ a TEGRA_OTA_BOOT_DEVICE ${OTABOOTDEV}' \
-	    -e '$ a TEGRA_OTA_GPT_DEVICE ${OTAGPTDEV}' \
-	    ${S}/bootloader/nv_boot_control.conf >${D}${sysconfdir}/nv_boot_control.template
-	chmod 0644 ${D}${sysconfdir}/nv_boot_control.template
-        install -d ${D}${localstatedir}/lib/nvbootctrl
-        ln -sf ${localstatedir}/lib/nvbootctrl/nv_boot_control.conf ${D}${sysconfdir}/
+	install -m 0644 ${B}/nv_boot_control.template ${D}${sysconfdir}/
+	ln -sf /run/nv_boot_control/nv_boot_control.conf ${D}${sysconfdir}/
 }
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
@@ -4,7 +4,9 @@ DESC="Set up redundant boot configuration"
 
 case "$1" in
   start|restart)
-      @bindir@/setup-nv-boot-control
+      mkdir -p /run/nv_boot_control
+      chmod 755 /run/nv_boot_control
+      RUNTIME_DIRECTORY=/run/nv_boot_control @bindir@/setup-nv-boot-control
       ;;
   stop)
       ;;

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.service.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.service.in
@@ -1,8 +1,12 @@
 [Unit]
 Description=Set up redundant boot configuration
+DefaultDependencies=no
 Before=nv_update_verifier.service
 
 [Service]
+RuntimeDirectory=nv_boot_control
+RuntimeDirectoryPreserve=yes
+RuntimeDirectoryMode=0755
 Type=oneshot
 ExecStart=@bindir@/setup-nv-boot-control
 

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
@@ -3,7 +3,106 @@ TARGET="@TARGET@"
 BOOTDEV="@BOOTDEV@"
 sysconfdir="@sysconfdir@"
 
-[ ! -e "${sysconfdir}/nv_boot_control.conf" ] || exit 0
+fab=
+boardsku=
+boardrev=
+chiprev=
+
+# TX1
+gen_compat_2180() {
+    fab=
+    boardsku=
+    boardrev=
+    chiprev=
+    return 0
+}
+# Nano
+gen_compat_3448() {
+    if echo "$fab" | grep -q "^0.."; then
+	fab="000"
+    elif echo "$fab" | grep -q "^1.."; then
+	fab="100"
+    elif echo "$fab" | grep -q "^2.."; then
+	fab="200"
+    else
+	fab="300"
+    fi
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# TX2
+gen_compat_3310() {
+    if [ "$fab" != "B00" ] && echo "$fab" | grep -q "^[B-Z].."; then
+	fab="B01"
+    fi
+    boardsku=
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# TX2i/TX2-4GB
+gen_compat_3489() {
+    if echo "$fab" | grep -q "^[012].."; then
+	fab="200"
+    else
+	fab="300"
+    fi
+    boardsku=
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# TX2-NX
+gen_compat_3636() {
+    fab=
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# AGX Xavier
+gen_compat_2888() {
+    if [ "$fab" = "400" ]; then
+	if [ "$boardsku" = "0004" ]; then
+	    boardrev=
+	else
+	    if echo "$boardrev" | grep -q "^[ABCD]\."; then
+		boardrev="D.0"
+	    else
+		boardrev="E.0"
+	    fi
+	    boardsku="0001"
+	fi
+    elif [ "$fab" = "600" -a "$boardsku" = "0008" ]; then
+	boardrev=
+    fi
+    return 0
+}
+
+# Xavier NX
+gen_compat_3668() {
+    if [ "$fab" != "301" ]; then
+	fab="100"
+    fi
+    boardsku=
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# boardspec should be piped into this function
+gen_compat_spec() {
+    IFS=- read boardid fab boardsku boardrev fuselevel chiprev
+    if gen_compat_$boardid 2>/dev/null; then
+	echo "$boardid-$fab-$boardsku-$boardrev-$fuselevel-$chiprev"
+	return 0
+    fi
+    echo ""
+}
 
 if [ ! -e "${sysconfdir}/nv_boot_control.template" ]; then
     echo "ERR: nv_boot_control.conf template file not found" >&2
@@ -15,9 +114,14 @@ if [ -z "${boardspec}" ]; then
     echo "ERR: could not retrieve boardspec for nv_boot_control.conf setup" >&2
     exit 1
 fi
+compatspec=$(echo "$boardspec" | gen_compat_spec)
+if [ -z "$compatspec" ]; then
+    compatsed="-e/^COMPATIBLE_SPEC/d"
+else
+    compatsed="-es,@COMPATIBLE_SPEC@,${compatspec}-${TARGET}-,"
+fi
 
-sed -e"s,@TNSPEC@,${boardspec}-${TARGET}-${BOOTDEV}," \
-    "${sysconfdir}/nv_boot_control.template" > "${sysconfdir}/nv_boot_control.conf"
-chmod 0644 "${sysconfdir}/nv_boot_control.conf"
+sed -e"s,@TNSPEC@,${boardspec}-${TARGET}-${BOOTDEV}," $compatsed \
+    "${sysconfdir}/nv_boot_control.template" > "$RUNTIME_DIRECTORY/nv_boot_control.conf"
+chmod 0644 "$RUNTIME_DIRECTORY/nv_boot_control.conf"
 exit 0
-

--- a/recipes-bsp/tools/tegra-boot-tools_3.1.0.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_3.1.0.bb
@@ -1,12 +1,12 @@
 DESCRIPTION = "Boot-related tools for Tegra platforms"
 HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
 LICENSE = "MIT & BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=7a9217de7f233011b127382da9a035a1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=481ed6124b0f84b3a5ad255a328bcaa5"
 
 DEPENDS = "zlib util-linux-libuuid systemd tegra-eeprom-tool"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "df765aec0838501b8f3400ee309f18a0ffe503b424196d39e86211e0e3f0f78e"
+SRC_URI[sha256sum] = "e370b883ba9e44c170b7fdccfcb1771faebbf379d5b6cb7c94b1e24018211aae"
 
 OTABOOTDEV ??= "/dev/mmcblk0boot0"
 OTAGPTDEV ??= "/dev/mmcblk0boot1"

--- a/recipes-bsp/tools/tegra-boot-tools_git.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Boot-related tools for Tegra platforms"
 HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
 LICENSE = "MIT & BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=7a9217de7f233011b127382da9a035a1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=481ed6124b0f84b3a5ad255a328bcaa5"
 
 DEFAULT_PREFERENCE = "-1"
 
@@ -12,7 +12,7 @@ SRCBRANCH = "master"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
 SRCREV = "${AUTOREV}"
 
-PV = "2.99.0+git${SRCPV}"
+PV = "3.0.99+git${SRCPV}"
 S = "${WORKDIR}/git"
 
 DEBUG_BUILD = "1"


### PR DESCRIPTION
This is already present in the JetPack 5/R35.1.0-based branches, but was more involved for R32.7.x because:
* More platforms are involved
* tegra-boot-tools also needed updating

When using the stock NVIDIA bootloader update tools, the `setup-nv-boot-control` service will add a COMPATIBLE_SPEC line to the configuration file so that BUP payload entries either matching the actual TNSPEC or the compatible spec will be considered valid for an update.  The new version of the `tegra-bootloader-update` tool implements similar logic for its compatibility checks.

With the above changes, the `TEGRA_BUP_SPECS` settings for all machines needed revising.  In most cases, fewer specs are required, making BUP packages smaller and taking less time to build/sign.

For reviewing, I'd appreciate it if someone could cross check the `setup-nv-boot-control.sh` changes here (and the translation of the logic in that script to the C code [here](https://github.com/OE4T/tegra-boot-tools/blob/86d9f18a7eec7570ffa69e12a3481bb10e6c0764/bup.c#L340-L480) in tegra-boot-tools) to derive the compatible spec string against NVIDIA's implementation in their `nv-l4t-bootloader-config.sh` script.  To get a copy of the NVIDIA script, extract it from the `nvidia-l4t-init` package, which you can download [here](https://repo.download.nvidia.com/jetson/t186/pool/main/n/nvidia-l4t-init/nvidia-l4t-init_32.7.2-20220417024839_arm64.deb), with:

       $ dpkg-deb --fsys-tarfile nvidia-l4t-init_32.7.2-20220417024839_arm64.deb | tar -x -f- --strip-components=4 ./opt/nvidia/l4t-bootloader-config/nv-l4t-bootloader-config.sh

The relevant function in that script is called `generate_compatible_spec_info`.