### PR TITLE
tegra-helper-scripts: Fix error handling errors when flashing + Formatting

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -57,39 +57,39 @@ unset ARGS
 
 while true; do
     case "$1" in
-	--usb-instance)
-	    usb_instance="$2"
-	    shift 2
-	    ;;
-	--skip-bootloader)
-	    skip_bootloader=1
-	    shift
-	    ;;
-	--erase-nvme)
-	    erase_nvme=1
-	    shift
-	    ;;
-	-u)
-	    keyfile="$2"
-	    shift 2
-	    ;;
-	-v)
-	    sbk_keyfile="$2"
-	    shift 2
-	    ;;
-	-h|--help)
-	    usage
-	    exit 0
-	    ;;
-	--)
-	    shift
-	    break
-	    ;;
-	*)
-	    echo "Error processing options" >&2
-	    usage
-	    exit 1
-	    ;;
+        --usb-instance)
+            usb_instance="$2"
+            shift 2
+            ;;
+        --skip-bootloader)
+            skip_bootloader=1
+            shift
+            ;;
+        --erase-nvme)
+            erase_nvme=1
+            shift
+            ;;
+        -u)
+            keyfile="$2"
+            shift 2
+            ;;
+        -v)
+            sbk_keyfile="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Error processing options" >&2
+            usage
+            exit 1
+            ;;
     esac
 done
 
@@ -102,9 +102,9 @@ if [ -e "$here/odmsign.func" ]; then
 fi
 if [ -n "$PRESIGNED" ]; then
     if [ -n "$keyfile" -o -n "$sbk_keyfile" ]; then
-	echo "WARN: binaries already signed; ignoring signing options" >&2
-	keyfile=
-	sbk_keyfile=
+        echo "WARN: binaries already signed; ignoring signing options" >&2
+        keyfile=
+        sbk_keyfile=
     fi
 elif [ -n "$keyfile" -o -n "$sbk_keyfile" ] && [ $have_odmsign_func -eq 0 ]; then
     echo "ERR: missing odmsign.func from secureboot package, cannot sign binaries" >&2
@@ -115,6 +115,7 @@ wait_for_rcm() {
     "$here/find-jetson-usb" --wait "$usb_instance"
 }
 
