### PR TITLE
Kirkstone l4t r32.7.x+backport fix glibc conflicts in containers

### DIFF
--- a/classes/container-runtime-csv.bbclass
+++ b/classes/container-runtime-csv.bbclass
@@ -48,7 +48,15 @@ python populate_container_csv() {
         else:
             bb.warn("Unrecognized file type for container CSV: {}".format(entry))
             continue
-        csvlines.append("{}, /{}".format(csvtype, entry))
+        entry = "/" + entry
+        # CONTAINER_CSV_LIB_PATH can be set to /usr/lib/aarch64-linux-gnu/ to avoid glibc version mismatch
+        # See the l4t.csv file at https://github.com/OE4T/meta-tegra/pull/1194
+        # It's done differently because in this version of the code the csv file is generated and not statically defined
+        custom_lib_path = d.getVar('CONTAINER_CSV_LIB_PATH')
+        if custom_lib_path:
+            if entry.startswith('/usr/lib/') and not entry.startswith(custom_lib_path):
+                entry = entry.replace('/usr/lib/', custom_lib_path)
+        csvlines.append("{}, {}".format(csvtype, entry))
 
     os.chdir(oldcwd)
     csvfiledir = os.path.join(root, d.getVar('sysconfdir')[1:], 'nvidia-container-runtime',

--- a/classes/l4t_bsp.bbclass
+++ b/classes/l4t_bsp.bbclass
@@ -11,8 +11,18 @@ L4T_BSP_DEB_DEFAULT_VERSION:tegra210 = "20240611161210"
 
 L4T_BSP_DEB_VERSION ?= "${L4T_BSP_DEB_DEFAULT_VERSION}"
 
-def l4t_bsp_debian_version_suffix(d):
-    suffix = d.getVar('L4T_BSP_DEB_VERSION')
+# Version (date-time stamp) suffixes for nvidia-l4t-* packages
+# in the package feeds.
+L4T_BSP_DEB_ORIG_VERSION = ""
+L4T_BSP_DEB_PACKAGES_USING_ORIG_VERSION = ""
+
+def l4t_bsp_debian_version_suffix(d, pkgname=None):
+    if pkgname is None:
+        pkgname = d.getVar('L4T_DEB_TRANSLATED_BPN')
+    if pkgname in [ 'nvidia-l4t-' + p for p in d.getVar('L4T_BSP_DEB_PACKAGES_USING_ORIG_VERSION').split()]:
+        suffix = d.getVar('L4T_BSP_DEB_ORIG_VERSION')
+    else:
+        suffix = d.getVar('L4T_BSP_DEB_VERSION')
     return '-' + suffix if suffix else ''
 
 def l4t_release_dir(d):

--- a/classes/l4t_deb_pkgfeed.bbclass
+++ b/classes/l4t_deb_pkgfeed.bbclass
@@ -39,6 +39,12 @@ def l4t_deb_src_uri(d):
         soc = d.getVar('L4T_DEB_SOCNAME')
         return ' '.join(generate_uris(d, 'common', common_debs) + generate_uris(d, soc, soc_debs))
 
+    
+def l4t_deb_pkgname(d, name):
+    if not name.startswith('nvidia-l4t-'):
+        name = 'nvidia-l4t-' + name
+    return "%s_${L4T_VERSION}${@l4t_bsp_debian_version_suffix(d, pkgname='%s')}_arm64.deb" % (name, name)
+
 l4t_deb_src_uri[vardepsexclude] += "L4T_DEB_SOCNAME"
 
 SRC_URI = "${@l4t_deb_src_uri(d)}"

--- a/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
+++ b/external/openembedded-layer/recipes-multimedia/v4l2apps/v4l-utils_%.bbappend
@@ -23,6 +23,7 @@ TEGRA_PLUGINS:tegra = "tegra-libraries-multimedia-v4l"
 RRECOMMENDS:libv4l += "${TEGRA_PLUGINS}"
 
 CONTAINER_CSV_BASENAME = "libv4l"
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/ov* ${libdir}/libv4l/*.so"
 # These files aren't in nvidia host-files-for-container.d/l4t.csv and conflict with attempts
 # to install v4l-utils inside the container (Invalid cross-device link)

--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.10.0/0006-Add-support-for-separate-pass-through-tree.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools-0.10.0/0006-Add-support-for-separate-pass-through-tree.patch
@@ -1,0 +1,257 @@
+From 8f7c32038119c4183067310af459a08fcbfc834a Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 5 Mar 2023 08:47:33 -0800
+Subject: [PATCH] Add support for separate pass-through tree
+
+So we can export stock L4T pre-built userland binaries to
+containers, instead of the versions we build from sources,
+to avoid glibc and other shared library mismatches inside
+NVIDIA's containers.
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ Makefile           |  3 +++
+ src/jetson_mount.c | 57 +++++++++++++++++++++++++++++++++++++---------
+ src/nvc_info.c     | 31 +++++++++++++++++++++----
+ src/utils.c        | 12 ++++++++++
+ src/utils.h        |  1 +
+ 5 files changed, 88 insertions(+), 16 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index b4becad3..a2c1f10b 100644
+--- a/Makefile
++++ b/Makefile
+@@ -142,6 +142,9 @@ LIB_LDLIBS_SHARED  += -lelf
+ else
+ LIB_LDLIBS_STATIC  += -l:libelf.a
+ endif
++ifneq ($(PASSTHRU_ROOT),)
++LIB_CPPFLAGS       += -DPASSTHRU_ROOT="$(PASSTHRU_ROOT)"
++endif
+ ifeq ($(WITH_TIRPC), yes)
+ LIB_CPPFLAGS       += -isystem $(DEPS_DIR)$(includedir)/tirpc -DWITH_TIRPC
+ LIB_LDLIBS_STATIC  += -l:libtirpc.a
+diff --git a/src/jetson_mount.c b/src/jetson_mount.c
+index 5cf94c81..d5b6844d 100644
+--- a/src/jetson_mount.c
++++ b/src/jetson_mount.c
+@@ -21,13 +21,25 @@
+ #define stringify(s__) stringify__(s__)
+ #define stringify__(s__) #s__
+ static const char *hostlibdir = stringify(HOST_LIBDIR) "/";
++#ifdef PASSTHRU_ROOT
++static const char *passthrudir = stringify(PASSTHRU_ROOT) "/";
++#else
++static const char *passthrudir = NULL;
++#endif
+ 
+ static int
+ resolve_symlink(struct error *err, const char *src, char *dst)
+ {
+-        ssize_t n;
++        ssize_t n = -1;
++        char passthrusrc[PATH_MAX];
+ 
+-        n = readlink(src, dst, PATH_MAX);
++        if (passthrudir != NULL) {
++                if (path_join(err, passthrusrc, passthrudir, src) < 0)
++                return -1;
++                n = readlink(passthrusrc, dst, PATH_MAX);
++        }
++        if (n < 0)
++                n = readlink(src, dst, PATH_MAX);
+         if (n < 0 || n >= PATH_MAX)
+                 return -1;
+ 
+@@ -58,6 +70,13 @@ mount_jetson_files(struct error *err, const char *root, const struct nvc_contain
+                 if (path_new(err, src, root) < 0)
+                         goto fail;
+ 
++                if (passthrudir != NULL && str_has_prefix(paths[i], passthrudir)) {
++                        if (path_join(err, dst, cnt->cfg.rootfs, paths[i] + (strlen(passthrudir)-1)) < 0)
++                                goto fail;
++                        if (path_append(err, src, paths[i]) < 0)
++                                goto fail;
++                        goto mount_prep;
++                }
+                 if (dir != NULL) {
+                         size_t hostlibdirlen = strlen(hostlibdir);
+                         /*
+@@ -102,6 +121,7 @@ mount_jetson_files(struct error *err, const char *root, const struct nvc_contain
+                 if (path_append(err, dst, (samepath ? paths[i] : file)) < 0)
+                         goto fail;
+ 
++         mount_prep:
+                 if (file_mode(err, src, &mode) < 0)
+                         goto fail;
+                 if (file_create(err, dst, NULL, cnt->uid, cnt->gid, mode) < 0)
+@@ -131,35 +151,50 @@ create_jetson_symlinks(struct error *err, const char *root, const struct nvc_con
+         char src[PATH_MAX];
+         char src_lnk[PATH_MAX];
+         char dst[PATH_MAX];
+-        char *file;
++        size_t hostlibdirlen = strlen(hostlibdir);
+ 
+         for (size_t i = 0; i < size; ++i) {
+-                file = basename(paths[i]);
+                 if (!match_jetson_symlink_flags(paths[i], cnt->flags))
+                         continue;
+ 
+                 if (path_new(err, src, root) < 0)
+                         return (-1);
++                if (path_new(err, dst, cnt->cfg.rootfs) < 0)
++                        return (-1);
+ 
+                 if (path_append(err, src, paths[i]) < 0)
+                         return (-1);
++                if (path_append(err, dst, paths[i]) < 0)
++                        return (-1);
+ 
+                 if (resolve_symlink(err, src, src_lnk) < 0)
+                         return (-1);
+ 
+-                if (str_has_prefix(file, "lib")) {
+-                        if (path_resolve_full(err, dst, cnt->cfg.rootfs, cnt->cfg.libs_dir) < 0)
++                /* Move symlinks residing directly in /usr/lib (not in subdirs) on host to /usr/lib/aarch64-linux-gnu in container */
++                if (str_has_prefix(src, hostlibdir) && strchr(src+hostlibdirlen, '/') == NULL &&
++                    (strcmp(hostlibdir, cnt->cfg.libs_dir) != 0 && !str_has_prefix(src, cnt->cfg.libs_dir))) {
++                        char tmp[PATH_MAX];
++                        if (path_join(err, tmp, cnt->cfg.rootfs, cnt->cfg.libs_dir) < 0)
+                                 return (-1);
+-                        if (path_append(err, dst, file) < 0)
++                        if (path_append(err, tmp, basename(src)) < 0)
+                                 return (-1);
+-                } else {
+-                        if (path_new(err, dst, cnt->cfg.rootfs) < 0)
++                        log_infof("%s: moving symlink at %s to %s", __func__, dst, tmp);
++                        strcpy(dst, tmp);
++                }
++                if (str_has_prefix(src_lnk, hostlibdir) &&
++                    (strcmp(hostlibdir, cnt->cfg.libs_dir) != 0 && str_has_prefix(src_lnk, cnt->cfg.libs_dir) && strchr(src_lnk+hostlibdirlen, '/') != NULL)) {
++                        char tmp[PATH_MAX], sub[PATH_MAX], *cp;
++                        strcpy(sub, src_lnk+hostlibdirlen);
++                        for (cp = sub + strlen(sub); cp > sub && *cp != '/'; cp--);
++                        *cp = '\0';
++                        if (path_join(err, tmp, cnt->cfg.libs_dir, sub) < 0)
+                                 return (-1);
+-                        if (path_append(err, dst, paths[i]) < 0)
++                        if (path_append(err, tmp, basename(src_lnk)) < 0)
+                                 return (-1);
++                        log_infof("%s: %s rewritten to %s", __func__, src_lnk, tmp);
++                        strcpy(src_lnk, tmp);
+                 }
+ 
+-                printf("src: %s, src_lnk: %s, dst: %s\n", src, src_lnk, dst);
+                 if (remove(dst) < 0 && errno != ENOENT)
+                         return (-1);
+ 
+diff --git a/src/nvc_info.c b/src/nvc_info.c
+index fd0e60f1..e0c03da9 100644
+--- a/src/nvc_info.c
++++ b/src/nvc_info.c
+@@ -23,7 +23,15 @@
+ #include "jetson_info.h"
+ #include "xfuncs.h"
+ 
+-#define MAX_BINS (nitems(utility_bins) + \
++#define stringify(s__) stringify__(s__)
++#define stringify__(s__) #s__
++#ifdef PASSTHRU_ROOT
++static const char *passthrudir = stringify(PASSTHRU_ROOT) "/";
++#else
++static const char *passthrudir = NULL;
++#endif
++
++#define MAX_BINS (nitems(utility_bins) +        \
+                   nitems(compute_bins))
+ #define MAX_LIBS (nitems(utility_libs) + \
+                   nitems(compute_libs) + \
+@@ -402,10 +410,20 @@ static int
+ lookup_jetson_libs(struct error *err, struct nvc_jetson_info *info, const char *root)
+ {
+         char path[PATH_MAX];
++        char passthrulib[PATH_MAX], passthrupath[PATH_MAX];
+ 
+         for (size_t i = 0; i < info->nlibs; ++i) {
+-                if (path_resolve(err, path, root, info->libs[i]) < 0)
+-                        return (-1);
++                int ok = 0;
++                if (passthrudir != NULL && path_join(err, passthrulib, passthrudir, info->libs[i]) >= 0) {
++                        if (path_join(err, passthrupath, root, passthrulib) >= 0 && file_or_symlink_exists(err, passthrupath)) {
++                                strcpy(path, passthrupath);
++                                ok = 1;
++                        }
++                }
++                if (!ok && path_resolve(err, path, root, info->libs[i]) < 0) {
++                        log_infof("%s: could not find path for %s", __func__, info->libs[i]);
++                        continue;
++                }
+ 
+                 free(info->libs[i]);
+                 info->libs[i] = NULL;
+@@ -418,6 +436,7 @@ lookup_jetson_libs(struct error *err, struct nvc_jetson_info *info, const char *
+                 info->libs[i] = xstrdup(err, path);
+                 if (info->libs[i] == NULL)
+                         return (-1);
++                log_infof("%s: found library %s", __func__, path);
+         }
+ 
+         array_pack(info->libs, &info->nlibs);
+@@ -458,15 +477,17 @@ lookup_jetson_symlinks(struct error *err, struct nvc_jetson_info *info, const ch
+ {
+         (void) root;
+ 
+-        char path[PATH_MAX];
++        char path[PATH_MAX], passthrupath[PATH_MAX];
+         struct stat s;
+ 
+         for (size_t i = 0; i < info->nsyms; ++i) {
+                 strcpy(path, info->syms[i]);
++                if (passthrudir != NULL && path_join(err, passthrupath, passthrudir, info->syms[i]) < 0)
++                        return (-1);
+                 free(info->syms[i]);
+                 info->syms[i] = NULL;
+ 
+-                if (lstat(path, &s) < 0) {
++                if (lstat(passthrupath, &s) < 0 && lstat(path, &s) < 0) {
+                         log_warnf("missing symlink %s", path);
+                         continue;
+                 }
+diff --git a/src/utils.c b/src/utils.c
+index 1baab823..81a456e4 100644
+--- a/src/utils.c
++++ b/src/utils.c
+@@ -658,6 +658,18 @@ file_exists(struct error *err, const char *path)
+         return (rv == 0);
+ }
+ 
++int
++file_or_symlink_exists(struct error *err, const char *path)
++{
++        int rv;
++
++        if ((rv = faccessat(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW)) < 0 && errno != ENOENT) {
++                error_set(err, "file/symlink lookup failed: %s", path);
++                return (-1);
++        }
++        return (rv == 0);
++}
++
+ int
+ file_exists_at(struct error *err, const char *dir, const char *path)
+ {
+diff --git a/src/utils.h b/src/utils.h
+index 4beb86da..95d0834c 100644
+--- a/src/utils.h
++++ b/src/utils.h
+@@ -73,6 +73,7 @@ int  file_unmap(struct error *, const char *, void *, size_t);
+ int  file_create(struct error *, const char *, const char *, uid_t, gid_t, mode_t);
+ int  file_remove(struct error *, const char *);
+ int  file_exists(struct error *, const char *);
++int  file_or_symlink_exists(struct error *, const char *);
+ int  file_exists_at(struct error *, const char *, const char *);
+ int  file_mode(struct error *, const char *, mode_t *);
+ int  file_read_line(struct error *, const char *, char *, size_t);
+-- 
+2.34.1
+

--- a/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.10.0.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container-tools/libnvidia-container-tools_0.10.0.bb
@@ -49,6 +49,7 @@ SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;protocol=https;name=l
            file://0003-Fix-mapping-of-library-paths-for-jetson-mounts.patch \
            file://0004-Fix-build.h-generation-for-cross-builds.patch \
            file://0005-Update-makefile-for-statically-linking-external-libt.patch \
+           file://0006-Add-support-for-separate-pass-through-tree.patch \
            "
 
 SRC_URI[modprobe.md5sum] = "f82b649e7a0f1d1279264f9494e7cf43"
@@ -73,9 +74,10 @@ def build_date(d):
         return 'DATE=' + dt.isoformat(timespec='minutes')
     return ''
 
-# We need to link with libelf, otherwise we need to
-# include bmake-native which does not exist at the moment.
-EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes COMPILER=${@d.getVar('CC').split()[0]} REVISION=${SRCREV_libnvidia} ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
+# This must match the setting in tegra-container-passthrough recipe
+PASSTHRU_ROOT = "${datadir}/nvidia-container-passthrough"
+
+EXTRA_OEMAKE = "EXCLUDE_BUILD_FLAGS=1 PASSTHRU_ROOT=${PASSTHRU_ROOT} PLATFORM=${HOST_ARCH} JETSON=TRUE WITH_LIBELF=yes COMPILER=${@d.getVar('CC').split()[0]} REVISION=${SRCREV_libnvidia} ${@build_date(d)} ${PACKAGECONFIG_CONFARGS}"
 
 CFLAGS:prepend = " -I=/usr/include/tirpc-1.2.6 "
 
@@ -92,3 +94,4 @@ do_install () {
 }
 
 INSANE_SKIP:${PN} = "already-stripped"
+RDEPENDS:${PN} = "tegra-container-passthrough"

--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_32.7.5.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_32.7.5.bb
@@ -48,6 +48,8 @@ do_install() {
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvvidconv*
 }
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/gstreamer-1.0/*.so*"
 
 FILES_SOLIBSDEV = ""

--- a/recipes-bsp/tegra-binaries/tegra-container-passthrough_32.7.5.bb
+++ b/recipes-bsp/tegra-binaries/tegra-container-passthrough_32.7.5.bb
@@ -1,0 +1,63 @@
+L4T_DEB_COPYRIGHT_MD5 = "da66dd592b6aab6a884628599ea927fe"
+
+L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-multimedia"
+
+require tegra-debian-libraries-common.inc
+
+SRC_SOC_DEBS += "\
+    ${@l4t_deb_pkgname(d, 'camera')};subdir=${BP};name=camera \
+    ${@l4t_deb_pkgname(d, 'gstreamer')};subdir=${BP}/full;name=gstreamer \
+    ${@l4t_deb_pkgname(d, 'wayland')};subdir=${BP}/full;name=wayland \
+    ${@l4t_deb_pkgname(d, 'weston')};subdir=${BP}/full;name=weston \
+    ${@l4t_deb_pkgname(d, 'libvulkan')};subdir=${BP}/full;name=libvulkan \
+"
+MAINSUM = "00aee7780face8a801d1bd612eaef2beaa01b72738acdbc3a83a3dd050830ced"
+MAINSUM:tegra210 = "faf67ea3283106cbe825078e6d22c5d75ebae2a28d5c480071ffcd000ca8042e"
+
+CAMERASUM = "cf77eeec2ecfd373fc20b1f77d3a1c3414fae5e9074a9bf3e35ace104a288646"
+CAMERASUM:tegra210 = "036b6d6d400fb988274778f6d6028db5ce3a0a134c4fb6294672ddf8fc7f15a1"
+SRC_URI[camera.sha256sum] = "${CAMERASUM}"
+
+GSTREAMERSUM = "327efc561ff5d3f16a150f695bfc1e89f5bcd85bea1cc31f3fcc70cd71bbe885"
+GSTREAMERSUM:tegra210 = "92b79e5fbac38552b7c4226598001d040f152c87362084f25f3716211bbab2fb"
+SRC_URI[gstreamer.sha256sum] = "${GSTREAMERSUM}"
+
+WAYLANDSUM = "9745a61201326560cd19106a472a6ffd8788e31d571146c2edf8bb95110351c4"
+WAYLANDSUM:tegra210 = "b0f2acdb082ce891d72e1b4530e52e06afae075f6b2c461b7d11f91eed26fd8b"
+SRC_URI[wayland.sha256sum] = "${WAYLANDSUM}"
+
+WESTONSUM = "ef41d4134f4a5fe8fa6e5d662daef18e2de8deb8e21c284b0c28d84bc599e655"
+WESTONSUM:tegra210 = "d6996a01d6f388dc9ce4847541448658d0eb129ada032920832014669e86224c"
+SRC_URI[weston.sha256sum] = "${WESTONSUM}"
+
+LIBVULKANSUM = "f7957148490060e2c8b914c833db883dd21d09c69533b8940ee9f0e8119b807f"
+LIBVULKANSUM:tegra210 = "a37cfbf308a2179222d7a9268a242d058cdcea4a125dbe7a755864275d997237"
+SRC_URI[libvulkan.sha256sum] = "${LIBVULKANSUM}"
+
+PASSTHRU_ROOT = "${datadir}/nvidia-container-passthrough"
+
+do_install() {
+    install -d ${D}${PASSTHRU_ROOT}/usr/lib
+    # 'full' subdirectory is where we dumped the pacakges that we just copy in full
+    cp -R --preserve=mode,links,timestamps ${S}/full/usr/lib/aarch64-linux-gnu ${D}${PASSTHRU_ROOT}/usr/lib/
+    # Just the V4L2 files for the multimedia package
+    cp -R --preserve=mode,links,timestamps ${S}/usr/lib/aarch64-linux-gnu/libv4l ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/
+    for f in libnvv4l2.so libnvv4lconvert.so libv4l2_nvvideocodec.so libv4l2_nvcuvidvideocodec.so libv4l2_nvargus.so; do
+    # Library libv4l2_nvcuvidvideocodec.so not present in tegra210
+        [ -f "${S}/usr/lib/aarch64-linux-gnu/tegra/$f" ] &&  install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/tegra/$f ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/tegra/
+    done
+    ln -sf libnvv4l2.so ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/tegra/libv4l2.so.0
+    ln -sf libnvv4lconvert.so ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/tegra/libv4lconvert.so.0
+    ln -sf tegra/libv4l2.so.0 ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/libv4l2.so.0.0.999999
+    ln -sf libv4l2.so.0.0.999999 ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/libv4l2.so.0
+    ln -sf tegra/libv4lconvert.so.0 ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/libv4lconvert.so.0.0.999999
+    ln -sf libv4lconvert.so.0.0.999999 ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/libv4lconvert.so.0
+    ln -sf libgstreamer-1.0.so.0.1603.99999 ${D}${PASSTHRU_ROOT}/usr/lib/aarch64-linux-gnu/libgstreamer-1.0.so.0
+}
+
+EXCLUDE_FROM_SHLIBS = "1"
+SKIP_FILEDEPS = "1"
+FILES:${PN} = "${PASSTHRU_ROOT}"
+INSANE_SKIP:${PN} = "textrel"
+
+CONTAINER_CSV_FILES = ""

--- a/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-omx-tegra_1.0.0-r32.7.5.bb
@@ -33,6 +33,8 @@ inherit autotools pkgconfig gettext container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_configure:append() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r32.7.5.bb
@@ -23,6 +23,8 @@ inherit pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_install() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor.inc
@@ -18,6 +18,8 @@ inherit pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_install() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink_1.14.0-r32.7.5.bb
@@ -19,6 +19,8 @@ inherit pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 CFLAGS:append = " -fpic"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r32.7.5.bb
@@ -33,6 +33,8 @@ inherit autotools gtk-doc gettext gobject-introspection pkgconfig container-runt
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/gstreamer-1.0/*.so*"
 
 delete_pkg_m4_file() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg_1.14.0-r32.7.5.bb
@@ -19,6 +19,8 @@ inherit autotools gtk-doc gettext pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 PACKAGES_DYNAMIC = "^${PN}-.*"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee_1.14.0-r32.7.5.bb
@@ -14,6 +14,8 @@ S = "${WORKDIR}/gst-nvtee"
 
 inherit pkgconfig container-runtime-csv
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_install() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc_1.14.0-r32.7.5.bb
@@ -25,6 +25,8 @@ inherit pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_install() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv.inc
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv.inc
@@ -21,6 +21,8 @@ inherit pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 do_install() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r32.7.5.bb
@@ -33,6 +33,8 @@ inherit gettext pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 copy_headers() {

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideosinks_1.14.0-r32.7.5.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideosinks_1.14.0-r32.7.5.bb
@@ -20,6 +20,8 @@ S = "${WORKDIR}/gst-plugins-nv-video-sinks"
 
 inherit gettext pkgconfig container-runtime-csv cuda features_check
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/gstreamer-1.0/*.so*"
 
 EXTRA_OEMAKE = "CUDA_VER=${CUDA_VERSION}"

--- a/recipes-multimedia/libv4l2/libv4l2-minimal_1.18.0.bb
+++ b/recipes-multimedia/libv4l2/libv4l2-minimal_1.18.0.bb
@@ -29,6 +29,7 @@ do_install:append:tegra() {
 }
 
 CONTAINER_CSV_BASENAME = "libv4l"
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
 CONTAINER_CSV_FILES = "${libdir}/*.so* ${libdir}/libv4l/ov* ${libdir}/libv4l/*.so"
 
 PACKAGES =+ "libv4l libv4l-dev"

--- a/recipes-multimedia/libv4l2/libv4l2-nvvidconv-wrapper_git.bb
+++ b/recipes-multimedia/libv4l2/libv4l2-nvvidconv-wrapper_git.bb
@@ -19,6 +19,8 @@ inherit cmake pkgconfig container-runtime-csv features_check
 
 REQUIRED_DISTRO_FEATURES = "opengl"
 
+CONTAINER_CSV_LIB_PATH = "/usr/lib/aarch64-linux-gnu/"
+
 CONTAINER_CSV_FILES = "${libdir}/libv4l/plugins/*.so*"
 
 FILES:${PN} = "${libdir}/libv4l/plugins/*${SOLIBSDEV}"


### PR DESCRIPTION
Backport of https://github.com/OE4T/meta-tegra/pull/1194

Since the csv is not an static file but rather automatically generated, we need to come up with some mechanism of replacing the lib path. That's why I added CONTAINER_CSV_LIB_PATH.

But I am open to any suggestion.