### PR TITLE
cuda-target-environment: add nvcc/glibc 2.38 workaround

### DIFF
--- a/recipes-devtools/cuda/cuda-target-environment_1.0.bb
+++ b/recipes-devtools/cuda/cuda-target-environment_1.0.bb
@@ -12,11 +12,12 @@ S = "${WORKDIR}"
 
 COMPILER_CMD  = "${@d.getVar('CXX_FOR_CUDA').split()[0]}"
 CMAKE_CUDA_ARCHITECTURES = "${@d.getVar('CUDA_ARCHITECTURES') if d.getVar('CUDA_ARCHITECTURES') else 'OFF'}"
+CUDA_EXTRA_CXXFLAGS ??= "-isystem=${includedir}/cuda-compat-workarounds"
 
 def arch_flags(d):
-    archflags = d.getVar('TARGET_CC_ARCH')
+    archflags = (d.getVar('TARGET_CC_ARCH') or '').split() + (d.getVar('CUDA_EXTRA_CXXFLAGS') or '').split()
     if archflags:
-        return "-Xcompiler " + ','.join(archflags.split())
+        return "-Xcompiler " + ','.join(archflags)
     return ""
 
 do_compile() {


### PR DESCRIPTION
Update the CUDACXXARCHFLAGS environment variable to include the same glibc 2.38 workaround to SDKs that was added to cuda.bbclass with 52f994fbb3844e11919139a4250a2859fa153ace.

Fixes #1443 