### PR TITLE
gcc-for-nvcc: fix build and package issue

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
@@ -119,7 +119,7 @@ FILES:gcov-for-nvcc-symlinks = "${bindir}/gcov-${BINV} \
 "
 
 FILES:g++-for-nvcc = "\
-    ${bindir}/${TARGET_PREFIX}g++ \
+    ${bindir}/${TARGET_PREFIX}g++* \
     ${libexecdir}/gcc/${TARGET_SYS}/${BINV}/cc1plus \
 "
 FILES:g++-for-nvcc-symlinks = "\
@@ -199,8 +199,6 @@ do_install () {
 	ln -sf ${TARGET_PREFIX}cpp-${BINV} cpp-${BINV}
 	ln -sf ${TARGET_PREFIX}gcov-${BINV} gcov-${BINV}
 	ln -sf ${TARGET_PREFIX}gcov-tool-${BINV} gcov-tool-${BINV}
-	install -d ${D}${base_libdir}
-	ln -sf ${bindir}/${TARGET_PREFIX}cpp ${D}${base_libdir}/cpp
 	ln -sf g++-${BINV} c++-${BINV}
 	ln -sf gcc-${BINV} cc-${BINV}
 	chown -R root:root ${D}

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc_10.3.bb
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc_10.3.bb
@@ -11,4 +11,6 @@ ARMFPARCHEXT:armv6 = "${@'+fp' if d.getVar('TARGET_FPU') == 'hard' else ''}"
 ARMFPARCHEXT:armv7a = "${@'+fp' if d.getVar('TARGET_FPU') == 'hard' else ''}"
 ARMFPARCHEXT:armv7ve = "${@'+fp' if d.getVar('TARGET_FPU') == 'hard' else ''}"
 
+SECURITY_STRINGFORMAT = ""
+
 BBCLASSEXTEND = "nativesdk"


### PR DESCRIPTION
* Kindly see below the build and package issues
1- Build issue 

