### PR TITLE
edk2-firmware-tegra: adds ostree support

### DIFF
--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
@@ -1,0 +1,81 @@
+From c5680ec1c81fd841d638968988757bd0abfb9d2f Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Tue, 28 Feb 2023 10:59:20 +0000
+Subject: [PATCH 1/3] L4TLauncher: boot syslinux instead of extlinux for ostree
+ support
+
+Ostree uses syslinux.cfg instead of extlinux.conf for providing the
+required kernel/initrd/dtb files for the bootloader.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c | 12 +-----------
+ Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h |  6 +++---
+ 2 files changed, 4 insertions(+), 14 deletions(-)
+
+diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+index ac53522d..7bb70625 100644
+--- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
++++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+@@ -1084,11 +1084,6 @@ ProcessExtLinuxConfig (
+       if ((BootConfig->NumberOfBootOptions <= MAX_EXTLINUX_OPTIONS) &&
+           (BootConfig->NumberOfBootOptions != 0))
+       {
+-        Status = CheckCommandString (CleanLine, EXTLINUX_KEY_MENU_LABEL, &BootConfig->BootOptions[BootConfig->NumberOfBootOptions-1].MenuLabel);
+-        if (!EFI_ERROR (Status)) {
+-          continue;
+-        }
+-
+         Status = CheckCommandString (CleanLine, EXTLINUX_KEY_LINUX, &BootConfig->BootOptions[BootConfig->NumberOfBootOptions-1].LinuxPath);
+         if (!EFI_ERROR (Status)) {
+           continue;
+@@ -1200,7 +1195,7 @@ ExtLinuxBootMenu (
+   }
+ 
+   for (Index = 0; Index < BootConfig->NumberOfBootOptions; Index++) {
+-    Print (L"%d: %s\r\n", Index, BootConfig->BootOptions[Index].MenuLabel);
++    Print (L"%d: %s\r\n", Index, BootConfig->BootOptions[Index].Label);
+   }
+ 
+   Status = gBS->SetTimer (EventArray[0], TimerRelative, EFI_TIMER_PERIOD_SECONDS (BootConfig->Timeout)/10);
+@@ -2101,11 +2096,6 @@ L4TLauncher (
+         FreePool (ExtLinuxConfig.BootOptions[Index].LinuxPath);
+         ExtLinuxConfig.BootOptions[Index].LinuxPath = NULL;
+       }
+-
+-      if (ExtLinuxConfig.BootOptions[Index].MenuLabel != NULL) {
+-        FreePool (ExtLinuxConfig.BootOptions[Index].MenuLabel);
+-        ExtLinuxConfig.BootOptions[Index].MenuLabel = NULL;
+-      }
+     }
+ 
+     if (ExtLinuxConfig.MenuTitle != NULL) {
+diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
+index f68ed615..4c3dedff 100644
+--- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
++++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
+@@ -16,7 +16,7 @@
+ #define GRUB_BOOTCONFIG_CONTENT_FORMAT  "set cbootargs=\"%s\"\r\nset root_partition_number=%d\r\nset bootimg_present=%d\r\nset recovery_present=%d\r\n"
+ #define DETACHED_SIG_FILE_EXTENSION     L".sig"
+ 
+-#define EXTLINUX_CONF_PATH  L"boot\\extlinux\\extlinux.conf"
++#define EXTLINUX_CONF_PATH  L"boot\\loader\\syslinux.cfg"
+ 
+ #define BOOTMODE_DIRECT_STRING    L"bootmode=direct"
+ #define BOOTMODE_GRUB_STRING      L"bootmode=grub"
+@@ -41,9 +41,9 @@
+ #define EXTLINUX_KEY_MENU_TITLE  L"MENU TITLE"
+ #define EXTLINUX_KEY_LABEL       L"LABEL"
+ #define EXTLINUX_KEY_MENU_LABEL  L"MENU LABEL"
+-#define EXTLINUX_KEY_LINUX       L"LINUX"
++#define EXTLINUX_KEY_LINUX       L"KERNEL"
+ #define EXTLINUX_KEY_INITRD      L"INITRD"
+-#define EXTLINUX_KEY_FDT         L"FDT"
++#define EXTLINUX_KEY_FDT         L"DEVICETREE"
+ #define EXTLINUX_KEY_APPEND      L"APPEND"
+ 
+ #define EXTLINUX_CBOOT_ARG  L"${cbootargs}"
+-- 
+2.34.1
+

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
@@ -1,0 +1,52 @@
+From ade039b7f95ca86f9bc8c574e15f618ebec33f35 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Mon, 27 Mar 2023 22:08:46 -0300
+Subject: [PATCH 2/3] l4tlauncher: support booting otaroot-based partitions
+
+Besides looking for the APP part-name (standard in emmc), also look for
+otaroot-based partitions when searching for extlinux configuration. This
+allows the device to boot from OTA-enabled rootfs.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c | 9 ++++++---
+ Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h | 1 +
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+index 7bb70625..a2f36473 100644
+--- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
++++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+@@ -1024,10 +1024,13 @@ ProcessExtLinuxConfig (
+     return EFI_INVALID_PARAMETER;
+   }
+ 
+-  Status = FindPartitionInfo (DeviceHandle, ROOTFS_BASE_NAME, BootChain, NULL, RootFsHandle);
++  Status = FindPartitionInfo (DeviceHandle, OTAROOTFS_BASE_NAME, BootChain, NULL, RootFsHandle);
+   if (EFI_ERROR (Status)) {
+-    ErrorPrint (L"%a: Unable to find partition info\r\n", __FUNCTION__);
+-    return Status;
++    Status = FindPartitionInfo (DeviceHandle, ROOTFS_BASE_NAME, BootChain, NULL, RootFsHandle);
++    if (EFI_ERROR (Status)) {
++      ErrorPrint (L"%a: Unable to find partition info\r\n", __FUNCTION__);
++      return Status;
++    }
+   }
+ 
+   Status = OpenAndReadFileToBuffer (
+diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
+index 4c3dedff..74ace3de 100644
+--- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
++++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.h
+@@ -31,6 +31,7 @@
+ #define BOOT_OS_VARIABLE_NAME  L"BootChainOsCurrent"
+ 
+ #define ROOTFS_BASE_NAME        L"APP"
++#define OTAROOTFS_BASE_NAME     L"otaroot"
+ #define BOOTIMG_BASE_NAME       L"kernel"
+ #define BOOTIMG_DTB_BASE_NAME   L"kernel-dtb"
+ #define RECOVERY_BASE_NAME      L"recovery"
+-- 
+2.34.1
+

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
@@ -1,0 +1,40 @@
+From 739813f08471028eae87002e19f55e8b59083fd6 Mon Sep 17 00:00:00 2001
+From: Ricardo Salveti <ricardo@foundries.io>
+Date: Mon, 27 Mar 2023 22:10:53 -0300
+Subject: [PATCH 3/3] l4tlauncher: disable a/b rootfs validation
+
+We don't support a/b rootfs, so disable the runtime bootcount and slot
+validation to avoid requiring nvbootctrl to be called during boot (to
+clear up the variables).
+
+This is to avoid forcing the device to boot in recovery after 3 boots
+without confirmation from nvbootctrl.
+
+Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
+Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+---
+ Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+index a2f36473..ccecfd72 100644
+--- a/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
++++ b/Silicon/NVIDIA/Application/L4TLauncher/L4TLauncher.c
+@@ -1530,10 +1530,10 @@ ProcessBootParams (
+   }
+ 
+   // Find valid Rootfs Chain. If not, select recovery kernel
+-  Status = ValidateRootfsStatus (BootParams);
+-  if (EFI_ERROR (Status)) {
+-    ErrorPrint (L"Failed to validate rootfs status: %r\r\n", Status);
+-  }
++  //Status = ValidateRootfsStatus (BootParams);
++  //if (EFI_ERROR (Status)) {
++  //  ErrorPrint (L"Failed to validate rootfs status: %r\r\n", Status);
++  //}
+ 
+   // Store the current boot chain in volatile variable to allow chain loading
+   Status = gRT->SetVariable (BOOT_OS_VARIABLE_NAME, &gNVIDIAPublicVariableGuid, EFI_VARIABLE_BOOTSERVICE_ACCESS|EFI_VARIABLE_RUNTIME_ACCESS, sizeof (BootParams->BootChain), &BootParams->BootChain);
+-- 
+2.34.1
+

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra_%.bbappend
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# ostree support
+SRC_URI:append = " \
+        file://0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch;patchdir=../edk2-nvidia \
+        file://0002-l4tlauncher-support-booting-otaroot-based-partitions.patch;patchdir=../edk2-nvidia \
+        file://0003-l4tlauncher-disable-a-b-rootfs-validation.patch;patchdir=../edk2-nvidia \
+"


### PR DESCRIPTION
This group of patches is only applied with the sota override
 that is provided by the meta-updater [1] layer
    
 [1] https://github.com/uptane/meta-updater