### PR TITLE
Support separate virtual/dtb provider

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -27,7 +27,7 @@ TNSPEC_BOOTDEV_DEFAULT ??= "mmcblk0p1"
 TNSPEC_BOOTDEV ??= "${TNSPEC_BOOTDEV_DEFAULT}"
 
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-jammy-nvidia-tegra"
-PREFERRED_PROVIDER_virtual/dtb ?= "nvidia-kernel-oot"
+PREFERRED_PROVIDER_virtual/dtb ?= "nvidia-kernel-oot-dtb"
 PREFERRED_PROVIDER_virtual/bootloader ?= "edk2-firmware-tegra"
 OPTEE_MM_PROVIDER = "${@'tegra-uefi-prebuilt' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader') == 'tegra-uefi-prebuilt' else 'standalone-mm-optee-tegra'}"
 PREFERRED_PROVIDER_standalone-mm-optee-tegra ?= "${OPTEE_MM_PROVIDER}"

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_36.3.0.bb
@@ -1,0 +1,27 @@
+DESCRIPTION = "Virtual/dtb provider for Jetson Linux device trees"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS += "nvidia-kernel-oot"
+
+inherit deploy kernel-arch
+
+PROVIDES = "virtual/dtb"
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+do_deploy() {
+    for dtb in ${KERNEL_DEVICETREE}; do
+        dtbf="${STAGING_DIR_HOST}/boot/devicetree/$dtb"
+        if [ -z "$dtbf" ]; then
+            bbfatal "Not found: $dtbf"
+        fi
+    done
+    install -d ${DEPLOYDIR}/devicetree
+    install -m 0644 ${STAGING_DIR_HOST}/boot/devicetree/* ${DEPLOYDIR}/devicetree/
+}
+
+addtask deploy before do_build after do_install
+
+ALLOW_EMPTY:${PN} = "1"

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://nvdisplay/COPYING;md5=1d5fa2a493e937d5a4b96e5e03b90f7
 
 TEGRA_UEFI_SIGNING_CLASS ??= "tegra-uefi-signing"
 
-inherit module deploy
+inherit module
 inherit ${TEGRA_UEFI_SIGNING_CLASS}
 
 TEGRA_SRC_SUBARCHIVE = "\
@@ -33,7 +33,6 @@ COMPATIBLE_MACHINE = "(tegra)"
 S = "${WORKDIR}/${BPN}"
 B = "${S}"
 
-PROVIDES = "virtual/dtb"
 KERNEL_MODULE_PACKAGE_PREFIX = "nv-"
 
 # Out-of-tree drivers that are named identically to, and
@@ -89,13 +88,6 @@ do_install() {
     install -d ${D}${includedir}/${BPN}
     find ${B} -name Module.symvers -type f | xargs sed -e's:${B}/::g' >${D}${includedir}/${BPN}/Module.symvers
 }
-
-do_deploy() {
-    install -d ${DEPLOYDIR}/devicetree
-    install -m 0644 ${B}/nvidia-oot/device-tree/platform/generic-dts/dtbs/* ${DEPLOYDIR}/devicetree/
-}
-
-addtask deploy before do_build after do_install
 
 SYSROOT_DIRS += "/boot/devicetree"
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
@@ -72,7 +72,10 @@ do_compile() {
 
 do_sign_dtbs() {
     for dtbf in ${KERNEL_DEVICETREE}; do
-        tegra_uefi_attach_sign "${B}/nvidia-oot/device-tree/platform/generic-dts/dtbs/${dtbf}"
+        local dtb="${B}/nvidia-oot/device-tree/platform/generic-dts/dtbs/${dtbf}"
+        if [ -e "$dtb" ]; then
+            tegra_uefi_attach_sign "$dtb"
+        fi
     done
 }
 do_sign_dtbs[dirs] = "${B}"


### PR DESCRIPTION
Small updates that re-enable the use of a separate virtual/dtb provider for r36. Now we can simply change the `KERNEL_DEVICETREE` variable and update the `PREFERRED_PROVIDER_virtual/dtb`. The actual recipe to build the devicetrees has to pull in the oot-modules sources to build them, so an update to tegra demo distro will be subsequently due.