### PR TITLE
Add support for Qt 6

### DIFF
--- a/external/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
+++ b/external/qt6-layer/recipes-qt/qt6/qtbase_%.bbappend
@@ -1,0 +1,4 @@
+PACKAGECONFIG_GRAPHICS:append:tegra = " ${@bb.utils.contains('DISTRO_FEATURES', 'x11', '', 'eglfs-egldevice', d)}"
+
+QT_QPA_DEFAULT_EGLFS_INTEGRATION ?= "${@bb.utils.contains('PREFERRED_RPROVIDER_tegra-gbm-backend', 'tegra-libraries-gbm-backend', 'eglfs_kms_egldevice', 'eglfs_kms', d)}"
+EXTRA_OECMAKE:append:tegra = " -DQT_QPA_DEFAULT_EGLFS_INTEGRATION=${QT_QPA_DEFAULT_EGLFS_INTEGRATION}"


### PR DESCRIPTION
Add separate bbappends for Qt 6 (https://code.qt.io/cgit/yocto/meta-qt6.git). Enable the EGLFS EGLDevice platform support needed for NVIDIA boards. Disable GBM for qtbase, otherwise Qt tries to use wrong eglfs backend.