### PR TITLE
cuda.bbclass: filter TUNE_CCARGS for CUDA builds

### DIFF
--- a/classes/cuda.bbclass
+++ b/classes/cuda.bbclass
@@ -12,6 +12,8 @@ CUDA_LDFLAGS = "\
   -Wl,-rpath,/usr/local/cuda-${CUDA_VERSION}/${baselib} \
 "
 
+TUNE_CCARGS:remove:cuda = "-mbranch-protection=standard"
+
 LDFLAGS:prepend:cuda = "${TOOLCHAIN_OPTIONS} "
 LDFLAGS:append:cuda = " ${CUDA_LDFLAGS}"
 


### PR DESCRIPTION
to remove a flag added in OE-Core from compilations for CUDA targets that use an older compiler (through nvcc) which doesn't understand the new flag.

Fixes #1302 