### PR TITLE
uefi: capsule updates support

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra194-flash-helper.sh
@@ -593,7 +593,7 @@ if [ $bup_blob -ne 0 ]; then
     TBCFILE="uefi_jetson.bin"
     TOSFILE="tos-optee_t194.img"
     . "$here/l4t_bup_gen.func"
-    spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-${BOOTDEV}"
+    spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-"
     if [ $(expr length "$spec") -ge 128 ]; then
 	echo "ERR: TNSPEC must be shorter than 128 characters: $spec" >&2
 	exit 1

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
@@ -672,7 +672,7 @@ if [ $bup_blob -ne 0 ]; then
     bpfdtbfilename="$BPFDTB_FILE"
     localbootfile="boot.img"
     . "$here/l4t_bup_gen.func"
-    spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-${BOOTDEV}"
+    spec="${BOARDID}-${FAB}-${BOARDSKU}-${BOARDREV}-1-${CHIPREV}-${MACHINE}-"
     if [ $(expr length "$spec") -ge 128 ]; then
         echo "ERR: TNSPEC must be shorter than 128 characters: $spec" >&2
         exit 1

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
@@ -26,7 +26,7 @@ set_efi_var() {
 	fi
 	if [ ! -e "$ESPVARDIR/${varname}-${nv_guid}" ]; then
 	    local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)
-	    printf "%s%s" "\x07\x00\x00\x00" "$value" > "$datatmp"
+	    printf "\x07\x00\x00\x00%s" "$value" > "$datatmp"
 	    mkdir -p -m 0700 "$ESPVARDIR" || return 1
 	    cp "$datatmp" "$ESPVARDIR/${varname}-${nv_guid}" || return 1
 	fi
@@ -126,13 +126,13 @@ if [ -z "${boardspec}" ]; then
 fi
 rc=0
 mmc_only_hack=$(echo "$boardspec" | needs_mmc_hack)
-set_efi_var "TegraPlatformSpec" "${boardspec}-${TARGET}-${BOOTDEV}" || rc=1
+set_efi_var "TegraPlatformSpec" "${boardspec}-${TARGET}-" || rc=1
 compatspec=$(echo "$boardspec" | gen_compat_spec)
 if [ -z "$compatspec" ]; then
     compatsed="-e/^COMPATIBLE_SPEC/d"
 else
     compatsed="-es,@COMPATIBLE_SPEC@,${compatspec}-${TARGET}-,"
-    set_efi_var "TegraPlatformCompatSpec" "${boardspec}-${TARGET}-" || rc=1
+    set_efi_var "TegraPlatformCompatSpec" "${compatspec}-${TARGET}-" || rc=1
 fi
 sed -e"s,@TNSPEC@,${boardspec}-${TARGET}-${BOOTDEV}," $compatsed \
     "${sysconfdir}/nv_boot_control.template" > "$controlfile" || rc=1


### PR DESCRIPTION
Add changes to support manual [UEFI Capsule Updates](https://docs.nvidia.com/jetson/archives/r35.2.1/DeveloperGuide/text/SD/Bootloader/UpdateAndRedundancy.html#manually-trigger-the-capsule-update) in Jetpack 5.1.  This includes:

* Modifying efi variables to match stock L4T
* Modifying bup specs to match stock L4T

Tested with the sequence below and a manually generated capsule update.  The next step will be to automatically generate this capsule update as a part of the build.

Create the capsule update directory on the target:
```
mkdir -p /opt/nvidia/esp/EFI/UpdateCapsule/
```

Then on the host machine, from `~/nvidia_sdk/JetPack_5.1_Linux_JETSON_AGX_XAVIER_TARGETS/Linux_for_Tegra`, run
```
./generate_capsule/l4t_generate_soc_capsule.sh -i ~/<path to your build dir>/tmp/deploy/images/jetson-agx-xavier-devkit/tegra-minimal-initramfs-jetson-agx-xavier-devkit.bl_
only.bup-payload -o ./TEGRA_BL.Cap t194
```

Then copy to the target using
```
scp TEGRA_BL.Cap root@jetson-agx-xavier-devkit.local:/opt/nvidia/esp/EFI/UpdateCapsule/
```
Set the OSIndications variable to request a capsule update on the next boot
```
cd /opt/nvidia/esp/EFI/NVDA/Variables
printf "\x07\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00" > /tmp/var_tmp.bin
dd if=/tmp/var_tmp.bin of=OsIndications-8be4df61-93ca-11d2-aa0d-00e098032b8c bs=12
```
`reboot` the target
Then check `nvbootctrl dump-slots-info` to confirm capsule update status is 1 and current bootloader slot has changed to slot B

```
root@jetson-agx-xavier-devkit:~# nvbootctrl dump-slots-info
Current version: 35.2.1
Capsule update status: 1
Current bootloader slot: B
Active bootloader slot: B
num_slots: 2
slot: 0,             status: normal
slot: 1,             status: normal
root@jetson-agx-xavier-devkit:~#
```
