### PR TITLE
tegra-flashtools-native: install tegrasign_v3* files

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-flashtools-native_35.2.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-flashtools-native_35.2.1.bb
@@ -48,7 +48,7 @@ do_install() {
     install -m 0755 ${S}/bootloader/tegraparser_v2 ${D}${BINDIR}
     install -m 0755 ${S}/bootloader/tegrarcm_v2 ${D}${BINDIR}
     install -m 0755 ${S}/bootloader/tegrasign_v2 ${D}${BINDIR}
-    install -m 0755 ${S}/bootloader/tegrasign_v3*py ${D}${BINDIR}
+    install -m 0755 ${S}/bootloader/tegrasign_v3* ${D}${BINDIR}
     install -m 0755 ${S}/bootloader/tegraopenssl ${D}${BINDIR}
     install -d ${D}${BINDIR}/pyfdt
     install -m 0644 ${S}/bootloader/pyfdt/*.py ${D}${BINDIR}/pyfdt/


### PR DESCRIPTION
This fixes an issue where the tegrasign_v3_oemkey.yaml file was not being installed by the existing 'tegrasign_v3*py' install rule.