### PR TITLE
UefiUpdateSecurityKeys.dtbo now included in capsule update.

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -32,8 +32,7 @@ def tegra_bootcontrol_overlay_list(d, bup=False, separator=','):
     overlays = d.getVar('TEGRA_BOOTCONTROL_OVERLAYS').split()
     if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         overlays.append('UefiDefaultSecurityKeys.dtbo')
-        sysroot = d.getVar('RECIPE_SYSROOT')
-        if bup and os.path.exists(os.path.join(sysroot, 'UefiUpdateSecurityKeys.dtbo')):
+        if bup and os.path.exists(os.path.join(d.getVar('STAGING_DATADIR') + '/tegra-uefi-keys', 'UefiUpdateSecurityKeys.dtbo')):
             overlays.append('UefiUpdateSecurityKeys.dtbo')
     return separator.join(overlays)
 

--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -32,7 +32,7 @@ def tegra_bootcontrol_overlay_list(d, bup=False, separator=','):
     overlays = d.getVar('TEGRA_BOOTCONTROL_OVERLAYS').split()
     if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         overlays.append('UefiDefaultSecurityKeys.dtbo')
-        if bup and os.path.exists(os.path.join(d.getVar('STAGING_DATADIR') + '/tegra-uefi-keys', 'UefiUpdateSecurityKeys.dtbo')):
+        if bup and os.path.exists(os.path.join(d.getVar('STAGING_DATADIR'), 'tegra-uefi-keys', 'UefiUpdateSecurityKeys.dtbo')):
             overlays.append('UefiUpdateSecurityKeys.dtbo')
     return separator.join(overlays)
 

--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -32,7 +32,8 @@ def tegra_bootcontrol_overlay_list(d, bup=False, separator=','):
     overlays = d.getVar('TEGRA_BOOTCONTROL_OVERLAYS').split()
     if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         overlays.append('UefiDefaultSecurityKeys.dtbo')
-        if bup and os.path.exists('UefiUpdateSecurityKeys.dtbo'):
+        sysroot = d.getVar('RECIPE_SYSROOT')
+        if bup and os.path.exists(os.path.join(sysroot, 'UefiUpdateSecurityKeys.dtbo')):
             overlays.append('UefiUpdateSecurityKeys.dtbo')
     return separator.join(overlays)
 

--- a/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
+++ b/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
@@ -33,6 +33,14 @@ do_compile() {
     fi
 }
 
+do_populate_sysroot() {
+    install -d ${SYSROOT_DESTDIR}
+    install -m 0644 ${B}/UefiDefaultSecurityKeys.dtbo ${SYSROOT_DESTDIR}
+    if [ -a "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
+        install -m 0644 ${B}/UefiUpdateSecurityKeys.dtbo ${SYSROOT_DESTDIR}
+    fi
+}
+
 do_install[noexec] = "1"
 
 do_deploy() {

--- a/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
+++ b/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
@@ -28,7 +28,7 @@ do_configure() {
 
 do_compile() {
     dtc -Idts -Odtb -o ${B}/UefiDefaultSecurityKeys.dtbo ${WORKDIR}/UefiDefaultSecurityKeys.dts
-    if [ -a "${WORKDIR}/UefiUpdateSecurityKeys.dts" ]; then
+    if [ -e "${WORKDIR}/UefiUpdateSecurityKeys.dts" ]; then
         dtc -Idts -Odtb -o ${B}/UefiUpdateSecurityKeys.dtbo ${WORKDIR}/UefiUpdateSecurityKeys.dts
     fi
 }
@@ -38,7 +38,7 @@ do_install() {
     install -d ${D}${datadir}/tegra-uefi-keys/
     
     install -m 0644 ${B}/UefiDefaultSecurityKeys.dtbo ${D}${datadir}/tegra-uefi-keys/
-    if [ -a "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
+    if [ -e "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
         install -m 0644 ${B}/UefiUpdateSecurityKeys.dtbo ${D}${datadir}/tegra-uefi-keys/
     fi
 }
@@ -46,7 +46,7 @@ do_install() {
 do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0644 ${B}/UefiDefaultSecurityKeys.dtbo ${DEPLOYDIR}/
-    if [ -a "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
+    if [ -e "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
         install -m 0644 ${B}/UefiUpdateSecurityKeys.dtbo ${DEPLOYDIR}/
     fi
 }

--- a/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
+++ b/recipes-bsp/uefi/tegra-uefi-keys-dtb.bb
@@ -33,15 +33,15 @@ do_compile() {
     fi
 }
 
-do_populate_sysroot() {
-    install -d ${SYSROOT_DESTDIR}
-    install -m 0644 ${B}/UefiDefaultSecurityKeys.dtbo ${SYSROOT_DESTDIR}
+do_install() {
+    install -d ${D}${datadir}
+    install -d ${D}${datadir}/tegra-uefi-keys/
+    
+    install -m 0644 ${B}/UefiDefaultSecurityKeys.dtbo ${D}${datadir}/tegra-uefi-keys/
     if [ -a "${B}/UefiUpdateSecurityKeys.dtbo" ]; then
-        install -m 0644 ${B}/UefiUpdateSecurityKeys.dtbo ${SYSROOT_DESTDIR}
+        install -m 0644 ${B}/UefiUpdateSecurityKeys.dtbo ${D}${datadir}/tegra-uefi-keys/
     fi
 }
-
-do_install[noexec] = "1"
 
 do_deploy() {
     install -d ${DEPLOYDIR}


### PR DESCRIPTION
I believe updating UEFI keys via tegra-uefi-keys-dtb.bb does not work on scarthgap nor master branches.

When adding UefiUpdateSecurityKeys.dts to tegra-uefi-keys-dtb.bbappend, the UefiUpdateSecurityKeys.dtbo is not installed in the sysroot of the recipe, causing tegra_bootcontrol_overlay_list() to not append it to the list of overlays to use for the capsule update. The result is that it is missing from the capsule update, making it impossible to update the KEK and other keys used by UEFI secure boot.

The problem can be observed without deploying the capsule update by searching for 'UefiUpdateSecurityKeys.dtbo' in 'tmp/work/horizon_orin_devkit-mdt-linux\tegra-uefi-capsules'; you should see that with the current code the file is not present.

With the changes proposed UefiUpdateSecurityKeys.dtbo is picked up for the capsule update and deploying the update I can see the new keys using mokutil --kek and mokutil --db.

A word of warning, having updated the UEFI KEK, db and dbx keys using this recipe, the board boots once, but on second reboot it stops at the following error:
ASSERT [FvbNorFlashStandaloneMm] /usr/src/debug/standalone-mm-optee-tegra/36.3.0/edk2-nvidia/Silicon)

This happens when signing the UEFI payloads with either the 'old' keys (pre-update) and with the new keys brought by the update. I am yet to test with Jetpack (not meta-tegra) to confirm whether updating the EKB actually works.