### PR TITLE
libdrm-nvdc: set DEBIAN_NOAUTONAME also for license package

### DIFF
--- a/recipes-bsp/tegra-binaries/libdrm-nvdc_35.3.1.bb
+++ b/recipes-bsp/tegra-binaries/libdrm-nvdc_35.3.1.bb
@@ -24,6 +24,7 @@ do_install() {
 DEBIAN_NOAUTONAME:${PN} = "1"
 DEBIAN_NOAUTONAME:${PN}-dev = "1"
 DEBIAN_NOAUTONAME:${PN}-dbg = "1"
+DEBIAN_NOAUTONAME:${PN}-lic = "1"
 FILES:${PN} = "${libdir} ${sysconfdir}/ld.so.conf.d"
 FILES:${PN}-dev = "${includedir}/libdrm/nvidia"
 PRIVATE_LIBS = "libdrm.so.2"


### PR DESCRIPTION
This is needed to avoid spdx from failing with:

ERROR: libdrm-nvdc-35.3.1-20230319081403-r0 do_create_spdx: The recipe libdrm-nvdc is trying to install files into a shared area when those files already exist. Those files and their manifest location are:
  /home/qt/work/build/build/tmp/deploy/spdx/armv8a_tegra/packages/libdrm-lic.spdx.json
    (matched in manifest-armv8a_tegra-libdrm.create_spdx)
Please verify which recipe should provide the above files.