### PR TITLE
tegra-uefi-prebuilt: fix typo in do_compile

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_35.2.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_35.2.1.bb
@@ -13,7 +13,6 @@ inherit deploy tegra-uefi-signing
 
 do_compile() {
     cp ${S}/bootloader/uefi_jetson.bin ${S}/bootloader/BOOTAA64.efi ${B}
-    install -m 0644  ${D}${EFIDIR}/${EFI_BOOT_IMAGE}
 }
 
 do_compile:tegra194() {


### PR DESCRIPTION
Fixes #1177 