### PR TITLE
libgstnvcustomhelper: fix runtime dependency

### DIFF
--- a/recipes-multimedia/gstreamer/libgstnvcustomhelper_35.4.1.bb
+++ b/recipes-multimedia/gstreamer/libgstnvcustomhelper_35.4.1.bb
@@ -27,4 +27,6 @@ do_install() {
 }
 RPROVIDES:${PN} += "libgstnvcustomhelper.so()(64bit)"
 
-
+FILES:${PN} = "${libdir}/libgstnvcustomhelper.so*"
+FILES_SOLIBSDEV = ""
+INSANE_SKIP:${PN} = "dev-so"


### PR DESCRIPTION
* This PR fixes the following issue 
```
(gst-plugin-scanner:947): GStreamer-WARNING **: 08:26:59.581: Failed to load plugin '/usr/lib/gstreamer-1.0/deepstream/libnvdsgst_nvmultiurisrcbin.so': libgstnvcustomhelper.so: cannot open shared object fi
le: No such file or directory

** (gst-plugin-scanner:947): CRITICAL **: 08:26:59.605: Couldn't g_module_open libpython. Reason: /usr/lib/libpython3.11.so: cannot open shared object file: No such file or directory

(gst-plugin-scanner:947): GStreamer-WARNING **: 08:26:59.714: Failed to load plugin '/usr/lib/gstreamer-1.0/libgstnvvideo4linux2.so': libgstnvcustomhelper.so: cannot open shared object file: No such file o
r directory
```