### PR TITLE
tegra-udrm-gbm: update to version 1.1.0

### DIFF
--- a/recipes-graphics/mesa/tegra-udrm-gbm_1.1.0.bb
+++ b/recipes-graphics/mesa/tegra-udrm-gbm_1.1.0.bb
@@ -5,15 +5,16 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c43c2c3b83cc7c8460566fb6da10f02a"
 
 RPROVIDES:${PN} += "tegra-gbm-backend"
 
-DEPENDS = "mesa libdrm"
+DEPENDS = "mesa libdrm tegra-mmapi"
+RDEPENDS:${PN} = "tegra-libraries-multimedia-utils"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
 SRC_REPO = "github.com/oe4t/tegra-udrm-gbm.git;protocol=https"
 SRCBRANCH = "master"
 SRC_URI = "git://${SRC_REPO};branch=${SRCBRANCH}"
-# v1.0.2 tag
-SRCREV = "103d33d07e6c38106bf952403b336dc3ca809a08"
+# v1.1.0 tag
+SRCREV = "13969b866134073936f10b0905f8b6e15c9b9e57"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This update is required due to the removal of nvgbm in 35.2.1. It replaces the nvgbm wrapper with its own buffer allocation using nvbuffersurface.