### PR TITLE
l4t-launcher-extlinux: fix dependencies for virtual/dtb provider

### DIFF
--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -52,7 +52,8 @@ python do_concat_dtb_overlays() {
                                           os.path.join(d.getVar('B'), d.getVar('DTBFILE')), d)
 }
 do_concat_dtb_overlays[dirs] = "${B}"
-do_concat_dtb_overlays[depends] += "${@'virtual/dtb:do_populate_sysroot' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else 'virtual/kernel:do_deploy'}"
+do_concat_dtb_overlays[depends] += "virtual/kernel:do_deploy"
+do_concat_dtb_overlays[depends] += "${@'virtual/dtb:do_populate_sysroot' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else ''}"
 
 addtask concat_dtb_overlays after do_configure before do_sign_files
 


### PR DESCRIPTION
When using a virtual/dtb provider, it is possible that not all dtb artifacts will come from there. This is typically the case when the virtual/dtb makes the main device tree binary, but some of the built in TEGRA_PLUGIN_MANAGER_OVERLAYS from linux-tegra are used.

Rather than try to sort out if we actually need anything from linux-tegra or not, just assume that we do. And the additional depends on virtual/dtb will be added if we need it.