### PR TITLE
jetson-orin-nano-devkit-nvme: set TNSPEC_BOOTDEV instead of TNSPEC_BO…

### DIFF
--- a/conf/machine/jetson-orin-nano-devkit-nvme.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme.conf
@@ -3,7 +3,7 @@
 #@DESCRIPTION: Nvidia Jetson Orin Nano devkit using NVMe drive for rootfs
 
 MACHINEOVERRIDES =. "jetson-orin-nano-devkit:"
-TNSPEC_BOOTDEV_DEFAULT ?= "nvme0n1p1"
+TNSPEC_BOOTDEV ?= "nvme0n1p1"
 PARTITION_LAYOUT_TEMPLATE ?= "flash_t234_qspi.xml"
 PARTITION_LAYOUT_EXTERNAL ?= "flash_l4t_external.xml"
 require conf/machine/include/orin-nano.inc


### PR DESCRIPTION
…OTDEV_DEFAULT

so that the external flash layout gets populated in the tegraflash package.