### PR TITLE
tegra-libraries-eglcore: Create a symlink instead of hardlink

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-eglcore_36.3.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-eglcore_36.3.0.bb
@@ -24,7 +24,7 @@ do_install() {
 pkg_postinst:${PN}() {
     # argus and scf libraries hard-coded to use this path
     install -d $D/usr/lib/aarch64-linux-gnu/tegra-egl
-    ln $D${libdir}/libEGL_nvidia.so.0 $D/usr/lib/aarch64-linux-gnu/tegra-egl/
+    ln -f $D${libdir}/libEGL_nvidia.so.0 $D/usr/lib/aarch64-linux-gnu/tegra-egl/
 }
 
 FILES:${PN} += "${datadir}/glvnd/egl_vendor.d"


### PR DESCRIPTION
And force the creation, otherwise O_P_M update does not work and fails like below

Configuring tegra-libraries-eglcore.
ln: failed to create hard link '/usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0': File exists error: pkg_run_script: package "tegra-libraries-eglcore" postinst script returned status 1.