### PR TITLE
libnvidia-container: rdepend on tegra-libraries-cuda

### DIFF
--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.10.0.bb
@@ -76,4 +76,4 @@ do_install () {
 
 PACKAGES =+ "${PN}-tools"
 FILES:${PN}-tools = "${bindir}"
-RDEPENDS:${PN}:append:tegra = " libnvidia-container-jetson ldconfig"
+RDEPENDS:${PN}:append:tegra = " libnvidia-container-jetson ldconfig tegra-libraries-cuda"


### PR DESCRIPTION
Fixes:
```
root@jetson-agx-xavier-devkit:~# nvidia-container-cli -d log info
nvidia-container-cli: initialization error: driver error: failed to process request

root@jetson-agx-xavier-devkit:~# cat log

-- WARNING, the following logs are for debugging purposes only --

I0116 15:56:51.761083 1362 nvc.c:281] initializing library context (version=0.11.0+jetpack, build=1b60893021cd00c87f201d11eb207215afa3ab11)
I0116 15:56:51.761474 1362 nvc.c:255] using root /
I0116 15:56:51.761547 1362 nvc.c:256] using ldcache /etc/ld.so.cache
I0116 15:56:51.761618 1362 nvc.c:257] using unprivileged user 65534:65534
I0116 15:56:51.762404 1363 driver.c:134] starting driver service
E0116 15:56:51.763612 1363 driver.c:196] could not start driver service: load library failed: libcuda.so.1: cannot open shared object file: no such file or directory
I0116 15:56:51.764073 1362 driver.c:231] driver service terminated successfully
```