### PR TITLE
tegra-storage-layout: fix support for large rootfs

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-storage-layout_35.4.1.bb
+++ b/recipes-bsp/tegra-binaries/tegra-storage-layout_35.4.1.bb
@@ -78,7 +78,7 @@ do_compile() {
         # original for that purpose, stripping out the APP
         # partition so that the offsets of the partitions
         # referenced during early boot match the split layout above.
-        nvflashxmlparse -v --remove --partitions-to-remove=APP --output=bupgen-internal-flash.xml internal-flash.xml.orig
+        nvflashxmlparse -v --remove --partitions-to-remove=APP,APP_b --output=bupgen-internal-flash.xml internal-flash.xml.orig
     else
         if [ "${TEGRAFLASH_NO_INTERNAL_STORAGE}" = "1" ]; then
             # For modules with *only* SPI flash (or other boot device) and no


### PR DESCRIPTION
When using a rootfs with external device too large for the emmc and a redundant rootfs partition, the APP_b partition is not removed from the emmc partition and therefore bup payload creation fails when it tries to place the too large rootfs into the emmc.

Expand the existing logic to remove the APP_b partition, if it exists, in addition to the APP partition.

Tested with `jetson-xavier-nx-devkit-emmc` with nvme and this config:

```
TNSPEC_BOOTDEV = "nvme0n1p1"
TEGRA_EXTERNAL_DEVICE_SECTORS = "488397168"
USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
ROOTFSPART_SIZE = "59055800320"
```

After boot I see a 51GB rootfs
```
root@jetson-xavier-nx-devkit-emmc:~# df -h | grep nvme
/dev/nvme0n1p1           51.3G    720.3M     47.8G   1% /
```
Closes https://github.com/OE4T/meta-tegra/issues/1439