### PR TITLE
uefi_common.func.in: Fix gen_compat_3701 typo

### DIFF
--- a/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
@@ -96,7 +96,7 @@ gen_compat_3701() {
             fab="300"
         fi
     fi
-    if [ "$boardksu" = "0005" ]; then
+    if [ "$boardsku" = "0005" ]; then
         fab=""
     fi
     boardrev=


### PR DESCRIPTION
This fixed UEFI Capsules for me with an Orin AGX with this boardspec.
```
$ tegra-boardspec 
3701-500-0005-M.0-1-0
```