### PR TITLE
remove extra esp dependency

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -284,7 +284,6 @@ tegraflash_populate_package() {
         cp "${STAGING_DATADIR}/tegraflash/${EMMC_BCT_OVERRIDE}" .
     fi
     cp "$kernelimg" ./$lnxfile
-    cp "${IMAGE_TEGRAFLASH_ESPIMG}" ./esp.img
     if [ -n "${DATAFILE}" -a -n "${IMAGE_TEGRAFLASH_DATA}" ]; then
         cp "${IMAGE_TEGRAFLASH_DATA}" ./${DATAFILE}
         DATAARGS="--datafile ${DATAFILE}"
@@ -333,6 +332,7 @@ create_tegraflash_pkg() {
     mkdir -p ${WORKDIR}/tegraflash
     cd ${WORKDIR}/tegraflash
     tegraflash_populate_package ${IMAGE_TEGRAFLASH_KERNEL} ${LNXFILE} ${@tegra_bootcontrol_overlay_list(d)}
+    cp "${IMAGE_TEGRAFLASH_ESPIMG}" ./esp.img
     if [ -n "${IMAGE_TEGRAFLASH_INITRD_FLASHER}" ]; then
         cp "${IMAGE_TEGRAFLASH_INITRD_FLASHER}" ./initrd-flash.img
     fi

--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
@@ -93,5 +93,5 @@ do_compile[depends] += "${@bup_dependency(d)} ${TEGRA_UEFI_CAPSULE_SIGNING_EXTRA
 do_compile[depends] += "virtual/kernel:do_deploy tegra-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
 do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot"
 do_compile[depends] += "tegra-bootfiles:do_populate_sysroot"
-do_compile[depends] += "coreutils-native:do_populate_sysroot ${TEGRA_ESP_IMAGE}:do_image_complete virtual/secure-os:do_deploy"
+do_compile[depends] += "coreutils-native:do_populate_sysroot virtual/secure-os:do_deploy"
 do_compile[depends] += "${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS}"


### PR DESCRIPTION
Remove unnecessary dependency between firmware BUP and EFI system partition image. This creates circular dependency if you want to place your kerneln on ESP.