### PR TITLE
p3768-0000-p3767-0001: allign machine config with stock SDK

### DIFF
--- a/conf/machine/p3768-0000-p3767-0001.conf
+++ b/conf/machine/p3768-0000-p3767-0001.conf
@@ -7,6 +7,7 @@ NVPMODEL ?= "nvpmodel_p3767_0001"
 TEGRA_BUPGEN_SPECS ?= "fab=000;boardsku=0001;boardrev=;bup_type=bl \
                        fab=000;boardsku=0001;boardrev=;bup_type=kernel"
 
+TEGRA_BOARDSKU ?= "0001"
 KERNEL_DEVICETREE ?= "tegra234-p3768-0000+p3767-0001-nv.dtb"
 EMMC_BCT ?= "tegra234-p3767-0001-sdram-l4t.dts"
 


### PR DESCRIPTION
It seems official SDK manager is loading different BPFDTB for Orin NX 8Gb.

Also SKU is set 0001 as otherwise 0000 is used from included 16Gb Orin NX variant.