### PR TITLE
AGX Xavier missing fab

### DIFF
--- a/conf/machine/jetson-agx-xavier-devkit.conf
+++ b/conf/machine/jetson-agx-xavier-devkit.conf
@@ -9,6 +9,7 @@ TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0001;boardrev=H.0 \
                        fab=400;boardsku=0001;boardrev=J.0 \
                        fab=400;boardsku=0001;boardrev=L.0 \
                        fab=400;boardsku=0004;boardrev= \
+                       fab=401;boardsku=0004;boardrev= \
 		       fab=402;boardsku=0005;boardrev="
 
 KERNEL_DEVICETREE ?= "tegra194-p2888-0001-p2822-0000.dtb"


### PR DESCRIPTION
The 401 fab was added in dunfell-l4t-r32.5.0 but missing in this branch