### PR TITLE
Refactor tegra-libraries-multimedia

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-ds_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-ds_35.3.1.bb
@@ -1,0 +1,29 @@
+L4T_DEB_COPYRIGHT_MD5 = "3d9212d4d5911fa3200298cd55ed6621"
+DEPENDS = "tegra-libraries-multimedia glib-2.0 gstreamer1.0-plugins-base"
+
+L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-multimedia"
+
+require tegra-debian-libraries-common.inc
+
+LICENSE += "& MIT & BSD-3-Clause"
+
+MAINSUM = "83dd039e6e790fd0aae4a1e68101ba1ac75b661038142e6ded826a35ff27376e"
+
+inherit features_check
+
+REQUIRED_DISTRO_FEATURES = "opengl"
+
+TEGRA_LIBRARIES_TO_INSTALL = "\
+    tegra/libnvdsbufferpool.so.1.0.0 \
+"
+
+do_install() {
+    install_libraries
+    for libname in nvdsbufferpool; do
+	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so.1
+	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so
+    done
+}
+
+FILES_SOLIBSDEV = ""
+SOLIBS = ".so*"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-utils_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-utils_35.3.1.bb
@@ -17,7 +17,7 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
 
 do_install() {
     install_libraries
-    for libname in nvbuf_utils; do
+    for libname in nvbufsurface nvbuf_utils; do
 	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so.1
 	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so
     done

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia_35.3.1.bb
@@ -1,5 +1,5 @@
 L4T_DEB_COPYRIGHT_MD5 = "3d9212d4d5911fa3200298cd55ed6621"
-DEPENDS = "tegra-libraries-core tegra-libraries-cuda tegra-libraries-multimedia-utils tegra-libraries-nvsci pango cairo glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base virtual/egl"
+DEPENDS = "tegra-libraries-core tegra-libraries-cuda tegra-libraries-multimedia-utils tegra-libraries-nvsci pango cairo glib-2.0 virtual/egl"
 
 require tegra-debian-libraries-common.inc
 
@@ -19,7 +19,6 @@ REQUIRED_DISTRO_FEATURES = "opengl"
 TEGRA_LIBRARIES_TO_INSTALL = "\
     tegra/libnvbufsurftransform.so.1.0.0 \
     tegra/libnvdecode2eglimage.so \
-    tegra/libnvdsbufferpool.so.1.0.0 \
     tegra/libnveventlib.so \
     tegra/libnvexif.so \
     tegra/libnvid_mapper.so.1.0.0 \
@@ -59,7 +58,7 @@ TEGRA_LIBRARIES_TO_INSTALL = "\
 
 do_install() {
     install_libraries
-    for libname in nvdsbufferpool nvbufsurface nvbufsurftransform nvid_mapper; do
+    for libname in nvbufsurftransform nvid_mapper; do
 	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so.1
 	ln -sf lib$libname.so.1.0.0 ${D}${libdir}/lib$libname.so
     done

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r35.3.1.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r35.3.1.bb
@@ -14,7 +14,7 @@ SRC_URI += "\
     file://0001-Build-fixups.patch \
 "
 
-DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries-camera tegra-mmapi"
+DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries-camera tegra-libraries-multimedia-ds tegra-mmapi"
 
 S = "${WORKDIR}/gst-nvarguscamera"
 


### PR DESCRIPTION
Creates a new recipe to install the `libnvdsbufferpool.so` library so that the main `tegra-libraries-multimedia` recipe doesn't have to depend on `gstreamer1.0-plugins-base`.

Fixes #1243 