### PR TITLE
p3768-0000-p3767-0001: set correct SKU for Orin NX 8Gb

### DIFF
--- a/conf/machine/p3768-0000-p3767-0001.conf
+++ b/conf/machine/p3768-0000-p3767-0001.conf
@@ -7,6 +7,7 @@ NVPMODEL ?= "nvpmodel_p3767_0001"
 TEGRA_BUPGEN_SPECS ?= "fab=000;boardsku=0001;boardrev=;chipsku=00:00:00:D4;bup_type=bl \
                        fab=000;boardsku=0001;boardrev=;bup_type=kernel"
 
+TEGRA_BOARDSKU ?= "0001"
 KERNEL_DEVICETREE ?= "tegra234-p3768-0000+p3767-0001-nv.dtb"
 EMMC_BCT ?= "tegra234-p3767-0001-sdram-l4t.dts"
 


### PR DESCRIPTION
Board SKU fix was not picked for r36.3.0 branch.

So far this version seems to works fine for me.