### PR TITLE
Update find-jetson-usb.sh to support usb hubs

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/find-jetson-usb.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/find-jetson-usb.sh
@@ -52,12 +52,12 @@ find_jetson() {
 	    printf "%s-%s" $(cat "$usbpath/busnum") $(cat "$usbpath/devpath")
 	    return 0
 	fi
-    done < <(ls -d /sys/bus/usb/devices/usb*/*-* 2>/dev/null | grep -v ':')
+    done < <(ls -d /sys/bus/usb/devices/*-* 2>/dev/null | grep -v ':')
     return 1
 }
 
 find_buspath() {
-    usbpath=$(ls -d /sys/bus/usb/devices/usb*/$1 2>/dev/null)
+    usbpath=$(ls -d /sys/bus/usb/devices/$1 2>/dev/null)
     if [ -z "$usbpath" ]; then
 	return 1
     fi


### PR DESCRIPTION
Currently, the `find-jetson-usb` script only looks for one level of usb devices, which doesn't let you use a usb hub

all the devices are symlinked automatically to the top level directory under `/sys/bus/usb/devices`, so we can just look at those to support direct connections and usb hubs

Not sure if this the right branch to target