### PR TITLE
tegra-uefi-capsules: add missing DTB_EXTRA_DEPS dependency

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_35.5.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_35.5.0.bb
@@ -95,4 +95,4 @@ do_compile[depends] += "virtual/kernel:do_deploy tegra-flashtools-native:do_popu
 do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot"
 do_compile[depends] += "tegra-redundant-boot-rollback:do_populate_sysroot tegra-bootfiles:do_populate_sysroot"
 do_compile[depends] += "coreutils-native:do_populate_sysroot ${TEGRA_ESP_IMAGE}:do_image_complete virtual/secure-os:do_deploy"
-do_compile[depends] += "${TEGRA_SIGNING_EXTRA_DEPS}"
+do_compile[depends] += "${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS}"


### PR DESCRIPTION
The collection of dtb overlays used during tegraflash package creation can come from sources other than l4t or the kernel. Most commonly this is the virtual/dtb package, but it can be overridden, and is specified by the DTB_EXTRA_DEPS variable.

The migration from creating bup payloads to creating only capsules inadvertantly dropped this dependency, so this change adds it back.