### PR TITLE
Add tegra-pinmux-dts2cfg for xavier

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-pinmux-dts2cfg_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-pinmux-dts2cfg_35.3.1.bb
@@ -1,0 +1,39 @@
+# Recipe for providing the pinmux-dts2cfg.py script for converting nvidia dtsi
+# files to nvidia cfg files - used later for minimal initramfs for pin setup
+
+require recipes-bsp/tegra-binaries/tegra-binaries-${PV}.inc
+
+DESCRIPTION = "pixmux-dts2cfg for converting dtsi to cfg - used on xavier"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Being a python tool used on native host, we need to clear COMPATIBLE_MACHINE
+COMPATIBLE_MACHINE = ""
+
+# Normally used as native package E.g. convert the dtsi to cfg on host, but
+# support target install also.
+BBCLASSEXTEND = "native nativesdk"
+
+# Need to setup workdir like set in include file after extending to native
+# Also see tegra-flashtools-native for similar setup.
+WORKDIR = "${TMPDIR}/work-shared/L4T-${L4T_BSP_ARCH}-${PV}-${PR}"
+SSTATE_SWSPEC = "sstate:tegra-binaries-${L4T_BSP_ARCH}::${PV}:${PR}::${SSTATE_VERSION}:"
+STAMP = "${STAMPS_DIR}/work-shared/L4T-${L4T_BSP_ARCH}-${PV}-${PR}"
+STAMPCLEAN = "${STAMPS_DIR}/work-shared/L4T-${L4T_BSP_ARCH}-${PV}-*"
+
+S = "${TMPDIR}/work-shared/L4T-${L4T_BSP_ARCH}-${PV}-${PR}/Linux_for_Tegra"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/kernel/pinmux/t19x/pinmux-dts2cfg.py ${D}${bindir}/
+
+    install -d ${D}${datadir}/tegra-pinmux/
+    install -m 0644 ${S}/kernel/pinmux/t19x/addr_info.txt ${D}${datadir}/tegra-pinmux/
+    install -m 0644 ${S}/kernel/pinmux/t19x/gpio_addr_info.txt ${D}${datadir}/tegra-pinmux/
+    install -m 0644 ${S}/kernel/pinmux/t19x/mandatory_pinmux.txt ${D}${datadir}/tegra-pinmux/
+    install -m 0644 ${S}/kernel/pinmux/t19x/pad_info.txt ${D}${datadir}/tegra-pinmux/
+    install -m 0644 ${S}/kernel/pinmux/t19x/por_val.txt ${D}${datadir}/tegra-pinmux/
+}


### PR DESCRIPTION
Can be used to convert the dtsi files comming from nvidia excel sheet to cfg files used later by flashvars / minimal initramfs.

On your local bsp layer you can create a recipe like this for a single machine. Just use it as inspiration

```
DESCRIPTION = "pinmux - xxxx"

# License setup

DEPENDS = "tegra-pinmux-dts2cfg-native"

# only applicable for specific machine
COMPATIBLE_MACHINE = "xxxx"

# Use machine specific work folder. 
PACKAGE_ARCH = "${MACHINE_ARCH}"

SRC_URI = "path-to-your-git-repo-with-excel-and-dtsi-files"
SRCREV = "xyz"

S = "${WORKDIR}/git"
B = "${WORKDIR}/build"

do_configure[noexec] = "1"

do_compile() {
  # see README.txt in L4T-tegra-35.3.1-r0/Linux_for_Tegra/kernel/pinmux/t19x/

  # PINMUX and GPIO
  python3 ${RECIPE_SYSROOT_NATIVE}${bindir}/pinmux-dts2cfg.py \
    --pinmux \
    ${RECIPE_SYSROOT_NATIVE}${datadir}/tegra-pinmux/addr_info.txt \
    ${RECIPE_SYSROOT_NATIVE}${datadir}/tegra-pinmux/gpio_addr_info.txt \
    ${RECIPE_SYSROOT_NATIVE}${datadir}/tegra-pinmux/por_val.txt \
    --mandatory_pinmux_file ${RECIPE_SYSROOT_NATIVE}${datadir}/tegra-pinmux/mandatory_pinmux.txt \
    ${S}/pinmux/tegra19x-xxxx-pinmux.dtsi \
    ${S}/pinmux/tegra19x-xxxx-default.dtsi \
    1.0 > ${B}/tegra19x-mb1-pinmux-p2888-0000-a04-xxxx.cfg

  # Pad voltage
  python3 ${RECIPE_SYSROOT_NATIVE}${bindir}/pinmux-dts2cfg.py \
    --pad \
    ${RECIPE_SYSROOT_NATIVE}${datadir}/tegra-pinmux/pad_info.txt \
    ${S}/pinmux/tegra19x-xxxx-padvoltage-default.dtsi \
    1.0 > ${B}/tegra19x-mb1-padvoltage-p2888-0000-a04-xxxx.cfg    
}

do_install() {
  # Copy cfg files to tegraflash like the other cfg files - see tegra-bootfiles recipe
  # install -m 0644 ${S}/bootloader/${NVIDIA_BOARD}/BCT/tegra19* ${D}${datadir}/tegraflash/

  install -d ${D}${datadir}/tegraflash
  install -m 0644 ${B}/tegra19x*.cfg ${D}${datadir}/tegraflash/ 
}

# Add the cfg files to dev package like the similar cfg files in tegra-bootfiles
FILES:${PN}-dev = "${datadir}"
```