### PR TITLE
[scarthgap-l4t-r35.x] linux-tegra: properly quote KERNEL_ARGS

### DIFF
--- a/classes-recipe/image_types_cboot.bbclass
+++ b/classes-recipe/image_types_cboot.bbclass
@@ -18,7 +18,7 @@ oe_cbootimg_common() {
     ${STAGING_BINDIR_NATIVE}/tegra-flash/mkbootimg \
         --kernel ${CBOOTIMG_KERNEL} \
         --ramdisk ${IMGDEPLOYDIR}/$1 \
-        --cmdline "${KERNEL_ARGS}" \
+        --cmdline '${KERNEL_ARGS}' \
         --output "$outfile"
     sign_bootimg "$outfile"
     [ -n "$2" ] || ln -sf $1.cboot ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.cboot

--- a/recipes-kernel/linux/linux-tegra_5.10.bb
+++ b/recipes-kernel/linux/linux-tegra_5.10.bb
@@ -173,7 +173,7 @@ bootimg_from_bundled_initramfs() {
             ${STAGING_BINDIR_NATIVE}/tegra-flash/mkbootimg \
                                     --kernel $deployDir/${initramfs_base_name}.bin \
                                     --ramdisk ${WORKDIR}/initrd \
-                                    --cmdline "${KERNEL_ARGS}" \
+                                    --cmdline '${KERNEL_ARGS}' \
                                     --output $deployDir/${initramfs_base_name}.cboot
 	    sign_bootimg $deployDir/${initramfs_base_name}.cboot
             chmod 0644 $deployDir/${initramfs_base_name}.cboot
@@ -190,7 +190,7 @@ bootimg_from_bundled_initramfs() {
             ${STAGING_BINDIR_NATIVE}/tegra-flash/mkbootimg \
                                     --kernel $deployDir/${baseName}.bin \
                                     --ramdisk ${WORKDIR}/initrd \
-                                    --cmdline "${KERNEL_ARGS}" \
+                                    --cmdline '${KERNEL_ARGS}' \
                                     --output $deployDir/${baseName}.cboot
 	    sign_bootimg $deployDir/${initramfs_base_name}.cboot
             chmod 0644 $deployDir/${baseName}.cboot


### PR DESCRIPTION
This change permits passing kernel command line arguments that include quoted strings, including dyndbg.  Without single quotes, the recipe silently produces incorrect results in such cases.