### PR TITLE
nvidia-l4t-optee: add 'bash' as RDEPENDS

### DIFF
--- a/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.3.0.bb
+++ b/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.3.0.bb
@@ -99,4 +99,4 @@ FILES:${PN}-test = "\
 "
 RDEPENDS:${PN}-test = "${PN}"
 RDEPENDS:${PN}-nvsamples = "${PN}"
-RDEPENDS:${PN} = "${PN}-base-tas"
+RDEPENDS:${PN} = "${PN}-base-tas bash"


### PR DESCRIPTION
Regarding this [PR](https://github.com/OE4T/meta-tegra/pull/1652), I did the test on my custom meta-layer and having the change included in the meta-tegra resulted in the following error:

![image](https://github.com/user-attachments/assets/cb9d2646-f733-4a48-914e-b14413b7ed7f)

Sorry for the previous broken change.