### PR TITLE
conf/machine: fix KERNEL_ROOTSPEC_DEFAULT for SDcard-based Nanos

### DIFF
--- a/conf/machine/jetson-nano-2gb-devkit.conf
+++ b/conf/machine/jetson-nano-2gb-devkit.conf
@@ -14,7 +14,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0003"
 
 require conf/machine/include/tegra210.inc
 
-KERNEL_ROOTSPEC_DEFAULT = "root=/dev/mmcblk0p${distro_bootpart} rw rootwait"
+KERNEL_ROOTSPEC_DEFAULT = "mmcblk0p${distro_bootpart}"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-rtl8821cu"
 
 KERNEL_DEVICETREE ?= "tegra210-p3448-0003-p3542-0000.dtb"

--- a/conf/machine/jetson-nano-devkit.conf
+++ b/conf/machine/jetson-nano-devkit.conf
@@ -18,7 +18,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=000;boardsku=0000 \
 
 require conf/machine/include/tegra210.inc
 
-KERNEL_ROOTSPEC_DEFAULT = "root=/dev/mmcblk0p${distro_bootpart} rw rootwait"
+KERNEL_ROOTSPEC_DEFAULT = "mmcblk0p${distro_bootpart}"
 
 KERNEL_DEVICETREE ?= "tegra210-p3448-0000-p3449-0000-a02.dtb \
 		      tegra210-p3448-0000-p3449-0000-b00.dtb \


### PR DESCRIPTION
When adding support for booting from external devices, the composition of the KERNEL_ROOTSPEC setting got refactored so that the Nano and 2GB Nano dev kits no longer needed to override the full setting. I forgot about that when updating the Nano machine configs, and just copy-pasted the old setting to the new KERNEL_ROOTSPEC_DEFAULT variable. Fix that so the setting includes just the device name, like it's supposed to.


Fixes #1198