### PR TITLE
initrd-flash: Add custom extra init

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -371,6 +371,7 @@ generate_flash_package() {
 	echo "export-devices $ROOTFS_DEVICE" >> "$mnt/flashpkg/conf/command_sequence"
     fi
 
+    echo "extra" >> "$mnt/flashpkg/conf/command_sequence"
     echo "reboot" >> "$mnt/flashpkg/conf/command_sequence"
 
     unmount_and_release "$mnt" "$dev" || return 1

--- a/recipes-core/initrdscripts/tegra-flash-init/init-extra.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-extra.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Run custom extra init script(s) provided from seperate recipes.
+
+init_extra_dir="/init-extra.d"
+
+if [ -d $init_extra_dir ] && [ "$(ls -A $init_extra_dir)" ]; then
+  for init_extra in "$init_extra_dir"/*; do
+    ./"$init_extra" 2>&1 | tee "/tmp/flashpkg/flashpkg/logs/custom-extra-$(basename "$init_extra").log"
+  done
+else
+  echo "No init_extra was found, ignoring" > /tmp/flashpkg/flashpkg/logs/custom-extra.log
+fi

--- a/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
@@ -181,6 +181,13 @@ else
 		    break
 		done
 		;;
+	    extra)
+		if [ -f "/init-extra" ]; then
+		    ./init-extra
+		else
+		    echo "No init-extra was found" >&2
+		fi
+		;;
 	    reboot)
 		reboot_type="$args"
 		final_status="SUCCESS"

--- a/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
+++ b/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "\
     file://init-flash.sh \
+    file://init-extra.sh \
     file://program-boot-device.sh \
     file://initrd-flash.scheme.in \
 "
@@ -14,6 +15,8 @@ S = "${WORKDIR}"
 
 do_install() {
     install -m 0755 ${WORKDIR}/init-flash.sh ${D}/init
+    install -m 0755 ${WORKDIR}/init-extra.sh ${D}/init-extra
+    install -m 0755 -d ${D}/init-extra.d
     install -m 0555 -d ${D}/proc ${D}/sys
     install -m 0755 -d ${D}/dev ${D}/mnt ${D}/run ${D}/usr
     install -m 1777 -d ${D}/tmp


### PR DESCRIPTION
This makes it possible for extra custom steps to take before the final reboot step of the initrd flashing process.