### PR TITLE
image_types_tegra.bbclass: fix bad variable name

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -306,7 +306,7 @@ tegraflash_populate_package() {
     fi
 
     copy_dtbs .
-    local bcos=$(echo "$bcoverlays" | sed -e's!,! !g')
+    local bcos="$(echo "$bcoverlays" | sed -e's!,! !g')"
     copy_dtb_overlays . $bcos
     if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
         cp -R ${STAGING_BINDIR_NATIVE}/${FLASHTOOLS_DIR}/* .


### PR DESCRIPTION
* This PR fixes the following issue when using `ZSH` version `5.8 (x86_64-ubuntu-linux-gnu)`
```
+ copy_dtbs .
+ local destination=.
+ local dtb dtbf
+ basename tegra194-p3668-all-p3509-0000.dtb
+ dtbf=tegra194-p3668-all-p3509-0000.dtb
+ [ -e ./tegra194-p3668-all-p3509-0000.dtb ]
+ bbnote Copying KERNEL_DEVICETREE entry tegra194-p3668-all-p3509-0000.dtb to .
+ [ -p /home/icg/projects/oe4t/tegra-demo-distro/build-testdistro/tmp/work/jetson_xavier_nx_devkit_emmc-oe4t-linux/tegra-minimal-initramfs/1.0/temp/fifo.3441981 ]
+ echo NOTE: Copying KERNEL_DEVICETREE entry tegra194-p3668-all-p3509-0000.dtb to .
NOTE: Copying KERNEL_DEVICETREE entry tegra194-p3668-all-p3509-0000.dtb to .
+ cp -L /home/icg/projects/oe4t/tegra-demo-distro/build-testdistro/tmp/deploy/images/jetson-xavier-nx-devkit-emmc/tegra194-p3668-all-p3509-0000.dtb ./tegra194-p3668-all-p3509-0000.dtb
+ true
+ cp -L /home/icg/projects/oe4t/tegra-demo-distro/build-testdistro/tmp/deploy/images/jetson-xavier-nx-devkit-emmc/tegra194-p3668-all-p3509-0000.dtb.signed ./tegra194-p3668-all-p3509-0000.dtb.signed
+ [ -n  ]
+ echo L4TConfiguration.dtbo,UefiDefaultSecurityKeys.dtbo
+ sed -es!,! !g
+ local bcos=L4TConfiguration.dtbo UefiDefaultSecurityKeys.dtbo
/home/icg/projects/oe4t/tegra-demo-distro/build-testdistro/tmp/work/jetson_xavier_nx_devkit_emmc-oe4t-linux/tegra-minimal-initramfs/1.0/temp/run.do_image_cpio.3441981: 308: local: UefiDefaultSecurityKeys.dtbo: bad variable name
+ bb_sh_exit_handler
+ ret=2
+ [ 2 != 0 ]
+ echo WARNING: exit code 2 from a shell command.
WARNING: exit code 2 from a shell command.
+ exit 2
```