### PR TITLE
add support for Jetson AGX Xavier with new BOM according to PCN 208560

### DIFF
--- a/conf/machine/include/tegra194.inc
+++ b/conf/machine/include/tegra194.inc
@@ -31,7 +31,8 @@ TEGRA_BUPGEN_SPECS ?= "fab=400;boardsku=0001;boardrev=H.0 \
                        fab=400;boardsku=0001;boardrev=J.0 \
                        fab=400;boardsku=0001;boardrev=L.0 \
                        fab=400;boardsku=0004;boardrev= \
-                       fab=401;boardsku=0004;boardrev="
+                       fab=401;boardsku=0001;boardrev= \
+                       fab=401;boardsku=0004;boardrev= "
 
 TEGRA_SIGNING_ENV = "CHIPREV=${TEGRA_CHIPREV} BOARDID=${TEGRA_BOARDID} FAB=${TEGRA_FAB} BOARDSKU=${TEGRA_BOARDSKU} BOARDREV=${TEGRA_BOARDREV}"
 

--- a/recipes-bsp/tegra-binaries/tegra-binaries-32.5.2.inc
+++ b/recipes-bsp/tegra-binaries/tegra-binaries-32.5.2.inc
@@ -3,14 +3,19 @@ LIC_FILES_CHKSUM = "file://nv_tegra/LICENSE;md5=2cc00be68c1227a7c42ff3620ef75d05
                     file://nv_tegra/LICENSE.brcm_patchram_plus;md5=38fb07f0dacf4830bc57f40a0fb7532e"
 
 
-SRC_URI = "${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${L4T_VERSION}_aarch64.tbz2;name=l4t \
-	   ${L4T_ALT_URI_BASE}/secureboot_R${L4T_ALT_VERSION}_aarch64.tbz2;downloadfilename=${L4T_BSP_PREFIX}_secureboot_${L4T_ALT_VERSION}.tbz2;name=sb"
+SRC_URI = "\
+    ${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${L4T_VERSION}_aarch64.tbz2;name=l4t \
+    ${L4T_ALT_URI_BASE}/secureboot_R${L4T_ALT_VERSION}_aarch64.tbz2;downloadfilename=${L4T_BSP_PREFIX}_secureboot_${L4T_ALT_VERSION}.tbz2;name=sb \
+    https://developer.nvidia.com/overlay-3251-agx-sku4tbz2;downloadfilename=${L4T_BSP_PREFIX}_dtb_patch_${L4T_ALT_VERSION}.tbz2;name=dtb \
+"
 L4T_SHA256SUM = "308e21bb708c41bada1e349fbe6a1dd9fd7294826edf7aa81073a3ed11fb0c93"
 L4T_SHA256SUM_tegra210 = "6e61a77739fc9184d6eda5aa3de5a0d6b69659a78411cd2d9bcb3a59416bb8cd"
 SRC_URI[l4t.sha256sum] = "${L4T_SHA256SUM}"
 SB_SHA256SUM = "a795ef0e433ac1b3991f5597dd79e15e88d648170edcc25f2f2f3c1dd62c533b"
 SB_SHA256SUM_tegra210 = "0fc525061d203ec2929d985ec711f477cca679cc8e4f0a4a32ca384681811808"
 SRC_URI[sb.sha256sum] = "${SB_SHA256SUM}"
+DTB_SHA256SUM = "5aba8449861d4ff325c5539cc3a83622383d27a808b72f85f211a7413366e311"
+SRC_URI[dtb.sha256sum] = "${DTB_SHA256SUM}"
 
 inherit l4t_bsp
 


### PR DESCRIPTION
I can open a pull request per dunfell branch if this one is validated.

add support for PCN 208560 from L4T 32.7.4
Extracted from l4t_generate_soc_bup.sh for BOARDID=2888 and board=jetson-agx-xavier-devkit

SKU
0001 for Jetson AGX Xavier (16 GB RAM)
0004 for Jetson AGX Xavier (32 GB RAM)

FAB
400 for old model with classic BOM
401 and upper for new models with new BOM
