### PR TITLE
RFC: image_types_tegra: fix depends when TEGRA_SIGNING_ARGS is defined

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-flashtools-native_36.3.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-flashtools-native_36.3.0.bb
@@ -21,7 +21,7 @@ COMPATIBLE_MACHINE = ""
 inherit_defer native
 
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "tegra-helper-scripts-native"
+DEPENDS = "tegra-helper-scripts-native python3-pyyaml-native"
 
 do_compile[noexec] = "1"
 


### PR DESCRIPTION
Requesting comments regarding the fix for this error (not sure it's the right way of fixing the issue): [do_image_tegraflash.log](https://github.com/user-attachments/files/16623960/do_image_tegraflash.log)


It seems when defining `TEGRA_SIGNING_ARGS = "-u path/to/pkc.key -v path/to/sbk.key"`, we get the errors when building an image.

```
[...]
| ./tegraflash.py --chip 0x23 --bl uefi_jetson_with_dtb.bin --sdram_config tegra234-p3767-0001-sdram-l4t.dts --odmdata gbe-uphy-config-8,hsstp-lane-map-3,hsio-uphy-config-0 --applet mb1_t234_prod.bin --cmd "sign"  --skipuid --cfg flash.xml --bct_backup --boot_chain A --uphy tegra234-mb1-bct-uphylane-si.dtsi --minratchet_config tegra234-mb1-bct-ratchet-p3767-0000.dts --device_config tegra234-mb1-bct-device-p3767-0000.dts --misc_config tegra234-mb1-bct-misc-p3767-0000.dts --scr_config tegra234-mb2-bct-scr-p3767-0000.dts --pinmux_config tegra234-mb1-bct-pinmux-p3767-dp-a03.dtsi --gpioint_config tegra234-mb1-bct-gpioint-p3767-0000.dts --pmic_config tegra234-mb1-bct-pmic-p3767-0000-a02.dts --pmc_config tegra234-mb1-bct-padvoltage-p3767-dp-a03.dtsi --prod_config tegra234-mb1-bct-prod-p3767-0000.dts --br_cmd_config tegra234-mb1-bct-reset-p3767-0000.dts --dev_params tegra234-br-bct-p3767-0000-l4t.dts,tegra234-br-bct_b-p3767-0000-l4t.dts --deviceprod_config tegra234-mb1-bct-cprod-p3767-0000.dts --wb0sdram_config tegra234-p3767-0001-wb0sdram-l4t.dts --mb2bct_cfg tegra234-mb2-bct-misc-p3767-0000.dts --bldtb tegra234-p3768-0000+p3767-0005-nv.dtb --concat_cpubl_bldtb --cpubl uefi_jetson.bin --overlay_dtb L4TConfiguration.dtbo,UefiDefaultSecurityKeys.dtbo,tegra234-carveouts.dtbo,tegra-optee.dtbo,tegra234-p3768-0000+p3767-0000-dynamic.dtbo --bins "psc_fw pscfw_t234_prod.bin; mts_mce mce_flash_o10_cr_prod.bin; mb2_applet applet_t234.bin; mb2_bootloader mb2_t234.bin; xusb_fw xusb_t234_prod.bin; pva_fw nvpva_020.fw; dce_fw display-t234-dce.bin; nvdec nvdec_t234_prod.fw; bpmp_fw bpmp_t234-TE980M-A1_prod.bin; bpmp_fw_dtb tegra234-bpmp-3767-0003-3509-a02.dtb; rce_fw camera-rtcpu-t234-rce.img; ape_fw adsp-fw.bin; spe_fw spe_t234.bin; tsec_fw tsec_t234.bin; tos tos-optee_t234.img; eks eks.img" --key /home/builder/build/../meta-custom/keysPKC//pkc.key --encrypt_key /home/builder/build/../meta-custom/keysSBK//sbk.key
| Traceback (most recent call last):
|   File "/home/builder/build/tmp-glibc/work/jetson_devkit-oe-linux/basic-image/1.0/tegraflash/./tegraflash.py", line 27, in <module>
|     import tegraflash_internal
|   File "/home/builder/build/tmp-glibc/work/jetson_devkit-oe-linux/basic-image/1.0/tegraflash/tegraflash_internal.py", line 29, in <module>
|     from tegrasign_v3 import (compute_sha, do_key_derivation,
|   File "/home/builder/build/tmp-glibc/work/jetson_devkit-oe-linux/basic-image/1.0/tegraflash/tegrasign_v3.py", line 13, in <module>
|     from tegrasign_v3_internal import *
|   File "/home/builder/build/tmp-glibc/work/jetson_devkit-oe-linux/basic-image/1.0/tegraflash/tegrasign_v3_internal.py", line 14, in <module>
|     from tegrasign_v3_util import *
|   File "/home/builder/build/tmp-glibc/work/jetson_devkit-oe-linux/basic-image/1.0/tegraflash/tegrasign_v3_util.py", line 23, in <module>
|     import yaml
| ModuleNotFoundError: No module named 'yaml'
[...]
```

