### PR TITLE
tegra-uefi-capsule: add TEGRA_UEFI_CAPSULE_SIGNING_EXTRA_DEPS

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_35.4.1.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_35.4.1.bb
@@ -7,6 +7,8 @@ inherit tegra-bup deploy
 TEGRA_UEFI_CAPSULE_SIGNING_CLASS ??= "tegra-uefi-capsule-signing"
 inherit ${TEGRA_UEFI_CAPSULE_SIGNING_CLASS}
 
+TEGRA_UEFI_CAPSULE_SIGNING_EXTRA_DEPS ??= ""
+
 COMPATIBLE_MACHINE = "(tegra)"
 
 DEPENDS += "tegra-bup-payload"
@@ -49,4 +51,4 @@ do_deploy() {
 
 addtask deploy after do_install
 
-do_compile[depends] += "${@bup_dependency(d)}"
+do_compile[depends] += "${@bup_dependency(d)} ${TEGRA_UEFI_CAPSULE_SIGNING_EXTRA_DEPS}"


### PR DESCRIPTION
- The signing server version of the class that signs uefi capsules has some task dependencies that must be met.