### PR TITLE
nvidia-container-toolkit: Add version and gitCommit to nvidia-container-runtime --version

### DIFF
--- a/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.11.0.bb
+++ b/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.11.0.bb
@@ -45,11 +45,16 @@ SECURITY_LDFLAGS = ""
 LDFLAGS += "-Wl,-z,lazy"
 GO_LINKSHARED = ""
 
+GO_EXTRA_LDFLAGS:append = "\
+    -X github.com/NVIDIA/nvidia-container-toolkit/internal/info.version=${GITPKGVTAG} \
+    -X github.com/NVIDIA/nvidia-container-toolkit/internal/info.gitCommit=${GITPKGV} \
+"
+
 S = "${WORKDIR}/git"
 
 REQUIRED_DISTRO_FEATURES = "virtualization"
 
-inherit go-mod features_check
+inherit go-mod gitpkgv features_check
 
 do_install(){
     go_do_install


### PR DESCRIPTION
This feature enables the display of the version information for the `nvidia-container-toolkit` binaries. After this change, the binary versioning will appear as follows:

```bash
nvidia-container-runtime --version
NVIDIA Container Runtime version 1.11.0
commit: 670+d9de4a0
.
.
.
```