### PR TITLE
libnvvpi2: rename vpi2_pva_auth_allowlist firmware

### DIFF
--- a/recipes-devtools/vpi/libnvvpi2_2.3.9.bb
+++ b/recipes-devtools/vpi/libnvvpi2_2.3.9.bb
@@ -39,7 +39,7 @@ do_install() {
     install -d ${D}${sysconfdir}/ld.so.conf.d
     install -m 0644 ${B}/opt/nvidia/vpi2/etc/ld.so.conf.d/vpi2.conf ${D}${sysconfdir}/ld.so.conf.d/
     install -d ${D}${nonarch_base_libdir}/firmware
-    install -m 0644 ${B}/opt/nvidia/vpi2/lib/aarch64-linux-gnu/priv/vpi2_pva_auth_allowlist ${D}${nonarch_base_libdir}/firmware/
+    install -m 0644 ${B}/opt/nvidia/vpi2/lib/aarch64-linux-gnu/priv/vpi2_pva_auth_allowlist ${D}${nonarch_base_libdir}/firmware/pva_auth_allowlist
     rm -f ${D}/opt/nvidia/vpi2/lib/aarch64-linux-gnu/priv/vpi2_pva_auth_allowlist
 }
 


### PR DESCRIPTION
* This PR fixes the following issue 
```
[ 1027.619635] pva 16000000.pva0: Direct firmware load for pva_auth_allowlist failed with error -2
[ 1027.619864] pva 16000000.pva0: looking for firmware in subdirectory
[ 1027.627758] pva 16000000.pva0: Direct firmware load for tegra19x/pva_auth_allowlist failed with error -2
[ 1027.627974] pva 16000000.pva0: failed to get firmware
[ 1027.628076] pva 16000000.pva0: pva_auth_allow_list_parse: Failed to load the allow list
```
