### PR TITLE
Add nvargus_nvraw into Kirkstone l4t r32.7.x

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-libraries-camera_32.7.5.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-camera_32.7.5.bb
@@ -63,14 +63,16 @@ do_install() {
     fi
     install -d ${D}${sbindir}
     install -m755 ${B}/usr/sbin/nvargus-daemon ${D}${sbindir}/
+    install -m755 ${B}/usr/sbin/nvargus_nvraw ${D}${sbindir}/
     install -m755 ${B}/usr/sbin/nvtunerd ${D}${sbindir}/
 }
 
-PACKAGES =+ "tegra-libraries-argus-daemon-base ${PN}-nvtunerd"
+PACKAGES =+ "tegra-libraries-argus-daemon-base ${PN}-nvtunerd ${PN}-nvargus-nvraw"
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 FILES:${PN} += "${libdir}/libv4l/plugins"
 FILES:tegra-libraries-argus-daemon-base = "${sbindir}/nvargus-daemon"
+FILES:${PN}-nvargus-nvraw = "${sbindir}/nvargus_nvraw"
 FILES:${PN}-nvtunerd = "${sbindir}/nvtunerd"
 RDEPENDS:${PN} = "tegra-argus-daemon"
 


### PR DESCRIPTION
Add nvargis_nvraw utility, useful for debugging, getting raw data and listing sensors:

```bash
$ nvargus_nvraw --lps
nvargus_nvraw version 1.11.0
Number of supported sensor entries 5
Entry  Source Mode      Uniquename             Resolution   FR  BitDepth  Mode
Index  Index  Index                                             CSI Dyn   Type
  0      0      0         imx334_front_framos   3864x2180   59  10  10    Bayer       
  1      0      1         imx334_front_framos   1920x1080  120  10  10    Bayer       
  2      0      2         imx334_front_framos   1944x1080   59  12  12    Bayer       
  3      0      3         imx334_front_framos   3864x2180   59  12  12    Bayer       
  4      0      4         imx334_front_framos   1920x1080  120  12  12    Bayer    
  ```