### PR TITLE
initrd-flash.sh: fix sed command when using SBK

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -194,7 +194,7 @@ prepare_for_rcm_boot() {
 	fi
 	"$here/rewrite-tegraflash-args" -o rcm-boot.sh --bins kernel=initrd-flash.img,kernel_dtb=$dtbfile_for_rcmboot --cmd rcmboot --add="--securedev" flash_signed.sh || return 1
 	if [ "$CHIPID" = "0x23" ]; then
-	    sed -i -e's,mb2_t234_with_mb2_bct_MB2,mb2_t234_with_mb2_cold_boot_bct_MB2,' -e's, uefi_jetson, rcmboot_uefi_jetson,' rcm-boot.sh || return 1
+	    sed -i -e's,mb2_t234_with_mb2_bct_MB2,mb2_t234_with_mb2_cold_boot_bct_MB2,' -e's,_aligned_blob_w_bin,,' -e's, uefi_jetson, rcmboot_uefi_jetson,' rcm-boot.sh || return 1
 	fi
 	chmod +x rcm-boot.sh
     fi


### PR DESCRIPTION
- When secure boot is enabled the resulting doflash.sh contains 'uefi_jetson_with_dtb_aligned_blob_w_bin_sigheader_encrypt.bin.signed' vs 'uefi_jetson_with_dtb_sigheader_encrypt.bin.signed' when secure boot is not enabled.  Update the sed command to work with both.

- The command to replace '_aligned_blob_w_bin' with '' must appear before the command to replace 'uefi_jetson' with 'rcmboot_uefi_jetson'.