### PR TITLE
cuda-samples: Add missing runtime dep

### DIFF
--- a/external/openembedded-layer/recipes-support/opencv/opencv_4.9.%.bbappend
+++ b/external/openembedded-layer/recipes-support/opencv/opencv_4.9.%.bbappend
@@ -29,6 +29,7 @@ do_unpack_extra:append:cuda() {
     ln -sf ${UNPACKDIR}/${OPTICALFLOW_MD5}-${OPTICALFLOW_HASH}.zip ${OPENCV_DLDIR}/nvidia_optical_flow/
 }
 
+RDEPENDS:${PN}-apps += "cudnn"
 
 SRC_URI[opticalflow.md5sum] = "${OPTICALFLOW_MD5}"
 SRC_URI[opticalflow.sha256sum] = "e300c02e4900741700b2b857965d2589f803390849e1e2022732e02f4ae9be44"

--- a/recipes-devtools/cuda/cuda-samples_git.bb
+++ b/recipes-devtools/cuda/cuda-samples_git.bb
@@ -87,5 +87,6 @@ do_install() {
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 FILES:${PN} = "${bindir}/cuda-samples"
 FILES:${PN}-dev = "${CUDA_PATH}"
+RDEPENDS:${PN} += "libcublas"
 INSANE_SKIP:${PN}-dev = "staticdev"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
+++ b/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
@@ -2,6 +2,9 @@ DESCRIPTION = "tar wrapper script for handling zstd suffix"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+ 
 SRC_URI = "file://tar-wrapper.sh"
 
 NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"


### PR DESCRIPTION
Fixes

opkg install cuda-samples
 * Solver encountered 1 problem(s):
 * Problem 1/1:
 *   - conflicting requests
 *   - nothing provides libcublas >= 12.2.5.6-1 needed by cuda-samples-12.2-r0.8.armv8a_tegra234
 *