### PR TITLE
Incorporate signing server support into tegra-demo-distro

### DIFF
--- a/classes/image_types_cboot.bbclass
+++ b/classes/image_types_cboot.bbclass
@@ -1,19 +1,16 @@
 CBOOTIMG_KERNEL ?= "${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}"
+TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
 
-inherit tegra-uefi-signing
+inherit ${TEGRA_UEFI_SIGNING_CLASS}
 
 oe_cbootimg() {
     bbfatal "This image type only supported on tegra platforms"
 }
 
-# Override this function in a bbappend to
-# implement other signing mechanisms
 sign_bootimg() {
-    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
-        tegra_uefi_attach_sign "$1"
-	rm "$1"
-	mv "$1.signed" "$1"
-    fi
+    tegra_uefi_attach_sign "$1"
+    rm "$1"
+    mv "$1.signed" "$1"
 }
 oe_cbootimg_common() {
     outfile="$2"

--- a/classes/image_types_tegra.bbclass
+++ b/classes/image_types_tegra.bbclass
@@ -1,5 +1,9 @@
 inherit image_types image_types_cboot image_types_tegra_esp python3native perlnative kernel-artifact-names
 
+TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
+inherit ${TEGRA_UEFI_SIGNING_CLASS}
+TEGRA_UEFI_USE_SIGNED_FILES ??= "false"
+
 IMAGE_TYPES += "tegraflash"
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
@@ -25,13 +29,13 @@ def tegra_dtb_extra_deps(d):
     deps = []
     if d.getVar('PREFERRED_PROVIDER_virtual/dtb'):
         deps.append('virtual/dtb:do_populate_sysroot')
-    if d.getVar('TEGRA_UEFI_DB_KEY') and d.getVar('TEGRA_UEFI_DB_CERT'):
+    if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         deps.append('tegra-uefi-keys-dtb:do_populate_sysroot')
     return ' '.join(deps)
 
 def tegra_bootcontrol_overlay_list(d, bup=False, separator=','):
     overlays = d.getVar('TEGRA_BOOTCONTROL_OVERLAYS').split()
-    if d.getVar('TEGRA_UEFI_DB_KEY') and d.getVar('TEGRA_UEFI_DB_CERT'):
+    if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         overlays.append('UefiDefaultSecurityKeys.dtbo')
         if bup and os.path.exists('UefiUpdateSecurityKeys.dtbo'):
             overlays.append('UefiUpdateSecurityKeys.dtbo')
@@ -64,7 +68,6 @@ TEGRAFLASH_ROOTFS_EXTERNAL = "${@'1' if d.getVar('TNSPEC_BOOTDEV') != d.getVar('
 ROOTFS_DEVICE_FOR_INITRD_FLASH = "${@tegra_rootfs_device(d)}"
 TEGRAFLASH_NO_INTERNAL_STORAGE ??= "0"
 OVERLAY_DTB_FILE ??= ""
-USE_UEFI_SIGNED_FILES ?= "${@'true' if d.getVar('TEGRA_UEFI_DB_KEY') and d.getVar('TEGRA_UEFI_DB_CERT') else 'false'}"
 
 TEGRA_EXT4_OPTIONS ?= "-O ^metadata_csum_seed"
 EXTRA_IMAGECMD:append:ext4 = " ${TEGRA_EXT4_OPTIONS}"
@@ -332,7 +335,7 @@ copy_dtbs() {
         fi
         bbnote "Copying KERNEL_DEVICETREE entry $dtbf to $destination"
         cp -L "${DEPLOY_DIR_IMAGE}/$dtbf" $destination/$dtbf
-	if ${USE_UEFI_SIGNED_FILES}; then
+	if ${TEGRA_UEFI_USE_SIGNED_FILES}; then
             cp -L "${DEPLOY_DIR_IMAGE}/$dtbf.signed" $destination/$dtbf.signed
 	fi
     done
@@ -345,7 +348,7 @@ copy_dtbs() {
             fi
             bbnote "Copying EXTERNAL_KERNEL_DEVICETREE entry $dtb to $destination"
             cp -L "${EXTERNAL_KERNEL_DEVICETREE}/$dtb" $destination/$dtbf
-	    if ${USE_UEFI_SIGNED_FILES}; then
+	    if ${TEGRA_UEFI_USE_SIGNED_FILES}; then
                 cp -L "${DEPLOY_DIR_IMAGE}/$dtb.signed" $destination/$dtbf.signed
 	    fi
         done
@@ -360,7 +363,7 @@ copy_dtb_overlays() {
     if [ -n "${IMAGE_TEGRAFLASH_INITRD_FLASHER}" ]; then
         extraoverlays="$extraoverlays L4TConfiguration-rcmboot.dtbo"
     fi
-    if ${USE_UEFI_SIGNED_FILES}; then
+    if ${TEGRA_UEFI_USE_SIGNED_FILES}; then
         extraoverlays="$extraoverlays UefiDefaultSecurityKeys.dtbo"
     fi
     for dtb in "$@" ${TEGRA_PLUGIN_MANAGER_OVERLAYS} $extraoverlays; do

--- a/classes/tegra-uefi-signing.bbclass
+++ b/classes/tegra-uefi-signing.bbclass
@@ -10,23 +10,30 @@ TEGRA_UEFI_DB_KEY ??= ""
 TEGRA_UEFI_DB_CERT ??= ""
 TEGRA_UEFI_SIGNING_TASKDEPS ?= "${@tegra_uefi_signing_deps(d, tasks=True)}"
 TEGRA_UEFI_SIGNING_DEPENDS ?= "${@tegra_uefi_signing_deps(d)}"
+TEGRA_UEFI_USE_SIGNED_FILES ?= "${@'true' if d.getVar('TEGRA_UEFI_DB_KEY') and d.getVar('TEGRA_UEFI_DB_CERT') else 'false'}"
 
 # Standard signing, input file modified with signature
 tegra_uefi_sbsign() {
-    sbsign --key "${TEGRA_UEFI_DB_KEY}" --cert "${TEGRA_UEFI_DB_CERT}" --output "$1" "$1"
+    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
+        sbsign --key "${TEGRA_UEFI_DB_KEY}" --cert "${TEGRA_UEFI_DB_CERT}" --output "$1" "$1"
+    fi
 }
 
 # Separate signature file, for NVIDIA's L4TLauncher 
 tegra_uefi_split_sign() {
-    openssl cms -sign -signer "${TEGRA_UEFI_DB_CERT}" -inkey "${TEGRA_UEFI_DB_KEY}" -binary -in "$1" -outform der -out "$1".sig
+    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
+        openssl cms -sign -signer "${TEGRA_UEFI_DB_CERT}" -inkey "${TEGRA_UEFI_DB_KEY}" -binary -in "$1" -outform der -out "$1".sig
+    fi
 }
 
 # Signature attached to end, another NVIDIA special
 # Input file remains intact; output file has ".signed" suffix
 tegra_uefi_attach_sign() {
-    openssl cms -sign -signer "${TEGRA_UEFI_DB_CERT}" -inkey "${TEGRA_UEFI_DB_KEY}" -binary -in "$1" -outform der -out "$1".sig.tmp
     cp "$1" "$1.signed"
-    truncate --size=%2048 "$1.signed"
-    cat "$1".sig.tmp >> "$1.signed"
-    rm "$1".sig.tmp
+    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
+        openssl cms -sign -signer "${TEGRA_UEFI_DB_CERT}" -inkey "${TEGRA_UEFI_DB_KEY}" -binary -in "$1" -outform der -out "$1".sig.tmp
+        truncate --size=%2048 "$1.signed"
+        cat "$1".sig.tmp >> "$1.signed"
+        rm "$1".sig.tmp
+    fi
 }

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -96,3 +96,5 @@ EFI_PROVIDER ?= "l4t-launcher"
 TEGRA_SIGNING_ENV ?= "CHIPREV=${TEGRA_CHIPREV} BOARDID=${TEGRA_BOARDID} FAB=${TEGRA_FAB} BOARDSKU=${TEGRA_BOARDSKU} BOARDREV=${TEGRA_BOARDREV} fuselevel=fuselevel_production"
 
 EMMC_BCTS ?= "${EMMC_BCT}${@',' + d.getVar('EMMC_BCT_OVERRIDE') if d.getVar('EMMC_BCT_OVERRIDE') else ''}"
+
+TEGRA_UEFI_SIGNING_CLASS ?= "tegra-uefi-signing"

--- a/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_35.4.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_35.4.1.bb
@@ -9,7 +9,9 @@ PROVIDES = "virtual/bootloader standalone-mm-optee-tegra"
 
 DEPENDS = "coreutils-native dtc-native"
 
-inherit deploy tegra-uefi-signing
+TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
+
+inherit deploy ${TEGRA_UEFI_SIGNING_CLASS}
 
 do_compile() {
     cp ${S}/bootloader/uefi_jetson.bin ${S}/bootloader/BOOTAA64.efi ${B}
@@ -27,12 +29,8 @@ do_compile:append:tegra234() {
     cp ${S}/bootloader/standalonemm_optee_t234.bin ${B}/standalone_mm_optee.bin
 }
 
-# Override this function in a bbappend to
-# implement other signing mechanisms
 sign_efi_app() {
-    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
-        tegra_uefi_sbsign "$1"
-    fi
+    tegra_uefi_sbsign "$1"
 }
 
 do_sign_efi_launcher() {

--- a/recipes-bsp/uefi/edk2-firmware-tegra_35.4.1.bb
+++ b/recipes-bsp/uefi/edk2-firmware-tegra_35.4.1.bb
@@ -7,7 +7,9 @@ PROVIDES = "virtual/bootloader"
 DEPENDS += "dtc-native"
 DEPENDS:append:tegra194 = " nvdisp-init"
 
-inherit deploy tegra-uefi-signing
+TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
+
+inherit deploy ${TEGRA_UEFI_SIGNING_CLASS}
 
 EDK2_PLATFORM = "Jetson"
 EDK2_PLATFORM_DSC = "Platform/NVIDIA/Jetson/Jetson.dsc"
@@ -43,12 +45,8 @@ do_compile:append() {
 }
 do_compile[depends] += "${NVDISPLAY_INIT_DEPS}"
 
-# Override this function in a bbappend to
-# implement other signing mechanisms
 sign_efi_app() {
-    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
-        tegra_uefi_sbsign "$1"
-    fi
+    tegra_uefi_sbsign "$1"
 }
 
 do_sign_efi_launcher() {

--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -6,7 +6,9 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 DEPENDS = "tegra-flashtools-native dtc-native"
 
-inherit l4t-extlinux-config kernel-artifact-names tegra-uefi-signing
+TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
+
+inherit l4t-extlinux-config kernel-artifact-names ${TEGRA_UEFI_SIGNING_CLASS}
 
 KERNEL_ARGS ??= ""
 DTBFILE ?= "${@os.path.basename(d.getVar('KERNEL_DEVICETREE').split()[0])}"
@@ -57,15 +59,11 @@ do_concat_dtb_overlays[depends] += "${@'virtual/dtb:do_populate_sysroot' if d.ge
 
 addtask concat_dtb_overlays after do_configure before do_sign_files
 
-# Override this function in a bbappend to
-# implement other signing mechanisms
 sign_extlinux_files() {
-    if [ -n "${TEGRA_UEFI_DB_KEY}" -a -n "${TEGRA_UEFI_DB_CERT}" ]; then
-        while [ $# -gt 0 ]; do
-	    tegra_uefi_split_sign "$1"
-	    shift
-	done
-    fi
+    while [ $# -gt 0 ]; do
+        tegra_uefi_split_sign "$1"
+        shift
+    done
 }
 
 do_sign_files() {


### PR DESCRIPTION
@madisongh , I wanted to get this up for early feedback.  I discussed this at a high level in the last (September) OE4T monthly meeting.  I'm starting to work now on getting `digsigserver` to support UEFI signing of various artifacts.  My desire was to try and start simple (Orin NX development module fused with development keys, Orin Nano devkit carrier board, tegra-demo-distro build) and work my way up to supporting our own custom carrier card, tegra build, and production keys.  I refactored how the UEFI signing worked with the intent of making it easier for others to follow the same path.  My approach was to try and corral all the `TEGRA_UEFI_DB_KEY` and `TEGRA_UEFI_DB_CERT` references spread out in various recipes and bring those back to the `tegra-uefi-signing.bbclass`.  Then one can add a `signing-server` override to `OVERRIDES` in their `local.conf` to cause the build to use the signing server equivalents of the functions you provided for supporting signing with local keys.  This approach cuts down on having to `.bbappend` recipes and reduces the friction required to utilize an external signing server.  In the meeting I discussed creating signed and unsigned equivalents of machine configurations using this override mechanism, but I think that would possibly create more clutter than it is worth and settled on the approach I described above.  There was good discussion in the meeting regarding whether an advanced feature like this should be brought into the demo distro so I understand if you want to keep things simple.  Any feedback you have is welcome.