### PR TITLE
nvidia-kernel-oot: Fix buildpaths QA messages

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-tegra-virt-alt-Remove-leading-from-include-path-from.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-tegra-virt-alt-Remove-leading-from-include-path-from.patch
@@ -1,0 +1,42 @@
+From 41544d7f3baba32f092339653f2723ac16d070cf Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 11 Jul 2024 14:10:19 -0700
+Subject: [PATCH] tegra-virt-alt: Remove leading / from include path from
+ overlay
+
+When $(overlay) is empty this inserts an additional '/' in the
+pathname e.g. -I/mnt/b/yoe/... becomes -I=//mnt/b/yoe/...
+this works ok when searching for include files by compiler but
+it escapes the debug-prefix substitution options due to additional
+leading '/' and as a result absolute paths get emitted into debug
+info section. Yocto tries to flags these leaks and the relevant
+QA warning has been elevated to error which means the build now breaks
+
+The fix to avoid the separator works well when overlay is empty
+and if overlay is set then it should have a terminating '/'
+
+Fixes
+
+QA Issue: File /usr/lib/modules/5.15.136-l4 t-r36.3-1009.9+g46cdb595bebc/updates/sound/soc/tegra-virt-alt/.debug/snd-soc-tegra210-virt-alt-admaif.ko in package nvidia-kernel-oot-dbg contains reference to TMPDIR [buildpaths]
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ nvidia-oot/sound/soc/tegra-virt-alt/Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/nvidia-oot/sound/soc/tegra-virt-alt/Makefile b/nvidia-oot/sound/soc/tegra-virt-alt/Makefile
+index 77bad80..f9d526f 100644
+--- a/nvidia-oot/sound/soc/tegra-virt-alt/Makefile
++++ b/nvidia-oot/sound/soc/tegra-virt-alt/Makefile
+@@ -4,8 +4,8 @@
+ GCOV_PROFILE := y
+ 
+ subdir-ccflags-y += -Werror
+-ccflags-y += -I$(overlay)/$(src)/../tegra-virt-alt/include/
+-ccflags-y += -I$(overlay)/$(src)/../codecs
++ccflags-y += -I$(overlay)$(src)/../tegra-virt-alt/include/
++ccflags-y += -I$(overlay)$(src)/../codecs
+ ccflags-y += -I$(srctree.nvidia-oot)/sound/soc/tegra-virt-alt/nvaudio_ivc/
+ 
+ # Tegra platform Support

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
@@ -29,6 +29,7 @@ SRC_URI += "file://0001-Makefile-update-for-OE-builds.patch \
             file://0002-Fix-nvdisplay-modules-builds.patch \
             file://0003-nvidia-drm-add-dependency-on-tegra-drm-module.patch \
             file://0004-Fix-nvdisplay-conftest-gcc-14-compatibility-issues.patch \
+            file://0001-tegra-virt-alt-Remove-leading-from-include-path-from.patch \
 "
 
 COMPATIBLE_MACHINE = "(tegra)"


### PR DESCRIPTION
buildpaths is a QA warning up until now, but there are patches in oe-core/master-next which will elevate it to an error, therefore fix the error by helping makefile to not add extra leading '/', other fix would be to add another expression to -fdebug-prefix-map option in CFLAGS, but this if ok, is a better way to handle it.