### PR TITLE
tegra-minimal-initramfs: Bind DTB/DTBO extra dependencies via DTB_EXT…

### DIFF
--- a/recipes-core/images/tegra-minimal-initramfs.bb
+++ b/recipes-core/images/tegra-minimal-initramfs.bb
@@ -13,6 +13,9 @@ PACKAGE_INSTALL = "\
     ${TEGRA_INITRD_INSTALL} \
 "
 
+# Bind DTB/DTBO extra dependencies
+do_rootfs[depends] += " ${DTB_EXTRA_DEPS}"
+
 IMAGE_FEATURES = ""
 IMAGE_LINGUAS = ""
 


### PR DESCRIPTION
…RA_DEPS

When installing new DTBOs with OVERLAY_DTB_FILE:append = ",some-overlay.dtbo", you will find that do_image_tegraflash sorts intertasks dependencies with do_image_tegraflash[depends] += "${DTB_EXTRA_DEPS}". This is not the case with tegra-minimal-initramfs, and it actually collects the DTBOs into OVERLAY_DTB_FILE the same way as do_image_tegraflash does. With this dependency definition we tell it to wait for a given dependency's do_deploy definition. User will do DTB_EXTRA_DEPS:append = " some-overlay-recipe:do_deploy" so it works sucessfully.

Signed-off-by: Daniel Chaves <dchvs11@gmail.com>