```
| aarch64-oe4t-linux-g++  -march=armv8-a+crc -mbranch-protection=standard -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot  -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp -I. -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/../include -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/include  -O2 -pipe -g -feliminate-unused-debug-types -fcanon-prefix-map  -fmacro-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work-shared/gcc-10.3.0-r0/gcc-10.3.0=/usr/src/debug/gcc-for-nvcc/10.3.0  -fdebug-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work-shared/gcc-10.3.0-r0/gcc-10.3.0=/usr/src/debug/gcc-for-nvcc/10.3.0  -fmacro-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/build=/usr/src/debug/gcc-for-nvcc/10.3.0  -fdebug-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/build=/usr/src/debug/gcc-for-nvcc/10.3.0  -fdebug-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot=  -fmacro-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot=  -fdebug-prefix-map=/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native=  -fvisibility-inlines-hidden -W -Wall -Wno-narrowing -Wwrite-strings -Wmissing-format-attribute -pedantic -Wno-long-long  -fno-exceptions -fno-rtti -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp -I. -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/../include -I../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/include   -c -o init.o -MT init.o -MMD -MP -MF .deps/init.Tpo ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/init.c
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c: In member function 'vaopt_state::update_type vaopt_state::update(const cpp_token*)':
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c:183:26: error: format not a string literal and no format arguments [-Werror=format-security]
|   183 |             cpp_error_at (m_pfile, CPP_DL_ERROR, token->src_loc,
|       |             ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   184 |                           vaopt_paste_error);
|       |                           ~~~~~~~~~~~~~~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c:212:34: error: format not a string literal and no format arguments [-Werror=format-security]
|   212 |                     cpp_error_at (m_pfile, CPP_DL_ERROR, token->src_loc,
|       |                     ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   213 |                                   vaopt_paste_error);
|       |                                   ~~~~~~~~~~~~~~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/expr.c: In function 'unsigned int cpp_classify_number(cpp_reader*, const cpp_token*, const char**, location_t)':
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/expr.c:801:35: error: format not a string literal and no format arguments [-Werror=format-security]
|   801 |             cpp_warning_with_line (pfile, CPP_W_LONG_LONG, virtual_location,
|       |             ~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
|   802 |                                    0, message);
|       |                                    ~~~~~~~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/expr.c:804:38: error: format not a string literal and no format arguments [-Werror=format-security]
|   804 |             cpp_pedwarning_with_line (pfile, CPP_W_LONG_LONG,
|       |             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
|   805 |                                       virtual_location, 0, message);
|       |                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| gcc  -isystem/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/usr/include -O2 -pipe -L/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/usr/lib                         -L/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/lib                         -Wl,--enable-new-dtags                         -Wl,-rpath-link,/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/usr/lib                         -Wl,-rpath-link,/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/lib                         -Wl,-rpath,/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/usr/lib                         -Wl,-rpath,/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/recipe-sysroot-native/lib                         -Wl,-O1 -Wl,--allow-shlib-undefined -Wl,--dynamic-linker=/media/m2/tegra-demo-distro/build-testdistro/tmp/sysroots-uninative/x86_64-linux/lib/ld-linux-x86-64.so.2 -pthread -o fixincl fixincl.o fixtests.o fixfixes.o server.o procopen.o fixlib.o fixopts.o ../libiberty/libiberty.a
| echo timestamp > full-stamp
| make[1]: Leaving directory '/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/build/build-x86_64-linux/fixincludes'
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c: In function 'cpp_macro* create_iso_definition(cpp_reader*)':
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c:3490:25: error: format not a string literal and no format arguments [-Werror=format-security]
|  3490 |               cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
|       |               ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/macro.c:3505:25: error: format not a string literal and no format arguments [-Werror=format-security]
|  3505 |               cpp_error (pfile, CPP_DL_ERROR, paste_op_error_msg);
|       |               ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c: In function '_cpp_file* _cpp_find_file(cpp_reader*, const char*, cpp_dir*, int, bool, bool, bool, location_t)':
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c:590:32: warning: pointer 'file' may be used after 'void free(void*)' [-Wuse-after-free]
|   590 |                     *hash_slot = file;
|       |                     ~~~~~~~~~~~^~~~~~
| ../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c:586:22: note: call to 'void free(void*)' here
|   586 |                 free (file);
|       |                 ~~~~~^~~~~~
| ../../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c: In function ‘_cpp_file* _cpp_find_file(cpp_reader*, const char*, cpp_dir*, int, bool, bool, bool, location_t)’:
| ../../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c:590:32: warning: pointer ‘file’ may be used after ‘void free(void*)’ [-Wuse-after-free]
|   590 |                     *hash_slot = file;
|       |                     ~~~~~~~~~~~^~~~~~
| ../../../../../../../work-shared/gcc-10.3.0-r0/gcc-10.3.0/libcpp/files.c:586:22: note: call to ‘void free(void*)’ here
|   586 |                 free (file);
|       |                 ~~~~~^~~~~~
| rm -f libcpp.a
| ar cru libcpp.a charset.o directives.o directives-only.o errors.o expr.o files.o identifiers.o init.o lex.o line-map.o macro.o mkdeps.o pch.o symtab.o traditional.o
| ar: `u' modifier ignored since `D' is the default (see `U')
| ranlib libcpp.a
| make[1]: Leaving directory '/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/build/build-x86_64-linux/libcpp'
| cc1plus: some warnings being treated as errors
| make[1]: *** [Makefile:225: expr.o] Error 1
| make[1]: *** Waiting for unfinished jobs....
| cc1plus: some warnings being treated as errors
| make[1]: *** [Makefile:224: macro.o] Error 1
| make[1]: Leaving directory '/media/m2/tegra-demo-distro/build-testdistro/tmp/work/armv8a-oe4t-linux/gcc-for-nvcc/10.3.0/build/libcpp'
| make: *** [Makefile:7056: all-libcpp] Error 2
| ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
```


2- Package QA issue 

```
ERROR: gcc-for-nvcc-10.3.0-r0 do_package: QA Issue: gcc-for-nvcc: Files/directories were installed but not shipped in any package:
  /usr/bin/aarch64-oe4t-linux-g++-10.3.0
  /usr/lib/cpp
Please set FILES such that these items are packaged. Alternatively if they are unneeded, avoid installing them or delete them within do_install.
gcc-for-nvcc: 2 installed and not shipped files. [installed-vs-shipped]
ERROR: gcc-for-nvcc-10.3.0-r0 do_package: Fatal QA errors were found, failing task.
```
