### PR TITLE
Add support for building capsules

### DIFF
--- a/classes/tegra-bup.bbclass
+++ b/classes/tegra-bup.bbclass
@@ -1,0 +1,13 @@
+inherit kernel-artifact-names
+
+def bupfile_basename(d):
+    if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
+        return "${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}"
+    return "${INITRAMFS_IMAGE}-${MACHINE}"
+
+def bup_dependency(d):
+    if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
+        return "kernel-bup-payload:do_deploy"
+    return "${INITRAMFS_IMAGE}:do_image_complete"
+
+BUPFILENAME = "${@bupfile_basename(d)}"

--- a/conf/machine/jetson-xavier-nx-devkit-emmc.conf
+++ b/conf/machine/jetson-xavier-nx-devkit-emmc.conf
@@ -5,10 +5,7 @@
 
 TEGRA_BOARDSKU ?= "0001"
 TEGRA_BUPGEN_SPECS ?= "fab=100;boardsku=0001;boardrev= \
-		       fab=200;boardsku=0001;boardrev= \
-		       fab=300;boardsku=0001;boardrev= \
-		       fab=301;boardsku=0001;boardrev= \
-		       fab=301;boardsku=0003;boardrev="
+		       fab=301;boardsku=0001;boardrev="
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
 require conf/machine/include/xavier-nx.inc

