### PR TITLE
cuda-target-environment: update arch_flags function

### DIFF
--- a/recipes-devtools/cuda/cuda-target-environment_1.0.bb
+++ b/recipes-devtools/cuda/cuda-target-environment_1.0.bb
@@ -14,9 +14,9 @@ COMPILER_CMD  = "${@d.getVar('CXX_FOR_CUDA').split()[0]}"
 CMAKE_CUDA_ARCHITECTURES = "${@d.getVar('CUDA_ARCHITECTURES') if d.getVar('CUDA_ARCHITECTURES') else 'OFF'}"
 
 def arch_flags(d):
-    archflags = d.getVar('TARGET_CC_ARCH')
+    archflags = [flag for flag in (d.getVar('TARGET_CC_ARCH') or '').split() if not flag.startswith('-mbranch-protection')]
     if archflags:
-        return "-Xcompiler " + ','.join(archflags.split())
+        return "-Xcompiler " + ','.join(archflags)
     return ""
 
 do_compile() {


### PR DESCRIPTION
to filter the -mbranch-protection flag from TARGET_CC_ARCH when forming the -Xcompiler arguments in the CUDAFLAGS environment variable.

Fixes #1338 