### PR TITLE
haveged, nvpmodel, and nvphs updates

### DIFF
--- a/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.init
+++ b/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.init
@@ -1,0 +1,74 @@
+#!/bin/sh
+#
+# Copyright 2011-2021 Jirka Hladky hladky DOT jiri AT gmail DOT com
+# Copyright 2011-2012 Gary Wuertz gary@issiweb.com
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#
+# haveged: Starts the haveged entropy daemon
+#
+# chkconfig: - 75 25
+# description: havege entropy daemon
+# processname: haveged
+#
+# source function library
+. /etc/init.d/functions
+
+HAVEGED_BIN=@SBIN_DIR@/haveged
+
+RETVAL=0
+prog="haveged"
+LOCKFILE=/var/lock/subsys/$prog
+
+test -x ${HAVEGED_BIN} || { echo "Cannot find haveged executable ${HAVEGED_BIN}" 1>&2 ; exit 5 ; }
+
+case "$1" in
+start)
+  echo -n $"Starting $prog: "
+  ${HAVEGED_BIN} -w 1024 -v 1 && success || failure
+  RETVAL=$?
+  [ "$RETVAL" = 0 ] && touch ${LOCKFILE}
+  echo
+  ;;
+
+stop)
+  echo -n $"Stopping $prog: "
+  if [ -e /var/run/$prog.pid ]; then
+    kill `cat /var/run/$prog.pid` && success || failure
+  else
+    failure
+  fi
+  RETVAL=$?
+  [ "$RETVAL" = 0 ] && rm -f ${LOCKFILE}
+  echo
+  ;;
+
+restart|reload)
+  $0 stop
+  $0 start
+  ;;
+
+condrestart)
+  [ -f $LOCKFILE ] && $0 restart
+  ;;
+
+status)
+  status $prog
+  RETVAL=$?
+  ;;
+*)
+  echo $"Usage: $prog {start|stop|status|reload|restart|condrestart}"
+esac
+exit $RETVAL

--- a/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.service
+++ b/external/openembedded-layer/recipes-extended/haveged/haveged/haveged.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Entropy Daemon based on the HAVEGE algorithm
 Before=systemd-random-seed.service
+DefaultDependencies=no
 
 [Service]
 Type=forking
@@ -8,4 +9,4 @@ PIDFile=/run/haveged.pid
 ExecStart=@SBIN_DIR@/haveged -w 1024 -v 1
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=sysinit.target

--- a/recipes-bsp/tegra-binaries/tegra-nvphs/nvphs.service
+++ b/recipes-bsp/tegra-binaries/tegra-nvphs/nvphs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=NVIDIA PHS daemon
-Requires=nvstartup.service
-After=nvstartup.service
+Requires=nvstartup.service nvpmodel.service
+After=nvstartup.service nvpmodel.service
 Before=graphical.target
 
 [Service]

--- a/recipes-bsp/tegra-binaries/tegra-nvphs_32.7.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvphs_32.7.4.bb
@@ -22,7 +22,7 @@ do_install() {
 inherit systemd update-rc.d
 
 INITSCRIPT_NAME = "nvphs"
-INITSCRIPT_PARAMS = "defaults"
+INITSCRIPT_PARAMS = "defaults 22"
 SYSTEMD_SERVICE:${PN} = "nvphs.service"
 
 RDEPENDS:${PN} = "tegra-nvphs-base"

--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel/nvpmodel.service
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel/nvpmodel.service
@@ -5,7 +5,8 @@ After=nvstartup.service
 Before=graphical.target display-manager.service
 
 [Service]
-Type=simple
+Type=oneshot
+RemainAfterExit=on
 ExecStart=/usr/sbin/nvpmodel -f /etc/nvpmodel.conf
 Restart=on-failure
 

--- a/recipes-bsp/tegra-binaries/tegra-nvpmodel_32.7.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvpmodel_32.7.4.bb
@@ -22,6 +22,6 @@ do_install() {
 inherit systemd update-rc.d
 
 INITSCRIPT_NAME = "nvpmodel"
-INITSCRIPT_PARAMS = "defaults"
+INITSCRIPT_PARAMS = "defaults 20"
 SYSTEMD_SERVICE:${PN} = "nvpmodel.service"
 RDEPENDS:${PN} = "tegra-nvpmodel-base"


### PR DESCRIPTION
* Refresh the haveged bbappend so the daemon gets started when using sysvinit, and gets started earlier when using systemd.
* Update the nvpmodel and nvphs services/initscripts to ensure they start in the correct order.

Fixes #1364 