### PR TITLE
cuda-samples: Build all samples under 0_Introduction

### DIFF
--- a/recipes-devtools/cuda/cuda-samples_git.bb
+++ b/recipes-devtools/cuda/cuda-samples_git.bb
@@ -11,7 +11,7 @@ SRCREV = "1fa9c59db4ee8b34c4efa5b6e8fbd2a8c72a93ce"
 
 inherit cuda
 
-DEPENDS:append = "cuda-crt"
+DEPENDS:append = "cuda-crt cuda-profiler-api"
 
 PV = "12.2"
 CUDA_NVCC_ARCH_FLAGS ??= ""
@@ -25,8 +25,45 @@ def extract_sm(d):
     return ''
 
 CUDA_SAMPLES ?= " \
+    Samples/0_Introduction/asyncAPI \
+    Samples/0_Introduction/c++11_cuda \
+    Samples/0_Introduction/clock \
+    Samples/0_Introduction/concurrentKernels \
+    Samples/0_Introduction/cppIntegration \
+    Samples/0_Introduction/cppOverload \
+    Samples/0_Introduction/cudaOpenMP \
+    Samples/0_Introduction/fp16ScalarProduct \
+    Samples/0_Introduction/matrixMulDynlinkJIT \
+    Samples/0_Introduction/matrixMul \
+    Samples/0_Introduction/mergeSort \
+    Samples/0_Introduction/simpleAssert \
+    Samples/0_Introduction/simpleAtomicIntrinsics \
+    Samples/0_Introduction/simpleAttributes \
+    Samples/0_Introduction/simpleAWBarrier \
+    Samples/0_Introduction/simpleCallback \
+    Samples/0_Introduction/simpleCooperativeGroups \
+    Samples/0_Introduction/simpleCubemapTexture \
+    Samples/0_Introduction/simpleHyperQ \
+    Samples/0_Introduction/simpleLayeredTexture \
+    Samples/0_Introduction/simpleMultiCopy \
+    Samples/0_Introduction/simpleMultiGPU \
+    Samples/0_Introduction/simpleOccupancy \
+    Samples/0_Introduction/simplePitchLinearTexture \
+    Samples/0_Introduction/simplePrintf \
+    Samples/0_Introduction/simpleSeparateCompilation \
+    Samples/0_Introduction/simpleStreams \
+    Samples/0_Introduction/simpleSurfaceWrite \
+    Samples/0_Introduction/simpleTemplates \
+    Samples/0_Introduction/simpleTexture \
+    Samples/0_Introduction/simpleVoteIntrinsics \
+    Samples/0_Introduction/simpleZeroCopy \
+    Samples/0_Introduction/template \
     Samples/0_Introduction/UnifiedMemoryStreams \
+    Samples/0_Introduction/vectorAdd \
+    \
     Samples/1_Utilities/deviceQuery \
+    \
+    Samples/6_Performance/UnifiedMemoryPerf \
 "
 
 S = "${WORKDIR}/git"
@@ -49,7 +86,7 @@ def filtered_ldflags(d):
             newflags.append(flag)
     return ' '.join(newflags)
 
-LINKFLAGS = "-L${STAGING_DIR_HOST}${CUDA_PATH}/${baselib} ${TOOLCHAIN_OPTIONS} ${@filtered_ldflags(d)} -lstdc++"
+LINKFLAGS = "-L${STAGING_DIR_HOST}${CUDA_PATH}/${baselib} ${TOOLCHAIN_OPTIONS} ${@filtered_ldflags(d)} -lstdc++ -lm"
 
 EXTRA_OEMAKE = ' \
     GENCODE_FLAGS="${CUDA_NVCC_ARCH_FLAGS}" SMS="${@extract_sm(d)}" OPENMP=yes \
@@ -77,11 +114,12 @@ do_compile() {
 }
 
 do_install() {
-    install -d ${D}${bindir}/cuda-samples
+    install -d ${D}${bindir}/cuda-samples ${D}${bindir}/cuda-samples/data
     for f in ${B}/bin/${TARGET_ARCH}/${TARGET_OS}/release/*; do
         [ -e "$f" ] || continue
         install -m 0755 "$f" ${D}${bindir}/cuda-samples
     done
+    install -m 0644 ${S}/Samples/0_Introduction/c++11_cuda/warandpeace.txt ${D}${bindir}/cuda-samples/data
 }
 
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"


### PR DESCRIPTION
Add needed dependencies and linker flags as well as copy the data files to target, needed to run c++11_cuda sample, in order to run this the limitation is that one must be in /usr/bin/cuda-samples subdir when executing this sample, so it can find warandpeace.txt under ./data dir