### PR TITLE
tegra-storage-layout-base: fix typo on external layout

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-storage-layout-base_36.3.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-storage-layout-base_36.3.0.bb
@@ -10,7 +10,7 @@ PARTITION_FILE_EXTERNAL ?= "${S}/tools/kernel_flash/${PARTITION_LAYOUT_EXTERNAL}
 do_install() {
     install -d ${D}${datadir}/l4t-storage-layout
     install -m 0644 ${PARTITION_FILE} ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE}
-    [ -z "${PARTITION_LAYOUT_EXTERNAL}" ] || install -m 0644 ${PARTITION_FILE_EXTERNAL} ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXERNAL}
+    [ -z "${PARTITION_LAYOUT_EXTERNAL}" ] || install -m 0644 ${PARTITION_FILE_EXTERNAL} ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}
 }
 
 PACKAGES = "${PN}-dev"


### PR DESCRIPTION
Fix typo and missing 'T' character in variable reference for `PARTITION_LAYOUT_EXTERNAL`.

The current typo means if the name of the file referenced by `PARTITION_FILE_EXTERNAL` was different than the name `PARTITION_LAYOUT_EXTERNAL`, the wrong filename would be used in the l4t-storage-layout dir.

Relates to  https://github.com/OE4T/meta-tegra/pull/1684