### PR TITLE
[kirkstone] initrd-flash: Add custom extra-pre-wipe

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -361,6 +361,8 @@ generate_flash_package() {
 	cp bootloader_staging/* "$mnt/flashpkg/bootloader"
     fi
 
+    echo "extra-pre-wipe" >> "$mnt/flashpkg/conf/command_sequence"
+
     if [ $erase_nvme -eq 1 ]; then
 	echo "erase-nvme" >> "$mnt/flashpkg/conf/command_sequence"
     fi

--- a/recipes-core/initrdscripts/tegra-flash-init/init-extra-pre-wipe.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-extra-pre-wipe.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Run custom extra pre wipe init script(s) provided from seperate recipes.
+
+init_extra_pre_wipe_dir="/init-extra-pre-wipe.d"
+
+if [ -d "${init_extra_pre_wipe_dir}" ] && [ "$(ls -A ${init_extra_pre_wipe_dir})" ]; then
+  for script in "${init_extra_pre_wipe_dir}"/*; do
+    ./"${script}" 2>&1 | tee "/tmp/flashpkg/flashpkg/logs/custom-extra-pre-wipe-$(basename "${script}").log"
+  done
+else
+  echo "No init_extra_pre_wipe was found, ignoring" > /tmp/flashpkg/flashpkg/logs/custom-extra-pre-wipe.log
+fi

--- a/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
@@ -151,6 +151,13 @@ else
 		process_bootloader_package 2>&1 > /tmp/flashpkg/flashpkg/logs/bootloader.log &
 		wait_for_bootloader=yes
 		;;
+	    extra-pre-wipe)
+		if [ -f "/init-extra-pre-wipe" ]; then
+		    ./init-extra-pre-wipe
+		else
+		    echo "No init-extra-pre-wipe was found" >&2
+		fi
+		;;
 	    erase-mmc)
 		if [ -b /dev/mmcblk0 ]; then
 		    blkdiscard -f /dev/mmcblk0 2>&1 > /tmp/flashpkg/flashpkg/logs/erase-mmc.log

--- a/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
+++ b/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
@@ -4,6 +4,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = "\
     file://init-flash.sh \
+    file://init-extra-pre-wipe.sh \
     file://init-extra.sh \
     file://program-boot-device.sh \
     file://initrd-flash.scheme.in \
@@ -15,7 +16,9 @@ S = "${WORKDIR}"
 
 do_install() {
     install -m 0755 ${WORKDIR}/init-flash.sh ${D}/init
+    install -m 0755 ${WORKDIR}/init-extra-pre-wipe.sh ${D}/init-extra-pre-wipe
     install -m 0755 ${WORKDIR}/init-extra.sh ${D}/init-extra
+    install -m 0755 -d ${D}/init-extra-pre-wipe.d
     install -m 0755 -d ${D}/init-extra.d
     install -m 0555 -d ${D}/proc ${D}/sys
     install -m 0755 -d ${D}/dev ${D}/mnt ${D}/run ${D}/usr


### PR DESCRIPTION
This introduces a hook to the initrd-flash script which makes it possible to run custom scripts before erasing the storage disk via "erase-nvme" or overwriting it via "export-devices".

Note: There exists already an "extra" hock to run future scripts before the final reboot step. Similar to that, any future recipe intended to add custom extra pre-wipe scripts can use the TEGRA_INITRD_FLASH_INSTALL variable in the distro config to add the new package(s).

Furthermore, note that these custom scripts will need to be installed with executable permission set in the
/init_extra-pre-wipe.d folder of the tegraflash initrd image.