### PR TITLE
tegra-uefi-capsules: conditionally install capsules

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
@@ -60,12 +60,16 @@ do_compile() {
 TEGRA_UEFI_CAPSULE_INSTALL_DIR ??= "/opt/nvidia/UpdateCapsule"
 
 do_install() {
-    install -d ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
-    if [ -e ${B}/tegra-bl.cap ]; then
-        install -m 0644 ${B}/tegra-bl.cap ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
-    fi
-    if [ -e ${B}/tegra-kernel.cap ]; then
-        install -m 0644 ${B}/tegra-kernel.cap ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
+    if [ -n "${TEGRA_UEFI_CAPSULE_INSTALL_DIR}" ]; then
+        install -d ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
+        if [ -e ${B}/tegra-bl.cap ]; then
+            install -m 0644 ${B}/tegra-bl.cap ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
+        fi
+        if [ -e ${B}/tegra-kernel.cap ]; then
+            install -m 0644 ${B}/tegra-kernel.cap ${D}${TEGRA_UEFI_CAPSULE_INSTALL_DIR}
+        fi
+    else
+        bbnote "TEGRA_UEFI_CAPSULE_INSTALL_DIR is empty, capsules won't be installed"
     fi
 }
 


### PR DESCRIPTION
Install capsules to rootfs only when TEGRA_UEFI_CAPSULE_INSTALL_DIR is set.