### PR TITLE
nvpower and nvpmodel startup fixes

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel/nvpmodel.service
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel/nvpmodel.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=NVIDIA power model daemon
-Requires=nvstartup.service
-After=nvstartup.service
+Requires=nvstartup.service nvpower.service
+After=nvstartup.service nvpower.service
 Before=graphical.target display-manager.service
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/sbin/nvpmodel -f /etc/nvpmodel.conf
-Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel_35.3.1.bb
@@ -24,4 +24,4 @@ inherit systemd update-rc.d
 INITSCRIPT_NAME = "nvpmodel"
 INITSCRIPT_PARAMS = "defaults"
 SYSTEMD_SERVICE:${PN} = "nvpmodel.service"
-RDEPENDS:${PN} = "tegra-nvpmodel-base"
+RDEPENDS:${PN} = "tegra-nvpmodel-base tegra-nvpower"

--- a/recipes-bsp/tegra-binaries/tegra-nvpower/nvpower.service
+++ b/recipes-bsp/tegra-binaries/tegra-nvpower/nvpower.service
@@ -4,6 +4,7 @@ Before=graphical.target display-manager.service
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/libexec/nvpower.sh
 
 [Install]


### PR DESCRIPTION
Fixes for the `nvpower` and `nvpmodel` systemd service units so they execute only once and in the correct sequence at boot time.  Particularly on Orin Nano and NX modules, the GPU driver is very sensitive to when the power settings need to be applied via sysfs.  Errors occur if the settings are applied too early, or if nvpower hasn't performed some of the scheduling-related setup that has to be in place, or if settings are applied multiple times.
