### PR TITLE
initrd-flash.sh: ensure substitution for DTB_FILE

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -400,7 +400,7 @@ write_to_device() {
     # the raw image name.
     # XXX
     simgname="${ROOTFS_IMAGE%.*}.img"
-    sed -i -e"s,$simgname,$ROOTFS_IMAGE," -e"s,APPFILE_b,$ROOTFS_IMAGE," -e"s,APPFILE,$ROOTFS_IMAGE," $datased initrd-flash.xml
+    sed -i -e"s,$simgname,$ROOTFS_IMAGE," -e"s,APPFILE_b,$ROOTFS_IMAGE," -e"s,APPFILE,$ROOTFS_IMAGE," -e"s,DTB_FILE,kernel_$DTBFILE," $datased initrd-flash.xml
     if "$here/make-sdcard" -y $opts $extraarg initrd-flash.xml "$dev"; then
 	rc=0
     fi


### PR DESCRIPTION
- Pre-signed builds need to ensure that DTB_FILE has been substituted with the actual kernel .dtb file in initrd-flash.xml.  Unsigned builds take a different path through initrd-flash such that the tegraXXX-flash-helper will have already made the substitution.

- Fixes #1452