### PR TITLE
gcc-for-nvcc: fix breakage in libgcc-8 with upstream TUNE_CCARGS change

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-8-common.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-8-common.inc
@@ -14,6 +14,8 @@ BPN = "gcc"
 COMPILERDEP = "virtual/${MLPREFIX}${TARGET_PREFIX}cuda-gcc:do_gcc_stash_builddir"
 COMPILERDEP:class-nativesdk = "virtual/${TARGET_PREFIX}cuda-gcc-crosssdk:do_gcc_stash_builddir"
 
+TUNE_CCARGS:remove = "-mbranch-protection=standard"
+
 python extract_stashed_builddir () {
     src = d.expand("${COMPONENTS_DIR}/${BUILD_ARCH}/gcc-8-stashed-builddir-${TARGET_SYS}")
     dest = d.getVar("B")


### PR DESCRIPTION
Upstream commit
https://git.yoctoproject.org/poky/commit/?id=a2bf83842a72c3dfe24a824c650a2f64d3fdf1b0 added "-mbranch-protection=standard" to TUNE_CCARGS that breaks the gcc-for-nvcc (GCC 8) build during configure of libgcc-8:

configure:3731: error: in .../libgcc': configure:3734: error: cannot compute suffix of object files: cannot compile

Take this flag out of TUNE_CCARGS

Fixes #1302