### PR TITLE
Fix naming convention of bup payload

### DIFF
--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -765,8 +765,8 @@ create_bup_payload_image() {
     for f in ${WORKDIR}/bup-payload/*_only_payload; do
         [ -e $f ] || continue
         sfx=$(basename $f _payload)
-        install -m 0644 $f ${IMGDEPLOYDIR}/${IMAGE_NAME}.$sfx.bup-payload
-        ln -sf ${IMAGE_NAME}.$sfx.bup-payload ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.$sfx.bup-payload
+        install -m 0644 $f ${IMGDEPLOYDIR}/${IMAGE_NAME}.$sfx.bup_payload
+        ln -sf ${IMAGE_NAME}.$sfx.bup-payload ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.$sfx.bup_payload
     done
 }
 create_bup_payload_image[vardepsexclude] += "DATETIME"

--- a/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
+++ b/recipes-kernel/kernel-bup-payload/kernel-bup-payload.bb
@@ -27,7 +27,7 @@ do_deploy() {
 	    for f in ${WORKDIR}/bup-payload/*_only_payload; do
 		[ -e $f ] || continue
 		sfx=$(basename $f _payload)
-		install -m 0644 $f ${DEPLOYDIR}/${initramfs_symlink_name}.$sfx.bup-payload
+		install -m 0644 $f ${DEPLOYDIR}/${initramfs_symlink_name}.$sfx.bup_payload
 	    done
 	done
     fi


### PR DESCRIPTION
- bbclass and tegra-bup-payload recipe naming convention must match.