### PR TITLE
tegra-flash-init: use usb configuration state for connection status

### DIFF
--- a/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
@@ -83,8 +83,8 @@ wait_for_connect() {
     local count=0
     echo -n "Waiting for host to connect..."
     while true; do
-	suspended=$(expr $(cat /sys/class/udc/$UDC/device/gadget/suspended) \+ 0)
-	if [ $suspended -eq 0 ]; then
+	configured=$(cat /sys/class/udc/$UDC/state)
+	if [ $configured = "configured" ]; then
 	    echo "[connected]"
 	    break
 	fi
@@ -103,8 +103,8 @@ wait_for_disconnect() {
     local count=0
     echo -n "Waiting for host to disconnect..."
     while true; do
-	suspended=$(expr $(cat /sys/class/udc/$UDC/device/gadget/suspended) \+ 0)
-	if [ $suspended -eq 1 ]; then
+	configured=$(cat /sys/class/udc/$UDC/state)
+	if [ $configured != "configured" ]; then
 	    echo "[disconnected]"
 	    break
 	fi


### PR DESCRIPTION
When a device is enumerated by the host, its usb configuration state changes to positively identify that it is ready to go. Conversely, when it is powered down, its configuration state indicates that it is no longer in that ready ('configured') state.

A side effect of the power saving for the USB peripheral would change the device into a suspended state if it is not configured, but this mechanism does not work reliably on the Orin AGX devkit.

Additionally, the gadget device sysfs node changed from a single /UDC/device/gadget function to /UDC/device/gadget.# in kernels newer than the current L4T 5.15, breaking the previous method for newer kernels.

Use this more direct method of determining if the usb host is using the device so it will work across various platforms as well as kernel versions.