### PR TITLE
tegra-helper-scripts: use separate kernel DTB for RCM booting on t19x

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -187,7 +187,12 @@ sign_binaries() {
 
 prepare_for_rcm_boot() {
     if [ $have_odmsign_func -eq 1 ]; then
-	"$here/rewrite-tegraflash-args" -o rcm-boot.sh --bins kernel=initrd-flash.img,kernel_dtb=kernel_$DTBFILE --cmd rcmboot --add="--securedev" flash_signed.sh || return 1
+	local dtbfile_for_rcmboot=kernel_$DTBFILE
+	if [ "$CHIPID" = "0x19" ]; then
+	    cp kernel_$DTBFILE rcm_kernel_$DTBFILE
+	    dtbfile_for_rcmboot=rcm_kernel_$DTBFILE
+	fi
+	"$here/rewrite-tegraflash-args" -o rcm-boot.sh --bins kernel=initrd-flash.img,kernel_dtb=$dtbfile_for_rcmboot --cmd rcmboot --add="--securedev" flash_signed.sh || return 1
 	if [ "$CHIPID" = "0x23" ]; then
 	    sed -i -e's,mb2_t234_with_mb2_bct_MB2,mb2_t234_with_mb2_cold_boot_bct_MB2,' -e's, uefi_jetson, rcmboot_uefi_jetson,' rcm-boot.sh || return 1
 	fi

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
@@ -688,7 +688,12 @@ eks eks.img"
 fi
 
 if [ $rcm_boot -ne 0 ]; then
-    BINSARGS="$BINSARGS; kernel $kernfile; kernel_dtb $kernel_dtbfile"
+    if [ "$CHIPID" = "0x19" ]; then
+        cp $kernel_dtbfile rcmboot_$kernel_dtbfile
+        BINSARGS="$BINSARGS; kernel $kernfile; kernel_dtb rcmboot_$kernel_dtbfile"
+    else
+        BINSARGS="$BINSARGS; kernel $kernfile; kernel_dtb $kernel_dtbfile"
+    fi
 fi
 
 custinfo_args=


### PR DESCRIPTION
In L4T R35.3.1, NVIDIA changed the tegraflash scripts to modify the kernel DTB used during RCM booting to disable the rtcpu node in the device tree on t19x platforms. It does so without making a new copy of the DTB file, which leads to the modified DTB getting written to the kernel-dtb partition when using initrd-flash to flash a Xavier device (in some cases).

Work around this in the helper scripts by copying the kernel DTB to a new file used only for RCM booting.

Fixes #1537 