### PR TITLE
image_types_tegra: Adds EXTRA_IMAGEDEPENDS to fix the image task do_populate_lic_deploy

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -453,6 +453,7 @@ EOF
 
 IMAGE_CMD:tegraflash = "create_tegraflash_pkg"
 TEGRAFLASH_PKG_DEPENDS = "${@'zip-native:do_populate_sysroot' if d.getVar('TEGRAFLASH_PACKAGE_FORMAT') == 'zip' else '${CONVERSION_DEPENDS_gz}:do_populate_sysroot'}"
+EXTRA_IMAGEDEPENDS += "virtual/secure-os virtual/bootloader"
 do_image_tegraflash[depends] += "${TEGRAFLASH_PKG_DEPENDS} dtc-native:do_populate_sysroot coreutils-native:do_populate_sysroot \
                                  tegra-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \


### PR DESCRIPTION
This fix is needed to bring the complete dependency chain in order to guarantee the recursive runtime dependencies [1] of do_populate_lic_deploy in do_populate_lic will run as expected.

[1] _openembedded-core/meta/classes-recipe/license_image.bbclass:do_populate_lic_deploy[recrdeptask] += "do_populate_lic do_deploy"_

Fix the following image build issues:

```
ERROR: lmp-base-console-image-1.0-r0 do_populate_lic_deploy: Couldn't find license information for dependency tos-optee
ERROR: lmp-base-console-image-1.0-r0 do_populate_lic_deploy: Couldn't find license information for dependency edk2-firmware-tegra
```