### PR TITLE
AGX Xavier missing fab

### DIFF
--- a/conf/machine/include/tegra194.inc
+++ b/conf/machine/include/tegra194.inc
@@ -28,7 +28,8 @@ TEGRA_MINRATCHET_CONFIG ?= "tegra194-mb1-bct-ratchet-p2888-0000-p2822-0000.cfg"
 TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0001;boardrev=H.0 \
                        fab=400;boardsku=0001;boardrev=J.0 \
                        fab=400;boardsku=0001;boardrev=L.0 \
-                       fab=400;boardsku=0004;boardrev="
+                       fab=400;boardsku=0004;boardrev= \
+                       fab=401;boardsku=0004;boardrev="
 
 TEGRA_SIGNING_ENV = "CHIPREV=${TEGRA_CHIPREV} BOARDID=${TEGRA_BOARDID} FAB=${TEGRA_FAB} BOARDSKU=${TEGRA_BOARDSKU} BOARDREV=${TEGRA_BOARDREV}"
 


### PR DESCRIPTION
The 401 fab was added in dunfell-l4t-r32.5.0 but missing in this branch