--- a/recipes-bsp/tegra-bup-payload/tegra-bup-payload_1.0.bb
+++ b/recipes-bsp/tegra-bup-payload/tegra-bup-payload_1.0.bb
@@ -4,19 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-inherit kernel-artifact-names
-
-def bupfile_basename(d):
-    if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
-        return "${KERNEL_IMAGETYPE}-${INITRAMFS_LINK_NAME}"
-    return "${INITRAMFS_IMAGE}-${MACHINE}"
-
-def bup_dependency(d):
-    if bb.utils.to_boolean(d.getVar('INITRAMFS_IMAGE_BUNDLE')):
-        return "kernel-bup-payload:do_deploy"
-    return "${INITRAMFS_IMAGE}:do_image_complete"
-
-BUPFILENAME = "${@bupfile_basename(d)}"
+inherit tegra-bup
 
 do_install() {
     install -d ${D}/opt/ota_package/

--- a/recipes-bsp/tools/setup-nv-boot-control/oe4t-set-uefi-OSIndications
+++ b/recipes-bsp/tools/setup-nv-boot-control/oe4t-set-uefi-OSIndications
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+source /usr/bin/uefi_common.func
+
+rc=0
+value="\x04\x00\x00\x00\x00\x00\x00\x00"
+set_efi_var "OsIndications" "8be4df61-93ca-11d2-aa0d-00e098032b8c" "$value" || rc=1
+exit $rc

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
@@ -1,132 +1,10 @@
 #!/bin/sh
 TARGET="@TARGET@"
 BOOTDEV="@BOOTDEV@"
-ESPMOUNT="@ESPMOUNT@"
-NVESPMOUNT="@NVIDIA_ESPMOUNT@"
-ESPVARDIR="@ESPVARDIR@"
 sysconfdir="@sysconfdir@"
 controlfile="${sysconfdir}/nv_boot_control.conf"
-nv_guid="781e084c-a330-417c-b678-38e696380cb9"
 
-fab=
-boardsku=
-boardrev=
-chiprev=
-mmc_only_hack=
-
-set_efi_var() {
-    local varname="$1"
-    local value="$2"
-
-    # Only set if it doesn't exist already
-    if [ "$mmc_only_hack" = "yes" ]; then
-	if ! mountpoint -q "$ESPMOUNT"; then
-	    echo "ERR: cannot store EFI variable - ESP partition not mounted" >&2
-	    return 1
-	fi
-	if [ ! -e "$ESPVARDIR/${varname}-${nv_guid}" ]; then
-	    local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)
-	    printf "\x07\x00\x00\x00%s" "$value" > "$datatmp"
-	    mkdir -p -m 0700 "$ESPVARDIR" || return 1
-	    cp "$datatmp" "$ESPVARDIR/${varname}-${nv_guid}" || return 1
-	fi
-    else
-	if efivar -n "${nv_guid}-$varname" >/dev/null 2>&1; then
-	    return 0
-	fi
-	local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)
-	printf "%s" "$value" > "$datatmp"
-	efivar -w -f "$datatmp" -n "${nv_guid}-$varname"
-    fi
-}
-
-gen_compat_2888() {
-    if [ "$fab" = "400" ]; then
-	if [ "$boardsku" = "0004" ]; then
-	    boardrev=
-	else
-	    if echo "$boardrev" | grep -q "^[ABCD]\."; then
-		boardrev="D.0"
-	    else
-		boardrev="E.0"
-	    fi
-	    boardsku="0001"
-	fi
-    elif [ "$fab" = "600" -a "$boardsku" = "0008" ]; then
-	boardrev=
-    fi
-    return 0
-}
-
-gen_compat_3668() {
-    if [ "$fab" != "301" ]; then
-	fab="100"
-    fi
-    boardsku=
-    boardrev=
-    chiprev=
-    return 0
-}
-
-gen_compat_3701() {
-    boardrev=
-    if [ "$boardsku" = "0000" -o "$boardsku" = "0004" ]; then
-	if echo "$fab" | egrep -q "^([012][0-9][0-9]|TS|EB)"; then
-	    fab="000"
-	else
-	    fab="300"
-	fi
-    fi
-    if [ "$boardksu" = "0005" ]; then
-	fab=""
-    fi
-    boardrev=
-    chiprev=
-    return 0
-}
-
-gen_compat_3767() {
-    if [ "$boardsku" = "0000" -o "$boardsku" = "0002" ]; then
-	if ! echo "$fab" | egrep -q "^(TS|EB)"; then
-	    fab="000"
-	fi
-    else
-	fab=
-    fi
-    boardrev=
-    chiprev=
-    return 0
-}
-
-# boardspec should be piped into this function
-gen_compat_spec() {
-    IFS=- read boardid fab boardsku boardrev fuselevel chiprev
-    if gen_compat_$boardid 2>/dev/null; then
-	echo "$boardid-$fab-$boardsku-$boardrev-$fuselevel-$chiprev"
-	return 0
-    fi
-    echo ""
-}
-
-# boardspec should be piped into this function
-needs_mmc_hack() {
-    IFS=- read boardid fab boardsku boardrev fuselevel chiprev
-    if [ "$boardid" = "2888" -a "$fab" = "400" ]; then
-	echo "yes"
-    else
-	echo ""
-    fi
-    return 0
-}
-
-# NVIDIA tools will try to mount the ESP partition dynamically
-# if it's not already mounted at @NVIDIA_ESPMOUNT@, so bind-mount
-# it there if we've mounted that partition at a more typical location.
-if [ -n "$NVESPMOUNT" -a "$NVESPMOUNT" != "$ESPMOUNT" ]; then
-    if mountpoint -q "$ESPMOUNT" && ! mountpoint -q "$NVESPMOUNT"; then
-	mount --bind "$ESPMOUNT" "$NVESPMOUNT"
-    fi
-fi
+source /usr/bin/uefi_common.func
 
 [ ! -e "$controlfile" ] || exit 0
 
@@ -141,14 +19,13 @@ if [ -z "${boardspec}" ]; then
     exit 1
 fi
 rc=0
-mmc_only_hack=$(echo "$boardspec" | needs_mmc_hack)
-set_efi_var "TegraPlatformSpec" "${boardspec}-${TARGET}-" || rc=1
+set_efi_var "TegraPlatformSpec" "781e084c-a330-417c-b678-38e696380cb9" "${boardspec}-${TARGET}-" "write-once" || rc=1
 compatspec=$(echo "$boardspec" | gen_compat_spec)
 if [ -z "$compatspec" ]; then
     compatsed="-e/^COMPATIBLE_SPEC/d"
 else
     compatsed="-es,@COMPATIBLE_SPEC@,${compatspec}-${TARGET}-,"
