### PR TITLE
uefi_common.func.in: fix efi variable existence check

### DIFF
--- a/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
@@ -50,7 +50,7 @@ set_efi_var() {
         mkdir -p -m 0700 "$ESPVARDIR" || return 1
         cp "$datatmp" "$ESPVARDIR/${varname}-${guid}" || return 1
     else
-        if [ efivar -n "${guid}-$varname" >/dev/null 2>&1 ] && [ "$write_once" = "write-once" ]; then
+        if efivar -n "${guid}-$varname" >/dev/null 2>&1 && [ "$write_once" = "write-once" ]; then
             return 0
         fi
         local datatmp=$(TMPDIR=$RUNTIME_DIRECTORY mktemp --tmpdir nvcvar.XXXXXX)


### PR DESCRIPTION
After working on getting `swupdate` to work I noticed that the `setup-nv-boot-control` service was failing on startup.  I shouldn't have used `[]`'s around the `efivar` command to check to see whether the variable already existed or not.