### PR TITLE
tegra-uefi-capsules: remove ESP image dependency for BUP

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -407,6 +407,7 @@ create_tegraflash_pkg[vardepsexclude] += "DATETIME"
 
 def tegraflash_bupgen_strip_cmd(d):
     images = d.getVar('TEGRA_BUPGEN_STRIP_IMG_NAMES').split()
+    images.append("esp.img")
     if len(images) == 0:
         return 'cp flash.xml.in flash-stripped.xml.in'
     return 'sed {} flash.xml.in > flash-stripped.xml.in'.format(' '.join(['-e"/<filename>.*{}/d"'.format(img) for img in images]))

--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.3.0.bb
@@ -26,7 +26,6 @@ do_compile() {
     # BUP generator really wants to use 'boot.img' for the LNX
     # partition contents
     tegraflash_populate_package ${IMAGE_TEGRAFLASH_KERNEL} boot.img ${@tegra_bootcontrol_overlay_list(d, bup=True)}
-    cp "${IMAGE_TEGRAFLASH_ESPIMG}" ./esp.img
     mv generate_bup_payload.sh doflash.sh
     tegraflash_create_flash_config flash.xml.in boot.img ${STAGING_DATADIR}/tegraflash/bupgen-internal-flash.xml
     . ./flashvars
@@ -99,6 +98,5 @@ do_compile[depends] += "virtual/kernel:do_deploy tegra-flashtools-native:do_popu
 do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot"
 do_compile[depends] += "tegra-bootfiles:do_populate_sysroot"
 do_compile[depends] += "coreutils-native:do_populate_sysroot virtual/secure-os:do_deploy"
-do_compile[depends] += "${@'${TEGRA_ESP_IMAGE}:do_image_complete' if d.getVar('TEGRA_ESP_IMAGE') != '' else  ''}"
 do_compile[depends] += "virtual/bootloader:do_deploy"
 do_compile[depends] += "${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS}"


### PR DESCRIPTION
```
Remove ESP image dependency for BUP generation. This helps
to avoid some circular dependencies in such cases as explained in [1].

The helper script (l4t_bup_gen.func) for BUP generation doesn't use it,
and the only mention of ESP partition is in the list of boot artifacts to
be included into BUP image (bup_type=bl),
where ESP image is explicitly marked to be skipped:

5. SKIP: 0 - built in BUP, 1 - not built in BUP
t23x_bl_table=(
        #PART_NAME        IMAGE_SIGNED BOARD_SPECIFIC OP_MODE_SPECIFIC SKIP
        'BCT              1            1              1                0'
        'BCT_A            1            1              1                0'
        'BCT_B            1            1              1                0'
        'BCT-boot-chain_backup 1       1              1                0'
        'A_mb1            1            1              1                0'
        'A_psc_bl1        1            0              1                0'
        'A_MB1_BCT        1            1              0                0'
        'A_MEM_BCT        1            1              0                0'
        'A_tsec-fw        1            0              0                0'
        'A_fsi-fw         1            0              0                0'
        'A_nvdec          1            0              1                0'
        'A_mb2            1            1              0                0'
        'A_bpmp-fw        1            1              1                0'
        'A_bpmp-fw-dtb    1            1              0                0'
        'A_psc-fw         1            0              1                0'
        'A_mts-mce        1            0              1                0'
        'A_sc7            1            0              1                0'
        'A_pscrf          1            0              1                0'
        'A_mb2rf          1            0              0                0'
        'A_cpu-bootloader 1            1              0                0'
        'A_secure-os      1            0              0                0'
        'A_smm-fw         1            0              0                1'
        'A_eks            1            0              0                0'
        'A_dce-fw         1            1              0                0'
        'A_spe-fw         1            0              0                0'
        'A_rce-fw         1            0              0                0'
        'A_adsp-fw        1            0              0                0'
        'uefi_variables   1            0              0                1'
        'uefi_ftw         1            0              0                1'
        'mb2-applet       0            0              0                0'
        'A_VER            0            1              0                0'
        'esp              1            0              0                1'
        'A_xusb-fw        1            0              1                0'
        'secondary_gpt    1            1              0                0'
        'secondary_gpt_backup 1        1              0                0'
)

[1] dc2d7526b1ac("bup: remove extra dependency to ESP")
Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>
```