+# shellcheck disable=SC2120  # Don't warn about no arguments are passed
 copy_signed_binaries() {
     local signdir="${1:-signed}"
     local xmlfile="${2:-flash.xml.tmp}"
@@ -123,61 +124,61 @@ copy_signed_binaries() {
     local line
 
     while read line; do
-	eval "$line"
-	[ -n "$partfile" ] || continue
-	if [ ! -e "$signdir/$partfile" ]; then
-	    if [ ! -e "$destdir/$partfile" ] && ! echo "$partfile" | grep -q "FILE"; then
-		echo "ERR: could not copy $partfile from $signdir" >&2
-		return 1
-	    fi
-	else
-	    cp "$signdir/$partfile" "$destdir"
-	fi
+        eval "$line"
+        [ -n "$partfile" ] || continue
+        if [ ! -e "$signdir/$partfile" ]; then
+            if [ ! -e "$destdir/$partfile" ] && ! echo "$partfile" | grep -q "FILE"; then
+                echo "ERR: could not copy $partfile from $signdir" >&2
+                return 1
+            fi
+        else
+            cp "$signdir/$partfile" "$destdir"
+        fi
     done < <("$here/nvflashxmlparse" -t boot "$signdir/$xmlfile"; "$here/nvflashxmlparse" -t rootfs "$signdir/$xmlfile")
 }
 
 sign_binaries() {
     if [ -n "$PRESIGNED" ]; then
-	cp doflash.sh flash_signed.sh
-	if ! copy_bootloader_files bootloader_staging; then
-	    return 1
-	fi
-	return 0
+        cp doflash.sh flash_signed.sh
+        if ! copy_bootloader_files bootloader_staging; then
+            return 1
+        fi
+        return 0
     fi
     if [ -z "$BOARDID" -o -z "$FAB" ]; then
-	wait_for_rcm
+        wait_for_rcm
     fi
     if [ -e external-flash.xml.in ]; then
-	"$here/nvflashxmlparse" --extract --type rootfs --change-device-type=sdmmc_user -o external-flash.xml.tmp external-flash.xml.in
+        "$here/nvflashxmlparse" --extract --type rootfs --change-device-type=sdmmc_user -o external-flash.xml.tmp external-flash.xml.in
         if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV \
-		  "$here/$FLASH_HELPER" --no-flash --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
-		  external-flash.xml.tmp $DTBFILE $EMMC_BCTS $ODMDATA $LNXFILE $ROOTFS_IMAGE; then
-	    if [ $have_odmsign_func -eq 0 ]; then
-		cp signed/flash.xml.tmp external-secureflash.xml
-		copy_signed_binaries
-	    else
-		mv secureflash.xml external-secureflash.xml
-	    fi
-	else
-	    return 1
-	fi
-	. ./boardvars.sh
+                  "$here/$FLASH_HELPER" --no-flash --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
+                  external-flash.xml.tmp "$DTBFILE" "$EMMC_BCTS" "$ODMDATA" "$LNXFILE" "$ROOTFS_IMAGE"; then
+            if [ $have_odmsign_func -eq 0 ]; then
+                cp signed/flash.xml.tmp external-secureflash.xml
+                copy_signed_binaries
+            else
+                mv secureflash.xml external-secureflash.xml
+            fi
+        else
+            return 1
+        fi
+        . ./boardvars.sh
     fi
     if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV \
-	      "$here/$FLASH_HELPER" --no-flash --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
-	      flash.xml.in $DTBFILE $EMMC_BCTS $ODMDATA $LNXFILE $ROOTFS_IMAGE; then
-	if [ $have_odmsign_func -eq 0 ]; then
-	    cp signed/flash.xml.tmp secureflash.xml
-	    cp signed/flash.idx flash.idx
-	    copy_signed_binaries
-	else
-	    cp flashcmd.txt flash_signed.sh
-	fi
+              "$here/$FLASH_HELPER" --no-flash --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
+              flash.xml.in "$DTBFILE" "$EMMC_BCTS" "$ODMDATA" "$LNXFILE" "$ROOTFS_IMAGE"; then
+        if [ $have_odmsign_func -eq 0 ]; then
+            cp signed/flash.xml.tmp secureflash.xml
+            cp signed/flash.idx flash.idx
+            copy_signed_binaries
+        else
+            cp flashcmd.txt flash_signed.sh
+        fi
     else
-	return 1
+        return 1
     fi
     if ! copy_bootloader_files bootloader_staging; then
-	return 1
+        return 1
     fi
     . ./boardvars.sh
     return 0
@@ -185,47 +186,47 @@ sign_binaries() {
 
 prepare_for_rcm_boot() {
     if [ $have_odmsign_func -eq 1 ]; then
-	"$here/rewrite-tegraflash-args" -o rcm-boot.sh --bins kernel=initrd-flash.img,kernel_dtb=kernel_$DTBFILE --cmd rcmboot --add="--securedev" flash_signed.sh || return 1
-	if [ "$CHIPID" = "0x23" ]; then
-	    sed -i -e's,mb2_t234_with_mb2_bct_MB2,mb2_t234_with_mb2_cold_boot_bct_MB2,' -e's, uefi_jetson, rcmboot_uefi_jetson,' rcm-boot.sh || return 1
-	fi
-	chmod +x rcm-boot.sh
+        "$here/rewrite-tegraflash-args" -o rcm-boot.sh --bins "kernel=initrd-flash.img,kernel_dtb=kernel_$DTBFILE" --cmd rcmboot --add="--securedev" flash_signed.sh || return 1
+        if [ "$CHIPID" = "0x23" ]; then
+            sed -i -e's,mb2_t234_with_mb2_bct_MB2,mb2_t234_with_mb2_cold_boot_bct_MB2,' -e's, uefi_jetson, rcmboot_uefi_jetson,' rcm-boot.sh || return 1
+        fi
+        chmod +x rcm-boot.sh
     fi
 }
 
 run_rcm_boot() {
     if [ $have_odmsign_func -eq 1 ]; then
-	if [ -z "$BR_CID" ]; then
-	    if ./rcm-boot.sh | tee rcm-boot.output; then
-		BR_CID=$(grep BR_CID: rcm-boot.output | cut -d: -f2)
-		return 0
-	    else
-		return 1
-	    fi
-	fi
-	./rcm-boot.sh || return 1
+        if [ -z "$BR_CID" ]; then
+            if ./rcm-boot.sh | tee rcm-boot.output; then
+                BR_CID=$(grep BR_CID: rcm-boot.output | cut -d: -f2)
+                return 0
+            else
+                return 1
+            fi
+        fi
+        ./rcm-boot.sh || return 1
     else
-	MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV \
-	       "$here/$FLASH_HELPER" --rcm-boot -u "$keyfile" -v "$sbk_keyfile" \
-	       flash.xml.in $DTBFILE $EMMC_BCTS $ODMDATA initrd-flash.img $ROOTFS_IMAGE || return 1
+        MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV \
+               "$here/$FLASH_HELPER" --rcm-boot -u "$keyfile" -v "$sbk_keyfile" \
+               flash.xml.in "$DTBFILE" "$EMMC_BCTS" "$ODMDATA" initrd-flash.img "$ROOTFS_IMAGE" || return 1
     fi
 }
 
 mount_partition() {
     local dev="$1"
     local mnt=$(cat /proc/mounts | grep "^$dev" | cut -d' ' -f2)
-    local i=$(echo $mnt|awk -F' ' '{print NF}')
-    while [ $i -ne 0 ]; do
-        local mnt=$(echo ${mnt} | cut -d' ' -f$i)
-		if ! umount "${mnt}" > /dev/null 2>&1; then
+    local i=$(echo $mnt | awk -F' ' '{print NF}')
+    while [ "$i" -ne 0 ]; do
+        local mnt=$(echo "${mnt}" | cut -d' ' "-f$i")
+        if ! umount "${mnt}" > /dev/null 2>&1; then
             echo "ERR: unmount ${mnt} on device $dev failed" >&2
             return 1
         fi
-        i=$(expr $i - 1)
+        i=$(("$i" - 1))
     done
     if udisksctl mount -b "$dev" > /dev/null; then
-	cat /proc/mounts | grep "^$dev" | cut -d' ' -f2
-	return 0
+        cat /proc/mounts | grep "^$dev" | cut -d' ' -f2
+        return 0
     fi
     echo ""
     return 1
@@ -236,14 +237,14 @@ unmount_and_release() {
     local dev="$2"
     local remain=3
     if [ -n "$mnt" ]; then
-	udisksctl unmount --force -b "$dev"
+        udisksctl unmount --force -b "$dev"
     fi
-    while [ $remain -gt 0 ]; do
-	if udisksctl power-off -b "$dev"; then
-	    return 0
-	fi
-	sleep 1
-	remain=$(expr $remain - 1)
+    while [ "$remain" -gt 0 ]; do
+        if udisksctl power-off -b "$dev"; then
+            return 0
+        fi
+        sleep 1
+        remain=$(("$remain" - 1))
     done
     return 1
 }
@@ -256,32 +257,32 @@ wait_for_usb_storage() {
 
     echo -n "Waiting for USB storage device $name from $sessid..." >&2
     while [ -z "$output" ]; do
-	for candidate in /dev/sd[a-z]; do
-	    [ -b "$candidate" ] || continue
-	    cand_model=$(udevadm info --query=property $candidate | grep '^ID_MODEL=' | cut -d= -f2)
-	    if [ "$cand_model" = "$sessid" ]; then
-		cand_vendor=$(udevadm info --query=property $candidate | grep '^ID_VENDOR=' | cut -d= -f2)
-		if [ "$cand_vendor" = "$name" ]; then
-		    echo "[$candidate]" >&2
-		    output="$candidate"
-		    break
-		elif [ "$name" != "flashpkg" -a "$cand_vendor" = "flashpkg" ]; then
-		    # This could happen if there was a failure on the device side
-		    echo "[got flashpkg when expecting $name]" >&2
-		    echo ""
-		    early_final_status=1
-		    return 1
-		fi
-	    fi
-	done
-	if [ -z "$output" ]; then
-	    sleep 1
-	    count=$(expr $count \+ 1)
-	    if [ $count -ge 5 ]; then
-		echo -n "." >&2
-		count=0
-	    fi
-	fi
+        for candidate in /dev/sd[a-z]; do
+            [ -b "$candidate" ] || continue
+            cand_model=$(udevadm info --query=property $candidate | grep '^ID_MODEL=' | cut -d= -f2)
+            if [ "$cand_model" = "$sessid" ]; then
+                cand_vendor=$(udevadm info --query=property $candidate | grep '^ID_VENDOR=' | cut -d= -f2)
+                if [ "$cand_vendor" = "$name" ]; then
+                    echo "[$candidate]" >&2
+                    output="$candidate"
+                    break
+                elif [ "$name" != "flashpkg" -a "$cand_vendor" = "flashpkg" ]; then
+                    # This could happen if there was a failure on the device side
+                    echo "[got flashpkg when expecting $name]" >&2
+                    echo ""
+                    early_final_status=1
+                    return 1
+                fi
+            fi
+        done
+        if [ -z "$output" ]; then
+            sleep 1
+            count=$(expr $count \+ 1)
+            if [ $count -ge 5 ]; then
+                echo -n "." >&2
+                count=0
+            fi
+        fi
     done
     echo "$output"
     return 0
@@ -294,37 +295,37 @@ copy_bootloader_files() {
     local is_spi is_mmcboot
     rm -f "$dest/partitions.conf"
     while IFS=", " read partnumber partloc start_location partsize partfile partattrs partsha; do
-	# Need to trim off leading blanks
-	devnum=$(echo "$partloc" | cut -d':' -f 1)
-	instnum=$(echo "$partloc" | cut -d':' -f 2)
-	partname=$(echo "$partloc" | cut -d':' -f 3)
-	# SPI is 3:0
-	# eMMC boot blocks (boot0/boot1) are 0:3
-	# eMMC user is 1:3
-	# NVMe (any external device) is 9:0
-	if [ $devnum -eq 3 -a $instnum -eq 0 ] || [ $devnum -eq 0 -a $instnum -eq 3 ]; then
-	    if [ -n "$partfile" ]; then
-		cp "$partfile" "$dest/"
-	    fi
-	    if [ $devnum -eq 3 -a $instnum -eq 0 ]; then
-		is_spi=yes
-	    elif [ $devnum -eq 0 -a $instnum -eq 3 ]; then
-		is_mmcboot=yes
-	    fi
-	    echo "$partname:$start_location:$partsize:$partfile" >> "$dest/partitions.conf"
-	fi
+        # Need to trim off leading blanks
+        devnum=$(echo "$partloc" | cut -d':' -f 1)
+        instnum=$(echo "$partloc" | cut -d':' -f 2)
+        partname=$(echo "$partloc" | cut -d':' -f 3)
+        # SPI is 3:0
+        # eMMC boot blocks (boot0/boot1) are 0:3
+        # eMMC user is 1:3
+        # NVMe (any external device) is 9:0
+        if [ $devnum -eq 3 -a $instnum -eq 0 ] || [ $devnum -eq 0 -a $instnum -eq 3 ]; then
+            if [ -n "$partfile" ]; then
+                cp "$partfile" "$dest/"
+            fi
+            if [ $devnum -eq 3 -a $instnum -eq 0 ]; then
+                is_spi=yes
+            elif [ $devnum -eq 0 -a $instnum -eq 3 ]; then
+                is_mmcboot=yes
+            fi
+            echo "$partname:$start_location:$partsize:$partfile" >> "$dest/partitions.conf"
+        fi
     done < flash.idx
     if [ -n "$is_spi" ]; then
-	if [ -n "$is_mmcboot" ]; then
-	    echo "ERR: found bootloader entries for both SPI flash and eMMC boot partitions" >&2
-	    return 1
-	fi
-	echo "spi" > "$dest/boot_device_type"
+        if [ -n "$is_mmcboot" ]; then
+            echo "ERR: found bootloader entries for both SPI flash and eMMC boot partitions" >&2
+            return 1
+        fi
+        echo "spi" > "$dest/boot_device_type"
     elif [ -n "$is_mmcboot" ]; then
-	echo "mmcboot" > "$dest/boot_device_type"
+        echo "mmcboot" > "$dest/boot_device_type"
     else
-	echo "ERR: no SPI or eMMC boot partition entries found" >&2
-	return 1
+        echo "ERR: no SPI or eMMC boot partition entries found" >&2
+        return 1
     fi
     return 0
 }
@@ -334,34 +335,34 @@ generate_flash_package() {
     local exports
 
     if [ -z "$dev" ]; then
-	echo "ERR: could not locate USB storage device for sending flashing commands" >&2
-	return 1
+        echo "ERR: could not locate USB storage device for sending flashing commands" >&2
+        return 1
     fi
     local devsize=$(cat /sys/block/$(basename $dev)/size 2>/dev/null)
     echo "Device size in blocks: $devsize" >&2
     local mnt=$(mount_partition "$dev")
     if [ -z "$mnt" ]; then
-	echo "ERR: could not mount USB storage for writing flashing commands" >&2
-	return 1
+        echo "ERR: could not mount USB storage for writing flashing commands" >&2
+        return 1
     fi
 
     mkdir "$mnt/flashpkg/conf"
     rm -f "$mnt/flashpkg/conf/command_sequence"
     touch "$mnt/flashpkg/conf/command_sequence"
     if [ $skip_bootloader -eq 0 ]; then
-	echo "bootloader" >> "$mnt/flashpkg/conf/command_sequence"
-	mkdir "$mnt/flashpkg/bootloader"
-	cp bootloader_staging/* "$mnt/flashpkg/bootloader"
+        echo "bootloader" >> "$mnt/flashpkg/conf/command_sequence"
+        mkdir "$mnt/flashpkg/bootloader"
+        cp bootloader_staging/* "$mnt/flashpkg/bootloader"
     fi
 
     if [ $erase_nvme -eq 1 ]; then
-	echo "erase-nvme" >> "$mnt/flashpkg/conf/command_sequence"
+        echo "erase-nvme" >> "$mnt/flashpkg/conf/command_sequence"
     fi
-    if [ $EXTERNAL_ROOTFS_DRIVE -eq 1 -a $BOOT_PARTITIONS_ON_EMMC -eq 1 ]; then
-	echo "export-devices mmcblk0 $ROOTFS_DEVICE" >> "$mnt/flashpkg/conf/command_sequence"
+    if [ "$EXTERNAL_ROOTFS_DRIVE" -eq 1 -a "$BOOT_PARTITIONS_ON_EMMC" -eq 1 ]; then
+        echo "export-devices mmcblk0 $ROOTFS_DEVICE" >> "$mnt/flashpkg/conf/command_sequence"
     else
-	[ $EXTERNAL_ROOTFS_DRIVE -eq 0 -o $NO_INTERNAL_STORAGE -eq 1 ] || echo "erase-mmc" >> "$mnt/flashpkg/conf/command_sequence"
-	echo "export-devices $ROOTFS_DEVICE" >> "$mnt/flashpkg/conf/command_sequence"
+        [ "$EXTERNAL_ROOTFS_DRIVE" -eq 0 -o "$NO_INTERNAL_STORAGE" -eq 1 ] || echo "erase-mmc" >> "$mnt/flashpkg/conf/command_sequence"
+        echo "export-devices $ROOTFS_DEVICE" >> "$mnt/flashpkg/conf/command_sequence"
     fi
 
     echo "reboot" >> "$mnt/flashpkg/conf/command_sequence"
@@ -379,20 +380,20 @@ write_to_device() {
     local extraarg
 
     if [ -z "$dev" ]; then
-	echo "ERR: could not find $devname" >&2
-	return 1
+        echo "ERR: could not find $devname" >&2
+        return 1
     fi
     if [ -e external-secureflash.xml ]; then
-	rewritefiles="external-secureflash.xml,$rewritefiles"
+        rewritefiles="external-secureflash.xml,$rewritefiles"
     fi
     "$here/nvflashxmlparse" --rewrite-contents-from=$rewritefiles -o initrd-flash.xml "$flashlayout"
     if [ -n "$DATAFILE" ]; then
-	datased="-es,DATAFILE,$DATAFILE,"
+        datased="-es,DATAFILE,$DATAFILE,"
     else
-	datased="-e/DATAFILE/d"
+        datased="-e/DATAFILE/d"
     fi
-    if [ "$devname" = "mmcblk0" -a $BOOT_PARTITIONS_ON_EMMC -eq 1 ]; then
-	extraarg="--honor-start-locations"
+    if [ "$devname" = "mmcblk0" -a "$BOOT_PARTITIONS_ON_EMMC" -eq 1 ]; then
+        extraarg="--honor-start-locations"
     fi
     # XXX
     # For the pre-signed case, the flash layout will contain the
@@ -401,11 +402,11 @@ write_to_device() {
     # XXX
     simgname="${ROOTFS_IMAGE%.*}.img"
     sed -i -e"s,$simgname,$ROOTFS_IMAGE," -e"s,APPFILE_b,$ROOTFS_IMAGE," -e"s,APPFILE,$ROOTFS_IMAGE," $datased initrd-flash.xml
-    if "$here/make-sdcard" -y $opts $extraarg initrd-flash.xml "$dev"; then
-	rc=0
+    if "$here/make-sdcard" -y "$opts" $extraarg initrd-flash.xml "$dev"; then
+        rc=0
     fi
     if ! unmount_and_release "" "$dev"; then
-	rc=1
+        rc=1
     fi
     return $rc
 }
@@ -415,26 +416,26 @@ get_final_status() {
     local dev=$(wait_for_usb_storage "$session_id" "flashpkg")
     local mnt final_status logdir logfile
     if [ -z "$dev" ]; then
-	echo "ERR: could not get final status from device" >&2
-	return 1
+        echo "ERR: could not get final status from device" >&2
+        return 1
     fi
     mnt=$(mount_partition "$dev")
     if [ -z "$mnt" ]; then
-	echo "ERR: could not mount USB device to get final status from device" >&2
-	return 1
+        echo "ERR: could not mount USB device to get final status from device" >&2
+        return 1
     fi
     final_status=$(cat $mnt/flashpkg/status)
     if [ -d "$mnt/flashpkg/logs" ]; then
-	logdir="device-logs-$dtstamp"
-	if [ -d "$logdir" ]; then
-	    echo "Logs directory $logdir already exists, replacing" >&2
-	    rm -rf "$logdir"
-	fi
-	mkdir "$logdir"
-	for logfile in "$mnt"/flashpkg/logs/*; do
-	    [ -f "$logfile" ] || continue
-	    cp "$logfile" "$logdir/"
-	done
+        logdir="device-logs-$dtstamp"
+        if [ -d "$logdir" ]; then
+            echo "Logs directory $logdir already exists, replacing" >&2
+            rm -rf "$logdir"
+        fi
+        mkdir "$logdir"
+        for logfile in "$mnt"/flashpkg/logs/*; do
+            [ -f "$logfile" ] || continue
+            cp "$logfile" "$logdir/"
+        done
     fi
     unmount_and_release "$mnt" "$dev" || return 1
     echo "Final status: $final_status"
@@ -448,7 +449,7 @@ stepnumber=1
 step_banner() {
     local msg="$1"
     echo "== Step $stepnumber: $msg at $(date -Is) ==" | tee -a "$logfile"
-    stepnumber=$(expr $stepnumber \+ 1)
+    stepnumber=$(("$stepnumber" + 1))
 }
 
 echo "Starting at $(date -Is)" | tee "$logfile"
@@ -494,7 +495,7 @@ if [ -z "$BR_CID" ]; then
     exit 1
 fi
 
-session_id=$("$here/brcid-to-uid" $BR_CID)
+session_id=$("$here/brcid-to-uid" "$BR_CID")
 session_id=$(echo -n "$session_id" | tail -c8)
 
 # Boot device flashing
@@ -503,33 +504,32 @@ if ! generate_flash_package 2>&1 | tee -a "$logfile"; then
     echo "ERR: could not create command package at $(date -Is)" | tee -a "$logfile"
     exit 1
 fi
-if [ $EXTERNAL_ROOTFS_DRIVE -eq 1 ]; then
-    keep_going=1
-    if [ $BOOT_PARTITIONS_ON_EMMC -eq 1 ]; then
-	step_banner "Writing boot partitions to internal storage device"
-	if ! write_to_device mmcblk0 flash.xml.in --no-final-part 2>&1 | tee -a "$logfile"; then
-	    echo "ERR: write failure to internal storage at $(date -Is)" | tee -a "$logfile"
-	    if [ $early_final_status -eq 0 ]; then
-		exit 1
-	    fi
-	fi
+if [ "$EXTERNAL_ROOTFS_DRIVE" -eq 1 ]; then
+    if [ "$BOOT_PARTITIONS_ON_EMMC" -eq 1 ]; then
+        step_banner "Writing boot partitions to internal storage device"
+        if ! write_to_device mmcblk0 flash.xml.in --no-final-part 2>&1 | tee -a "$logfile"; then
+            echo "ERR: write failure to internal storage at $(date -Is)" | tee -a "$logfile"
+            if [ $early_final_status -eq 0 ]; then
+                exit 1
+            fi
+        fi
     fi
     if [ $early_final_status -eq 0 ]; then
-	step_banner "Writing partitions on external storage device"
-	if ! write_to_device $ROOTFS_DEVICE external-flash.xml.in 2>&1 | tee -a "$logfile"; then
-	    echo "ERR: write failure to external storage at $(date -Is)" | tee -a "$logfile"
-	    if [ $early_final_status -eq 0 ]; then
-		exit 1
-	    fi
-	fi
+        step_banner "Writing partitions on external storage device"
+        if ! write_to_device "$ROOTFS_DEVICE" external-flash.xml.in 2>&1 | tee -a "$logfile"; then
+            echo "ERR: write failure to external storage at $(date -Is)" | tee -a "$logfile"
+            if [ $early_final_status -eq 0 ]; then
+                exit 1
+            fi
+        fi
     fi
 else
     step_banner "Writing partitions on internal storage device"
-    if ! write_to_device $ROOTFS_DEVICE flash.xml.in 2>&1 | tee -a "$logfile"; then
-	echo "ERR: write failure to internal storage at $(date -Is)" | tee -a "$logfile"
-	if [ $early_final_status -eq 0 ]; then
-	    exit 1
-	fi
+    if ! write_to_device "$ROOTFS_DEVICE" flash.xml.in 2>&1 | tee -a "$logfile"; then
+        echo "ERR: write failure to internal storage at $(date -Is)" | tee -a "$logfile"
+        if [ $early_final_status -eq 0 ]; then
+            exit 1
+        fi
     fi
 fi
 step_banner "Waiting for final status from device"


### PR DESCRIPTION
Function calls under `| tee -a $logfile` don't propagate an error code. Some flashing errors are ignored without the fix.

And a separate commit for some formatting.