### PR TITLE
nvidia-kernel-oot: conditionalize Makefile copying for do_unpack

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
@@ -19,7 +19,7 @@ require recipes-bsp/tegra-sources/tegra-sources-36.3.0.inc
 do_unpack[depends] += "tegra-binaries:do_preconfigure"
 
 unpack_makefile_from_bsp() {
-    cp ${L4T_BSP_SHARED_SOURCE_DIR}/source/Makefile ${S}/
+    [ -e ${S}/Makefile ] || cp ${L4T_BSP_SHARED_SOURCE_DIR}/source/Makefile ${S}/
 }
 do_unpack[postfuncs] += "unpack_makefile_from_bsp"
 


### PR DESCRIPTION
When using devtool, the first bitibake build after the devtool workspace is set up triggers re-execution of our do_unpack postfunc, which is overwriting the patched copy of the top-level makefile.

Avoid this by copying it in only if the top-level makefile isn't already there.

Fixes #1704 