-    set_efi_var "TegraPlatformCompatSpec" "${compatspec}-${TARGET}-" || rc=1
+    set_efi_var "TegraPlatformCompatSpec" "781e084c-a330-417c-b678-38e696380cb9" "${compatspec}-${TARGET}-" "write-once" || rc=1
 fi
 sed -e"s,@TNSPEC@,${boardspec}-${TARGET}-${BOOTDEV}," $compatsed \
     "${sysconfdir}/nv_boot_control.template" > "$controlfile" || rc=1

--- a/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
@@ -1,0 +1,139 @@
+#!/bin/sh
+ESPMOUNT="@ESPMOUNT@"
+NVESPMOUNT="@NVIDIA_ESPMOUNT@"
+ESPVARDIR="@ESPVARDIR@"
+
+fab=
+boardsku=
+boardrev=
+chiprev=
+mmc_only_hack=
+
+set_efi_var() {
+    local varname="$1"
+    local guid="$2"
+    local value="$3"
+    local write_once="$4"
+
+    if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "Usage: set_efi_var varname guid value" >&2
+        return 1
+    fi
+
+    # NVIDIA tools will try to mount the ESP partition dynamically
+    # if it's not already mounted at @NVIDIA_ESPMOUNT@, so bind-mount
+    # it there if we've mounted that partition at a more typical location.
+    if [ -n "$NVESPMOUNT" -a "$NVESPMOUNT" != "$ESPMOUNT" ]; then
+        if mountpoint -q "$ESPMOUNT" && ! mountpoint -q "$NVESPMOUNT"; then
+            mount --bind "$ESPMOUNT" "$NVESPMOUNT"
+        fi
+    fi
+
+    boardspec=$(tegra-boardspec 2>/dev/null)
+    if [ -z "${boardspec}" ]; then
+        echo "ERR: could not retrieve boardspec for setting efi var" >&2
+        return 1
+    fi
+    mmc_only_hack=$(echo "$boardspec" | needs_mmc_hack)
+
+    # Only set if it doesn't exist already
+    if [ "$mmc_only_hack" = "yes" ]; then
+        if ! mountpoint -q "$ESPMOUNT"; then
+            echo "ERR: cannot store EFI variable - ESP partition not mounted" >&2
+            return 1
+        fi
+        if [ -e "$ESPVARDIR/${varname}-${guid}" ] && [ "$write_once" = "write-once" ]; then
+            return 0
+        fi
+        local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)
+        printf "\x07\x00\x00\x00%b" "$value" > "$datatmp"
+        mkdir -p -m 0700 "$ESPVARDIR" || return 1
+        cp "$datatmp" "$ESPVARDIR/${varname}-${guid}" || return 1
+    else
+        if [ efivar -n "${guid}-$varname" >/dev/null 2>&1 ] && [ "$write_once" = "write-once" ]; then
+            return 0
+        fi
+        local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)
+        printf "%b" "$value" > "$datatmp"
+        efivar -w -f "$datatmp" -n "${guid}-$varname"
+    fi
+}
+
+gen_compat_2888() {
+    if [ "$fab" = "400" ]; then
+        if [ "$boardsku" = "0004" ]; then
+            boardrev=
+        else
+            if echo "$boardrev" | grep -q "^[ABCD]\."; then
+                boardrev="D.0"
+            else
+                boardrev="E.0"
+            fi
+            boardsku="0001"
+        fi
+    elif [ "$fab" = "600" -a "$boardsku" = "0008" ]; then
+        boardrev=
+    fi
+    return 0
+}
+
+gen_compat_3668() {
+    if [ "$fab" != "301" ]; then
+        fab="100"
+    fi
+    boardsku=
+    boardrev=
+    chiprev=
+    return 0
+}
+
+gen_compat_3701() {
+    boardrev=
+    if [ "$boardsku" = "0000" -o "$boardsku" = "0004" ]; then
+        if echo "$fab" | egrep -q "^([012][0-9][0-9]|TS|EB)"; then
+            fab="000"
+        else
+            fab="300"
+        fi
+    fi
+    if [ "$boardksu" = "0005" ]; then
+        fab=""
+    fi
+    boardrev=
+    chiprev=
+    return 0
+}
+
+gen_compat_3767() {
+    if [ "$boardsku" = "0000" -o "$boardsku" = "0002" ]; then
+        if ! echo "$fab" | egrep -q "^(TS|EB)"; then
+            fab="000"
+        fi
+    else
+        fab=
+    fi
+    boardrev=
+    chiprev=
+    return 0
+}
+
+# boardspec should be piped into this function
+gen_compat_spec() {
+    IFS=- read boardid fab boardsku boardrev fuselevel chiprev
+    if gen_compat_$boardid 2>/dev/null; then
+        echo "$boardid-$fab-$boardsku-$boardrev-$fuselevel-$chiprev"
+        return 0
+    fi
+    echo ""
+}
+
+# boardspec should be piped into this function
+needs_mmc_hack() {
+    IFS=- read boardid fab boardsku boardrev fuselevel chiprev
+    if [ "$boardid" = "2888" -a "$fab" = "400" ]; then
+        echo "yes"
+    else
+        echo ""
+    fi
+    return 0
+}

