### PR TITLE
external/openembedded-layer: tensorrt-plugins: use CMAKE_CXX_STANDARD 17

### DIFF
--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.5.2.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_8.5.2.bb
@@ -49,6 +49,8 @@ OECMAKE_CXX_FLAGS:append = " -Wno-array-bounds"
 LDFLAGS += "-Wl,--no-undefined"
 
 do_configure:prepend() {
+    sed -i "s/CMAKE_CXX_STANDARD [0-9]\+/CMAKE_CXX_STANDARD 17/g" ${S}/CMakeLists.txt
+    sed -i "s/CXX_STANDARD [0-9]\+/CXX_STANDARD 17/g" ${S}/parsers/onnx/CMakeLists.txt
     sed -i "s/CMAKE_CXX_STANDARD [0-9]\+/CMAKE_CXX_STANDARD 17/g" ${S}/parsers/onnx/third_party/onnx/CMakeLists.txt
     sed -i "s/CXX_STANDARD [0-9]\+/CXX_STANDARD 17/g" ${S}/parsers/caffe/CMakeLists.txt
 }


### PR DESCRIPTION
Previously the 17 standard was needed just for some plugins, and leaving 14 was fine for the rest of the project. With recent changes to absl, now we need the 17 standard for other parts as well.

This change builds on the do_configure:prepend sed fixup to include the CMakeLists.txt CMAKE_CXX_STANDARD being forced in a couple more places.