### PR TITLE
initrd-flash: Add doflash dry run to retrieve board specs

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -24,6 +24,11 @@ Options passed through to flash helper:
 EOF
 }
 
+# Dry run doflash.sh to retrieve board specs
+./doflash.sh --no-flash
+
+. boardvars.sh
+
 # The build must generate these environment settings
 if [ ! -e .env.initrd-flash ]; then
     echo "Missing environment settings" >&2


### PR DESCRIPTION
Ensure that initrd-flash meets the board's specs parameters during flashing.