### PR TITLE
edk2-firmware-tegra: use bfd linker

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-tegra-35.2.1.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-35.2.1.inc
@@ -35,6 +35,7 @@ SRC_URI += "file://0001-Fix-eeprom-customer-part-numbers.patch;patchdir=.."
 SRC_URI += "file://0002-Disable-outline-atomics-in-eqos-driver.patch;patchdir=.."
 SRC_URI += "file://0003-Fix-RCM-boot-detection.patch;patchdir=.."
 SRC_URI += "file://0004-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch;patchdir=.."
+SRC_URI += "file://0005-Use-bfd-linker.patch;patchdir=.."
 
 S = "${WORKDIR}/edk2-tegra/edk2"
 

--- a/recipes-bsp/uefi/files/0005-Use-bfd-linker.patch
+++ b/recipes-bsp/uefi/files/0005-Use-bfd-linker.patch
@@ -1,0 +1,34 @@
+From 071b1a911c21b3a93c573bd121ce280842c06838 Mon Sep 17 00:00:00 2001
+From: Samuli Piippo <samuli.piippo@qt.io>
+Date: Tue, 14 Mar 2023 07:54:40 +0000
+Subject: [PATCH] Use bfd linker
+
+Builds fails when using gold linker:
+
+| Building ... /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/edk2-tegra/edk2-nvidia/Silicon/NVIDIA/Drivers/NorFlashDxe/NorFlashDxe.inf [AARCH64]
+| /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/
+12.2.0/ld: error: /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/edk2-tegra/edk2/BaseTools/Scripts/GccBase.lds:54:10: INFO section type is unsupported
+| /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/
+12.2.0/ld: error: /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/edk2-tegra/edk2/BaseTools/Scripts/GccBase.lds:66:14: INFO section type is unsupported
+| /home/qt/boot2qt/build-jetson-agx-xavier-devkit/tmp/work/jetson_agx_xavier_devkit-poky-linux/edk2-firmware-tegra/35.2.1-r0/recipe-sysroot-native/usr/bin/aarch64-poky-linux/../../libexec/aarch64-poky-linux/gcc/aarch64-poky-linux/
+12.2.0/ld: internal error in do_layout, at ../../gold/object.cc:1939
+| collect2: error: ld returned 1 exit status
+
+
+---
+ edk2/BaseTools/Conf/tools_def.template | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/edk2/BaseTools/Conf/tools_def.template b/edk2/BaseTools/Conf/tools_def.template
+index 5ed1981..945c025 100755
+--- a/edk2/BaseTools/Conf/tools_def.template
++++ b/edk2/BaseTools/Conf/tools_def.template
+@@ -1858,7 +1858,7 @@ DEFINE GCC_AARCH64_CC_XIPFLAGS     = -mstrict-align -mgeneral-regs-only
+ DEFINE GCC_DLINK_FLAGS_COMMON      = -nostdlib --pie
+ DEFINE GCC_DLINK2_FLAGS_COMMON     = -Wl,--script=$(EDK_TOOLS_PATH)/Scripts/GccBase.lds
+ DEFINE GCC_IA32_X64_DLINK_COMMON   = DEF(GCC_DLINK_FLAGS_COMMON) --gc-sections
+-DEFINE GCC_ARM_AARCH64_DLINK_COMMON= -Wl,--emit-relocs -nostdlib -Wl,--gc-sections -u $(IMAGE_ENTRY_POINT) -Wl,-e,$(IMAGE_ENTRY_POINT),-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map
++DEFINE GCC_ARM_AARCH64_DLINK_COMMON= -Wl,--emit-relocs -nostdlib -Wl,-fuse-ld=bfd -Wl,--gc-sections -u $(IMAGE_ENTRY_POINT) -Wl,-e,$(IMAGE_ENTRY_POINT),-Map,$(DEST_DIR_DEBUG)/$(BASE_NAME).map
+ DEFINE GCC_ARM_DLINK_FLAGS         = DEF(GCC_ARM_AARCH64_DLINK_COMMON) -z common-page-size=0x20 -Wl,--pic-veneer
+ DEFINE GCC_AARCH64_DLINK_FLAGS     = DEF(GCC_ARM_AARCH64_DLINK_COMMON) -z common-page-size=0x20
+ DEFINE GCC_ARM_AARCH64_ASLDLINK_FLAGS = -Wl,--defsym=PECOFF_HEADER_SIZE=0 DEF(GCC_DLINK2_FLAGS_COMMON) -z common-page-size=0x20


### PR DESCRIPTION
Build fails if using gold linker with DISTRO_FEATURE ld-is-gold. Add compiler flags to always use bfd linker.