### PR TITLE
tegra-flashtools-native: apply secureboot overlay

### DIFF
--- a/recipes-bsp/tegra-binaries/files/0015-tegrasign_v3_internal-overlay.patch
+++ b/recipes-bsp/tegra-binaries/files/0015-tegrasign_v3_internal-overlay.patch
@@ -1,0 +1,111 @@
+Index: Linux_for_Tegra/bootloader/tegrasign_v3_internal.py
+===================================================================
+--- Linux_for_Tegra.orig/bootloader/tegrasign_v3_internal.py
++++ Linux_for_Tegra/bootloader/tegrasign_v3_internal.py
+@@ -1115,7 +1115,6 @@ def do_kdf_params_t234(dk, params, kdf_l
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     # Derive the key relationship: dk -> kdk -> *_dec_kdk
+     dk_params = params['DK'][dk]
+@@ -1166,21 +1165,12 @@ def do_kdf_params_t234(dk, params, kdf_l
+         bl_dec_kdk_ctx['Msg'] = None
+         fw_dec_kdk_ctx['Msg'] = None
+ 
+-    dec_kdk_params = params['DEC_KDK'][kdk_to_use]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        'Label' : dec_kdk_params['Label'],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+ 
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.FLAG):
+         kdf_list.pop()
+ 
+-    return ([dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], dec_kdk_ctx["Msg"],
++    return ([None, None,
+             bl_dec_kdk_ctx["Msg"], kdk_ctx["Msg"], dk_ctx["Msg"]])
+ 
+ def do_kdf(params_slist, kdf_list):
+@@ -1260,7 +1250,6 @@ def do_kdf_params_oem_t234(dk, params, k
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     dk_params = params['DK'][dk]
+     dk_ctx = {
+@@ -1355,20 +1344,8 @@ def do_kdf_params_oem_t234(dk, params, k
+         count = count - 1
+ 
+     aes_params = params['AES'][kdk_to_use]
+-    aes_iv = manifest_xor_offset(basic_params[aes_params['IV']], aes_params["Offset"])
+-    aes_aad = aes_params['Manifest'] + AAD_0_96
+     aes_tag = bytes(16)
+ 
+-    dec_kdk_params = params['DEC_KDK'][aes_params['KDK']]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        "Label" : dec_kdk_params["Label"],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+-
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.DKSTR):
+         kdf_list.pop()
+@@ -1381,7 +1358,7 @@ def do_kdf_params_oem_t234(dk, params, k
+             if extract_AES_key(key_buf, p_key):
+                 sbk_keystr = hex_to_str(p_key.key.aeskey)
+ 
+-    return [dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], aes_iv,  aes_aad, sbk_keystr, dec_kdk_ctx['Msg'],
++    return [None, None, None, sbk_keystr, None,
+             bl_kdk_ctx['Msg'], tz_kdk_ctx['Msg'], gp_kdk_ctx['Msg'], gpto_kdk_ctx['Msg'],  kdk_ctx['Msg'], dk_ctx['Msg']]
+ 
+ def do_kdf_params_oem(dk, params, kdf_list, p_key):
+@@ -1389,7 +1366,6 @@ def do_kdf_params_oem(dk, params, kdf_li
+     is_hex = True
+     is_str = False
+     L = 256
+-    basic_params = params['BASIC']
+ 
+     dk_params = params['DK'][dk]
+     dk_ctx = {
+@@ -1488,20 +1464,8 @@ def do_kdf_params_oem(dk, params, kdf_li
+         count = count - 1
+ 
+     aes_params = params['AES'][kdk_to_use]
+-    aes_iv = manifest_xor_offset(basic_params[aes_params['IV']], aes_params["Offset"])
+-    aes_aad = aes_params['Manifest'] + AAD_0_96
+     aes_tag = bytes(16)
+ 
+-    dec_kdk_params = params['DEC_KDK'][aes_params['KDK']]
+-
+-    dec_kdk_ctx = {
+-        'KDK'   : basic_params[dec_kdk_params['KDK']],
+-        'KDD'   : basic_params[dec_kdk_params['KDD']],
+-        "Label" : dec_kdk_params["Label"],
+-    }
+-
+-    dec_kdk_ctx["Msg"] = get_composed_msg(dec_kdk_ctx['Label'], '', L, is_str)
+-
+     # Pop the elements that are no longer needed
+     while (len(kdf_list) > KdfArg.DKSTR):
+         kdf_list.pop()
+@@ -1514,7 +1478,7 @@ def do_kdf_params_oem(dk, params, kdf_li
+             if extract_AES_key(key_buf, p_key):
+                 sbk_keystr = hex_to_str(p_key.key.aeskey)
+ 
+-    return [dec_kdk_ctx['KDK'] + dec_kdk_ctx['KDD'], aes_iv,  aes_aad, sbk_keystr, dec_kdk_ctx['Msg'],
++    return [None, None, None, sbk_keystr, None,
+             bl_kdk_ctx['Msg'], tz_kdk_ctx['Msg'], gp_kdk_ctx['Msg'], gpto_kdk_ctx['Msg'],  kdk_ctx['Msg'], dk_ctx['Msg']]
+ 
+ # calls for offset, then enc, then do sha and returns

--- a/recipes-bsp/tegra-binaries/tegra-flashtools-native_35.2.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-flashtools-native_35.2.1.bb
@@ -1,5 +1,8 @@
 require tegra-binaries-${PV}.inc
 
+SRC_URI += "https://developer.download.nvidia.com/embedded/L4T/${@l4t_release_dir(d)}/secureboot_overlay_${L4T_VERSION}.tbz2;name=sboverlay;subdir=sboverlay"
+SRC_URI[sboverlay.sha256sum] = "5036ce047cddc87c59770fd7114c46c010bb13d9ee7d8012cc8f9e2c71946762"
+
 WORKDIR = "${TMPDIR}/work-shared/L4T-native-${PV}-${PR}"
 SSTATE_SWSPEC = "sstate:tegra-binaries-native::${PV}:${PR}::${SSTATE_VERSION}:"
 STAMP = "${STAMPS_DIR}/work-shared/L4T-native-${PV}-${PR}"
@@ -12,6 +15,7 @@ SRC_URI += "\
            file://0010-Rework-logging-in-l4t_sign_image.sh.patch \
            file://0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch \
            file://0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch \
+           file://0015-tegrasign_v3_internal-overlay.patch \
            "
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"
@@ -28,6 +32,12 @@ do_compile[noexec] = "1"
 BINDIR = "${bindir}/tegra-flash"
 
 addtask preconfigure after do_patch before do_configure
+
+add_overlay_files() {
+    cp ${WORKDIR}/sboverlay/Linux_for_Tegra/bootloader/tegrasign_v3_oemkey.yaml ${S}/bootloader/
+    cp ${WORKDIR}/sboverlay/Linux_for_Tegra/license.txt ${S}/
+}
+do_unpack[postfuncs] += "add_overlay_files"
 
 do_install() {
     install -d ${D}${BINDIR}


### PR DESCRIPTION
This applies the secureboot_overlay_35.2.1.tbz2 update to the signing tools that enables secure boot on Orin platforms.