### PR TITLE
[kirkstone-l4t-r32.7.x] update tegra-boot-tools: 3.1.0 -> 3.1.1

### DIFF
--- a/recipes-bsp/tools/tegra-boot-tools.inc
+++ b/recipes-bsp/tools/tegra-boot-tools.inc
@@ -1,0 +1,45 @@
+DESCRIPTION = "Boot-related tools for Tegra platforms"
+HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
+LICENSE = "MIT & BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=481ed6124b0f84b3a5ad255a328bcaa5"
+
+DEPENDS = "zlib util-linux-libuuid systemd tegra-eeprom-tool"
+
+OTABOOTDEV ??= "/dev/mmcblk0boot0"
+OTAGPTDEV ??= "/dev/mmcblk0boot1"
+
+EXTRA_OECMAKE = "-DSYSTEMD_SYSTEM_UNITDIR=${systemd_system_unitdir} \
+                 -DMACHINE=${MACHINE} \
+                 -DBOOT_DEVICE=${OTABOOTDEV} -DGPT_DEVICE=${OTAGPTDEV}"
+
+inherit cmake pkgconfig systemd features_check
+
+REQUIRED_DISTRO_FEATURES = "systemd"
+
+SYSTEMD_PACKAGES = "${PN}-earlyboot ${PN}-lateboot"
+
+PACKAGES =+ "libtegra-boot-tools ${PN}-earlyboot ${PN}-lateboot ${PN}-updater ${PN}-nvbootctrl ${PN}-nv-update-engine"
+
+SYSTEMD_SERVICE:${PN}-earlyboot = "bootcountcheck.service"
+SYSTEMD_SERVICE:${PN}-lateboot = "update_bootinfo.service"
+
+FILES:libtegra-boot-tools = "${libdir}/libtegra-boot-tools${SOLIBS} ${datadir}/tegra-boot-tools"
+
+FILES:${PN}-earlyboot = "${sbindir}/bootcountcheck"
+RDEPENDS:${PN}-earlyboot = "${PN}"
+
+RDEPENDS:${PN}-lateboot = "${PN}"
+
+FILES:${PN}-updater = "${bindir}/tegra-bootloader-update"
+RDEPENDS:${PN}-updater = "${PN} tegra-bootpart-config"
+
+FILES:${PN} += "${libdir}/tmpfiles.d"
+
+FILES:${PN}-nvbootctrl = "${sbindir}/nvbootctrl"
+RDEPENDS:${PN}-nvbootctrl = "${PN}"
+RCONFLICTS:${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
+FILES:${PN}-nv-update-engine = "${sbindir}/nv_update_engine"
+RDEPENDS:${PN}-nv-update-engine = "${PN}-updater ${PN}"
+RCONFLICTS:${PN}-nv-update-engine = "tegra-redundant-boot-base"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/tools/tegra-boot-tools_3.1.0.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_3.1.0.bb
@@ -1,48 +1,5 @@
-DESCRIPTION = "Boot-related tools for Tegra platforms"
-HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
-LICENSE = "MIT & BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=481ed6124b0f84b3a5ad255a328bcaa5"
-
-DEPENDS = "zlib util-linux-libuuid systemd tegra-eeprom-tool"
+require tegra-boot-tools.inc
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
 SRC_URI[sha256sum] = "e370b883ba9e44c170b7fdccfcb1771faebbf379d5b6cb7c94b1e24018211aae"
 
-OTABOOTDEV ??= "/dev/mmcblk0boot0"
-OTAGPTDEV ??= "/dev/mmcblk0boot1"
-
-EXTRA_OECMAKE = "-DSYSTEMD_SYSTEM_UNITDIR=${systemd_system_unitdir} \
-                 -DMACHINE=${MACHINE} \
-                 -DBOOT_DEVICE=${OTABOOTDEV} -DGPT_DEVICE=${OTAGPTDEV}"
-
-inherit cmake pkgconfig systemd features_check
-
-REQUIRED_DISTRO_FEATURES = "systemd"
-
-SYSTEMD_PACKAGES = "${PN}-earlyboot ${PN}-lateboot"
-
-PACKAGES =+ "libtegra-boot-tools ${PN}-earlyboot ${PN}-lateboot ${PN}-updater ${PN}-nvbootctrl ${PN}-nv-update-engine"
-
-SYSTEMD_SERVICE:${PN}-earlyboot = "bootcountcheck.service"
-SYSTEMD_SERVICE:${PN}-lateboot = "update_bootinfo.service"
-
-FILES:libtegra-boot-tools = "${libdir}/libtegra-boot-tools${SOLIBS} ${datadir}/tegra-boot-tools"
-
-FILES:${PN}-earlyboot = "${sbindir}/bootcountcheck"
-RDEPENDS:${PN}-earlyboot = "${PN}"
-
-RDEPENDS:${PN}-lateboot = "${PN}"
-
-FILES:${PN}-updater = "${bindir}/tegra-bootloader-update"
-RDEPENDS:${PN}-updater = "${PN} tegra-bootpart-config"
-
-FILES:${PN} += "${libdir}/tmpfiles.d"
-
-FILES:${PN}-nvbootctrl = "${sbindir}/nvbootctrl"
-RDEPENDS:${PN}-nvbootctrl = "${PN}"
-RCONFLICTS:${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
-FILES:${PN}-nv-update-engine = "${sbindir}/nv_update_engine"
-RDEPENDS:${PN}-nv-update-engine = "${PN}-updater ${PN}"
-RCONFLICTS:${PN}-nv-update-engine = "tegra-redundant-boot-base"
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/tools/tegra-boot-tools_3.1.1.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_3.1.1.bb
@@ -1,5 +1,5 @@
 require tegra-boot-tools.inc
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "e370b883ba9e44c170b7fdccfcb1771faebbf379d5b6cb7c94b1e24018211aae"
+SRC_URI[sha256sum] = "26c6c0d0678a70342604ab1f974931289117c0776af14b5e1bc393bbbe157818"
 

--- a/recipes-bsp/tools/tegra-boot-tools_git.bb
+++ b/recipes-bsp/tools/tegra-boot-tools_git.bb
@@ -1,11 +1,4 @@
-DESCRIPTION = "Boot-related tools for Tegra platforms"
-HOMEPAGE = "https://github.com/OE4T/tegra-boot-tools"
-LICENSE = "MIT & BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=481ed6124b0f84b3a5ad255a328bcaa5"
-
-DEFAULT_PREFERENCE = "-1"
-
-DEPENDS = "zlib util-linux-libuuid systemd tegra-eeprom-tool"
+require tegra-boot-tools.inc
 
 SRC_REPO = "github.com/OE4T/tegra-boot-tools.git;protocol=https"
 SRCBRANCH = "master"
@@ -15,43 +8,5 @@ SRCREV = "${AUTOREV}"
 PV = "3.0.99+git${SRCPV}"
 S = "${WORKDIR}/git"
 
+DEFAULT_PREFERENCE = "-1"
 DEBUG_BUILD = "1"
-
-OTABOOTDEV ??= "/dev/mmcblk0boot0"
-OTAGPTDEV ??= "/dev/mmcblk0boot1"
-
-EXTRA_OECMAKE = "-DSYSTEMD_SYSTEM_UNITDIR=${systemd_system_unitdir} \
-                 -DMACHINE=${MACHINE} \
-                 -DBOOT_DEVICE=${OTABOOTDEV} -DGPT_DEVICE=${OTAGPTDEV}"
-
-inherit cmake pkgconfig systemd features_check
-
-REQUIRED_DISTRO_FEATURES = "systemd"
-
-SYSTEMD_PACKAGES = "${PN}-earlyboot ${PN}-lateboot"
-
-PACKAGES =+ "libtegra-boot-tools ${PN}-earlyboot ${PN}-lateboot ${PN}-updater ${PN}-nvbootctrl ${PN}-nv-update-engine"
-
-SYSTEMD_SERVICE:${PN}-earlyboot = "bootcountcheck.service"
-SYSTEMD_SERVICE:${PN}-lateboot = "update_bootinfo.service"
-
-FILES:libtegra-boot-tools = "${libdir}/libtegra-boot-tools${SOLIBS} ${datadir}/tegra-boot-tools"
-
-FILES:${PN}-earlyboot = "${sbindir}/bootcountcheck"
-RDEPENDS:${PN}-earlyboot = "${PN}"
-
-RDEPENDS:${PN}-lateboot = "${PN}"
-
-FILES:${PN}-updater = "${bindir}/tegra-bootloader-update"
-RDEPENDS:${PN}-updater = "${PN} tegra-bootpart-config"
-
-FILES:${PN} += "${libdir}/tmpfiles.d"
-
-FILES:${PN}-nvbootctrl = "${sbindir}/nvbootctrl"
-RDEPENDS:${PN}-nvbootctrl = "${PN}"
-RCONFLICTS:${PN}-nvbootctrl = "tegra-redundant-boot-nvbootctrl"
-FILES:${PN}-nv-update-engine = "${sbindir}/nv_update_engine"
-RDEPENDS:${PN}-nv-update-engine = "${PN}-updater ${PN}"
-RCONFLICTS:${PN}-nv-update-engine = "tegra-redundant-boot-base"
-
-PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
* Refactors common settings out of the main and `_git` recipes into a `.inc` file
* Update to [3.1.1](https://github.com/OE4T/tegra-boot-tools/releases/tag/v3.1.1)