### PR TITLE
tar-l4t-workaround-native: Switch away from S = WORKDIR

### DIFF
--- a/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
+++ b/recipes-l4t-workarounds/tar/tar-l4t-workaround-native_1.0.bb
@@ -2,6 +2,9 @@ DESCRIPTION = "tar wrapper script for handling zstd suffix"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
+S = "${WORKDIR}/sources"
+UNPACKDIR = "${S}"
+ 
 SRC_URI = "file://tar-wrapper.sh"
 
 NATIVE_PACKAGE_PATH_SUFFIX = "/${PN}"


### PR DESCRIPTION
Fixes
WARNING: tar-l4t-workaround-native-1.0-r0 do_unpack: tar-l4t-workaround-native: the directory ${WORKDIR}/${BP} (/mnt/b/yoe/master/build/tmp/work/x86_64-linux/tar-l4t-workaround-native/1.0/tar-l4t-workaround-1.0) pointed to by the S variable doesn't exist - please set S within the recipe to point to where the source has been unpacked to