--- a/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
+++ b/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
@@ -9,6 +9,7 @@ SRC_URI = "\
     file://setup-nv-boot-control.init.in \
     file://esp.mount.in \
     file://uefi_common.func.in \
+    file://oe4t-set-uefi-OSIndications \
 "
 
 COMPATIBLE_MACHINE = "(tegra)"
@@ -54,6 +55,7 @@ do_install() {
     install -m 0644 ${B}/${ESPMOUNTUNIT} ${D}${systemd_system_unitdir}/
     install -d ${D}${ESPMOUNT} ${D}${NVIDIA_ESPMOUNT}
     install -m 0755 ${B}/uefi_common.func ${D}${bindir}/
+    install -m 0755 ${S}/oe4t-set-uefi-OSIndications ${D}${bindir}/
 }
 
 pkg_postinst:${PN}() {
@@ -76,6 +78,7 @@ FILES:${PN} = "\
     ${bindir}/setup-nv-boot-control \
     /opt/nvidia ${ESPMOUNT} \
     ${bindir}/uefi_common.func \
+    ${bindir}/oe4t-set-uefi-OSIndications \
 "
 FILES:${PN}-service = "${sysconfdir} ${systemd_system_unitdir}"
 

--- a/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
+++ b/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
@@ -8,6 +8,7 @@ SRC_URI = "\
     file://setup-nv-boot-control.service.in \
     file://setup-nv-boot-control.init.in \
     file://esp.mount.in \
+    file://uefi_common.func.in \
 "
 
 COMPATIBLE_MACHINE = "(tegra)"
@@ -25,11 +26,12 @@ inherit systemd update-rc.d
 do_compile() {
     sed -e's,@TARGET@,${TNSPEC_MACHINE},g' \
         -e's,@BOOTDEV@,${TNSPEC_BOOTDEV},g' \
-        -e's,@ESPMOUNT@,${ESPMOUNT},g' \
-        -e's,@NVIDIA_ESPMOUNT@,${NVIDIA_ESPMOUNT},g' \
-        -e's,@ESPVARDIR@,${ESPVARDIR},g' \
         -e's,@sysconfdir@,${sysconfdir},g' \
         ${S}/setup-nv-boot-control.sh.in >${B}/setup-nv-boot-control.sh
+    sed -e's,@ESPMOUNT@,${ESPMOUNT},g' \
+        -e's,@NVIDIA_ESPMOUNT@,${NVIDIA_ESPMOUNT},g' \
+        -e's,@ESPVARDIR@,${ESPVARDIR},g' \
+        ${S}/uefi_common.func.in >${B}/uefi_common.func
     sed -e's,@bindir@,${bindir},g' \
         -e's,@ESPMOUNT@,${ESPMOUNT},g' \
         ${S}/setup-nv-boot-control.service.in >${B}/setup-nv-boot-control.service
@@ -51,6 +53,7 @@ do_install() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${B}/${ESPMOUNTUNIT} ${D}${systemd_system_unitdir}/
     install -d ${D}${ESPMOUNT} ${D}${NVIDIA_ESPMOUNT}
+    install -m 0755 ${B}/uefi_common.func ${D}${bindir}/
 }
 
 pkg_postinst:${PN}() {
@@ -69,7 +72,11 @@ SYSTEMD_SERVICE:${PN}-service = "setup-nv-boot-control.service"
 RDEPENDS:${PN}-service = "${PN}"
 RDEPENDS:${PN} = "efivar tegra-nv-boot-control-config tegra-eeprom-tool-boardspec"
 
-FILES:${PN} = "${bindir}/setup-nv-boot-control /opt/nvidia ${ESPMOUNT}"
+FILES:${PN} = "\
+    ${bindir}/setup-nv-boot-control \
+    /opt/nvidia ${ESPMOUNT} \
+    ${bindir}/uefi_common.func \
+"
 FILES:${PN}-service = "${sysconfdir} ${systemd_system_unitdir}"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/recipes-bsp/uefi/edk2-basetools-tegra-native_35.3.1.bb
+++ b/recipes-bsp/uefi/edk2-basetools-tegra-native_35.3.1.bb
@@ -1,0 +1,18 @@
+# Install EDK2 Base Tools in native sysroot. Currently the BaseTools are not
+# built, they are just copied to native sysroot. This is sufficient for
+# generating UEFI capsules as it only depends on some python scripts. Other
+# tools need to be built first before adding to sysroot.
+
+SUMMARY = "EDK2 Base Tools"
+LICENSE = "BSD-2-Clause-Patent"
+
+require edk2-firmware-core-tegra-35.3.1.inc
+
+inherit native
+
+RDEPENDS:${PN} += "python3-core"
+
+do_install () {
+    mkdir -p ${D}${bindir}/edk2-BaseTools
+    cp -r ${S}/BaseTools/* ${D}${bindir}/edk2-BaseTools/
+}

--- a/recipes-bsp/uefi/edk2-firmware-core-tegra-35.3.1.inc
+++ b/recipes-bsp/uefi/edk2-firmware-core-tegra-35.3.1.inc
@@ -1,0 +1,11 @@
+LICENSE .= " & Proprietary"
+
+LIC_FILES_CHKSUM = "file://License.txt;md5=2b415520383f7964e96700ae12b4570a"
+
+EDK2_SRC_URI = "gitsm://github.com/NVIDIA/edk2.git;protocol=https;branch=main-edk2-stable202208-updates"
+
+SRCREV_edk2 = "7ba0a31b503cd0bf82a97e90f460ad7586ba80c4"
+
+SRC_URI = "${EDK2_SRC_URI};name=edk2;destsuffix=edk2-tegra/edk2;nobranch=1"
+
+S = "${WORKDIR}/edk2-tegra/edk2"

--- a/recipes-bsp/uefi/edk2-firmware-tegra-35.3.1.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-35.3.1.inc
@@ -1,28 +1,25 @@
 require edk2-firmware.inc
+require edk2-firmware-core-tegra-35.3.1.inc
 require conf/image-uefi.conf
 
 LICENSE .= " & Proprietary"
 
-LIC_FILES_CHKSUM = "file://License.txt;md5=2b415520383f7964e96700ae12b4570a"
 LIC_FILES_CHKSUM += "file://../edk2-platforms/License.txt;md5=2b415520383f7964e96700ae12b4570a"
 LIC_FILES_CHKSUM += "file://../edk2-nvidia-non-osi/Silicon/NVIDIA/Drivers/NvGopDriver/NOTICE.nvgop-chips-platform.efi;md5=549bbaa72578510a18ba3c324465027c"
 
 DEPENDS += "dtc-native"
 
-EDK2_SRC_URI = "gitsm://github.com/NVIDIA/edk2.git;protocol=https;branch=main-edk2-stable202208-updates"
 EDK2_PLATFORMS_SRC_URI = "git://github.com/NVIDIA/edk2-platforms.git;protocol=https;branch=r35.3.1-upstream-20220830-updates"
 EDK2_NVIDIA_SRC_URI = "git://github.com/NVIDIA/edk2-nvidia.git;protocol=https;branch=r35.3.1-updates"
 EDK2_NONOSI_SRC_URI = "git://github.com/NVIDIA/edk2-non-osi.git;protocol=https;branch=main-upstream-20220830"
 EDK2_NVIDIA_NONOSI_SRC_URI = "git://github.com/NVIDIA/edk2-nvidia-non-osi.git;protocol=https;branch=r35.3.1-updates"
 
-SRCREV_edk2 = "7ba0a31b503cd0bf82a97e90f460ad7586ba80c4"
 SRCREV_edk2-non-osi = "61662e8596dd9a64e3372f9a3ba6622d2628607c"
 SRCREV_edk2-nvidia = "63e71c987193cc57333994ca5b82a62c40fed5da"
 SRCREV_edk2-nvidia-non-osi = "952a02747566005181ec3248d7a9a5a24533e9dd"
 SRCREV_edk2-platforms = "3c3b1168017073c2bb2d97336c5929ebae805be1"
 
-SRC_URI = "\
-    ${EDK2_SRC_URI};name=edk2;destsuffix=edk2-tegra/edk2;nobranch=1 \
+SRC_URI += "\
     ${EDK2_PLATFORMS_SRC_URI};name=edk2-platforms;destsuffix=edk2-tegra/edk2-platforms \
     ${EDK2_NONOSI_SRC_URI};name=edk2-non-osi;destsuffix=edk2-tegra/edk2-non-osi \
     ${EDK2_NVIDIA_SRC_URI};name=edk2-nvidia;destsuffix=edk2-tegra/edk2-nvidia \

--- a/recipes-bsp/uefi/tegra-uefi-capsules_35.3.1.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_35.3.1.bb
@@ -1,0 +1,73 @@
+DESCRIPTION = "Generate UEFI capsules for bup paylods"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit l4t_bsp tegra-bup
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+DEPENDS += "edk2-basetools-tegra-native tegra-bup-payload"
+
+GUID:tegra194 ?= "be3f5d68-7654-4ed2-838c-2a2faf901a78"
+GUID:tegra234 ?= "bf0d4599-20d4-414e-b2c5-3595b1cda402"
+
+def get_hex_bsp_version(bsp_version):
+    verparts = bsp_version.split('.')
+    return hex(int(verparts[0])<<16 | int(verparts[1])<<8 | int(verparts[2]))
+
+BSP_VERSION32 = "${@get_hex_bsp_version(d.getVar('L4T_VERSION'))}"
+
+PYTHON_BASETOOLS = "${RECIPE_SYSROOT_NATIVE}/usr/bin/edk2-BaseTools/Source/Python"
+
+UEFI_CAPSULE_SIGNER_PRIVATE_CERT ?= "${PYTHON_BASETOOLS}/Pkcs7Sign/TestCert.pem"
+UEFI_CAPSULE_OTHER_PUBLIC_CERT ?= "${PYTHON_BASETOOLS}/Pkcs7Sign/TestSub.pub.pem"
+UEFI_CAPSULE_TRUSTED_PUBLIC_CERT ?= "${PYTHON_BASETOOLS}/Pkcs7Sign/TestRoot.pub.pem"
+
+# Override this function to have a secure signing server
+# perform the capsule signing.
+sign_uefi_capsules() {
+    export PYTHONPATH="${PYTHONPATH}:${PYTHON_BASETOOLS}"
+    if [ -e ${DEPLOY_DIR_IMAGE}/${BUPFILENAME}.bl_only.bup-payload ]; then
+        python3 ${PYTHON_BASETOOLS}/Capsule/GenerateCapsule.py \
+            -v --encode --monotonic-count 1 \
+            --fw-version "${BSP_VERSION32}" \
+            --lsv "${BSP_VERSION32}" \
+            --guid "${GUID}" \
+            --signer-private-cert "${UEFI_CAPSULE_SIGNER_PRIVATE_CERT}" \
+            --other-public-cert "${UEFI_CAPSULE_OTHER_PUBLIC_CERT}" \
+            --trusted-public-cert "${UEFI_CAPSULE_TRUSTED_PUBLIC_CERT}" \
+            -o ./tegra-bl.cap \
+            ${DEPLOY_DIR_IMAGE}/${BUPFILENAME}.bl_only.bup-payload
+    fi
+    if [ -e ${DEPLOY_DIR_IMAGE}/${BUPFILENAME}.kernel_only.bup-payload ]; then
+        python3 ${PYTHON_BASETOOLS}/Capsule/GenerateCapsule.py \
+            -v --encode --monotonic-count 1 \
+            --fw-version "${BSP_VERSION32}" \
+            --lsv "${BSP_VERSION32}" \
+            --guid "${GUID}" \
+            --signer-private-cert "${UEFI_CAPSULE_SIGNER_PRIVATE_CERT}" \
+            --other-public-cert "${UEFI_CAPSULE_OTHER_PUBLIC_CERT}" \
+            --trusted-public-cert "${UEFI_CAPSULE_TRUSTED_PUBLIC_CERT}" \
+            -o ./tegra-kernel.cap \
+            ${DEPLOY_DIR_IMAGE}/${BUPFILENAME}.kernel_only.bup-payload
+    fi
+}
+
+do_compile() {
+    sign_uefi_capsules
+}
+
+CAPSULE_DIR = "/opt/nvidia/UpdateCapsule"
+
+do_install() {
+    install -d ${D}${CAPSULE_DIR}
+    if [ -e ${B}/tegra-bl.cap ]; then
+        install -m 0644 ${B}/tegra-bl.cap ${D}${CAPSULE_DIR}
+    fi
+    if [ -e ${B}/tegra-kernel.cap ]; then
+        install -m 0644 ${B}/tegra-kernel.cap ${D}${CAPSULE_DIR}
+    fi
+}
+
+FILES:${PN} += "${CAPSULE_DIR}"
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Consider this just a starting point to spur some discussion on how best to implement.

1.  Should the capsules be included in the rootfs by default or simply be deployed to `${DEPLOYDIR}`?  I initially went ahead and included them in the rootfs.  That follows the pattern of how `swupdate` works (which is what we use) in `tegra-test-distro` whereby `tegra-bootloader-update` and `bl_update_payload` are packaged into the rootfs and then swupdate mounts the just programmed inactive partition to drive the bootloader upddate.  Having said that, I believe when we implemented `dm-verity` to create a full chain of trust from the bootloaders to the rootfs it created a cycle of dependencies in the build.  To break the cycle we pulled the bootloader payload out of the rootfs and packaged it directly into the .swu.  For uefi the capsules eventually have to end up in `/opt/nvidia/esp/EFI/UpdateCapsule/`.  Maybe that means that the capsules should simply be deployed to the `${DEPLOYDIR}` and it is up to the update mechanism to pull them out of the update specific packaging and copy them to the appropriate directory.

2.  Is a new recipe really required?  I created a separate recipe instead of piling on top of `tegra-bup-payload`.  By doing so I needed to move some logic to a  .bbclass to avoid having to repeat it in the new recipe and creating a new point of maintenance.

3.  Requesting a capsule update is obscure so I created and a helper script to set `OSIndications`.

I like choosing good names for things so if there are any suggestions to improved naming on anything I am open to suggestions.