### PR TITLE
tegra-helper-scripts: fix AGX Orin 64GB handling in t234 helper

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra234-flash-helper.sh
@@ -380,10 +380,11 @@ if [ "$BOARDID" = "3701" ]; then
             exit 1
             ;;
     esac
-    if [ "$chip_sku" = "00" -o "$chip_sku" = "D0" ] &&
-	   echo "$FAB" | egrep -q '^(TS[123]|EB[123]|[012]00)$'; then
-	PINMUX_CONFIG="tegra234-mb1-bct-pinmux-p3701-0000.dtsi"
-	PMC_CONFIG="tegra234-mb1-bct-padvoltage-p3701-0000.dtsi"
+    if [ "$BOARDSKU" != "0005" ]; then
+        if [ "$chip_sku" = "00" -o "$chip_sku" = "D0" ] && echo "$FAB" | egrep -q '^(TS[123]|EB[123]|[012]00)$'; then
+	    PINMUX_CONFIG="tegra234-mb1-bct-pinmux-p3701-0000.dtsi"
+	    PMC_CONFIG="tegra234-mb1-bct-padvoltage-p3701-0000.dtsi"
+	fi
     fi
     if ! [ "$BOARDSKU" = "0000" -o "$BOARDSKU" = "0001" -o "$BOARDSKU" = "0002" ]; then
 	BPFDTB_FILE=$(echo "$BPFDTB_FILE" | sed -e"s,3701-0000,3701-$BOARDSKU,")


### PR DESCRIPTION
Comparing to the logic in the L4T scripts, we were missing a check that the board SKU isn't 0005 before seeing if the pinmux and PMC config files need to be overridden based on the chip SKU and FAB values.

Fixes #1365 