### PR TITLE
setup-nv-boot-control: support t194 p2888 fabs 401 and 402

### DIFF
--- a/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
@@ -60,17 +60,16 @@ set_efi_var() {
 }
 
 gen_compat_2888() {
-    if [ "$fab" = "400" ]; then
-        if [ "$boardsku" = "0004" ]; then
-            boardrev=
+    if [ "$boardsku" = "0004" ]; then
+        boardrev=
+        fab="400"
+    elif [ "$fab" = "400" ]; then
+        if echo "$boardrev" | grep -q "^[ABCD]\."; then
+            boardrev="D.0"
         else
-            if echo "$boardrev" | grep -q "^[ABCD]\."; then
-                boardrev="D.0"
-            else
-                boardrev="E.0"
-            fi
-            boardsku="0001"
+            boardrev="E.0"
         fi
+        boardsku="0001"
     elif [ "$fab" = "600" -a "$boardsku" = "0008" ]; then
         boardrev=
     fi
@@ -130,7 +129,8 @@ gen_compat_spec() {
 # boardspec should be piped into this function
 needs_mmc_hack() {
     IFS=- read boardid fab boardsku boardrev fuselevel chiprev
-    if [ "$boardid" = "2888" -a "$fab" = "400" ]; then
+    if [ "$boardid" = "2888" -a "$boardsku" != "0008" ]; then
+        # all AGX except industrial need the workaround
         echo "yes"
     else
         echo ""


### PR DESCRIPTION
The stock TEGRA_BUPGEN_SPECS are unchanged (supporting only fabs 400 and 402), so this is not changed here.

However, for the emmc efi variable workarounds we need to look for these fabs when applicable. Notably missing from this workaround was the listed 402 fab, the apparently new 401 fab, and also the industrial 600 fab, all of which need this workaround. So this is now all boardid=2888 configurations.

Also handled here is the gen_compat_spec. This was changed a bit to apply the workarounds for older know board skus, and leave the newer style for all unlisted fabs.

---

I have one doubt, and that is the original code only named the 400 fab. Obviously it needs the 4xx fabs moving forward. I don't know about the industrial/600 fab - is it correct that this doesn't use a spi flash and would therefore need the workaround?