### PR TITLE
gcc-for-nvcc: fix build dependencies for sdk compilers [r35.4.1 + mickledore, partial]

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
@@ -3,7 +3,7 @@ inherit cross-canadian
 SUMMARY = "GNU cc and gcc C compilers (cross-canadian for ${TARGET_ARCH} target)"
 PN = "gcc-for-nvcc-cross-canadian-${TRANSLATED_TARGET_ARCH}"
 
-DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${HOST_PREFIX}gcc virtual/${HOST_PREFIX}binutils virtual/nativesdk-libc nativesdk-gettext flex-native virtual/libc"
+DEPENDS = "virtual/${TARGET_PREFIX}gcc virtual/${HOST_PREFIX}gcc-crosssdk virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-libc nativesdk-gettext flex-native virtual/libc"
 
 GCCMULTILIB = "--enable-multilib"
 

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
@@ -152,7 +152,7 @@ do_install () {
 		do
 			d=${D}${bindir}/../${TARGET_ARCH}$v-$i
 			install -d $d
-			for j in ${TARGET_PREFIX}gcc${EXEEXT} ${TARGET_PREFIX}g++${EXEEXT}
+			for j in ${TARGET_PREFIX}gcc-${BINV}${EXEEXT} ${TARGET_PREFIX}g++-${BINV}${EXEEXT}
 			do
 				p=${TARGET_ARCH}$v-$i-`echo $j | sed -e s,${TARGET_PREFIX},,`
 				case $i in

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-crosssdk.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-crosssdk.inc
@@ -8,5 +8,5 @@ SYSTEMLIBS1 = "${SDKPATHNATIVE}${libdir_nativesdk}/"
 
 GCCMULTILIB = "--disable-multilib"
 
-DEPENDS = "virtual/${TARGET_PREFIX}binutils gettext-native ${NATIVEDEPS}"
+DEPENDS = "virtual/${TARGET_PREFIX}cuda-binutils gettext-native ${NATIVEDEPS}"
 PROVIDES = "virtual/${TARGET_PREFIX}cuda-gcc virtual/${TARGET_PREFIX}cuda-g++"


### PR DESCRIPTION
This is required for mickledore with 35.4.1 wip (updates to nvcc with gcc 10.3). This may be required for existing master as well, but I haven't been running that build so I can't say for sure.