### PR TITLE
tegra-flash-reboot: fix build with clang 16

### DIFF
--- a/recipes-core/initrdscripts/tegra-flash-reboot/reboot-recovery.c
+++ b/recipes-core/initrdscripts/tegra-flash-reboot/reboot-recovery.c
@@ -2,6 +2,7 @@
 #include <linux/reboot.h>
 #include <sys/reboot.h>
 #include <sys/syscall.h>
+#include <unistd.h>
 
 static inline int sys_reboot(const void *arg) {
 	return (int) syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, LINUX_REBOOT_CMD_RESTART2, arg);


### PR DESCRIPTION
```
| /build/tmp/work/armv8a_tegra-lmp-linux/tegra-flash-reboot/1.0-r0/reboot-recovery.c:8:15: error: call to undeclared function 'syscall'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
|         return (int) syscall(SYS_reboot, LINUX_REBOOT_MAGIC1, LINUX_REBOOT_MAGIC2, LINUX_REBOOT_CMD_RESTART2, arg);
|                      ^
```