### PR TITLE
gcc-for-nvcc: rename gcc-for-nvcc-source -> gcc-source-for-nvcc

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-shared-source.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-shared-source.inc
@@ -7,9 +7,9 @@ deltask do_patch
 
 SRC_URI = ""
 
-do_configure[depends] += "gcc-for-nvcc-source-${PV}:do_preconfigure"
-do_populate_lic[depends] += "gcc-for-nvcc-source-${PV}:do_unpack"
-do_deploy_source_date_epoch[depends] += "gcc-for-nvcc-source-${PV}:do_deploy_source_date_epoch"
+do_configure[depends] += "gcc-source-for-nvcc-${PV}:do_preconfigure"
+do_populate_lic[depends] += "gcc-source-for-nvcc-${PV}:do_unpack"
+do_deploy_source_date_epoch[depends] += "gcc-source-for-nvcc-${PV}:do_deploy_source_date_epoch"
 
 # Copy the SDE from the shared workdir to the recipe workdir
 do_deploy_source_date_epoch () {

--- a/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc.inc
@@ -7,7 +7,7 @@ RM_WORK_EXCLUDE += "${PN}"
 
 inherit nopackages
 
-PN = "gcc-for-nvcc-source-${PV}"
+PN = "gcc-source-for-nvcc-${PV}"
 WORKDIR = "${TMPDIR}/work-shared/gcc-${PV}-${PR}"
 SSTATE_SWSPEC = "sstate:gcc::${PV}:${PR}::${SSTATE_VERSION}:"
 

--- a/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc_10.3.bb
+++ b/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc_10.3.bb
@@ -1,4 +1,4 @@
 require gcc-for-nvcc-${PV}.inc
-require gcc-for-nvcc-source.inc
+require gcc-source-for-nvcc.inc
 
 EXCLUDE_FROM_WORLD = "1"


### PR DESCRIPTION
to take advantage of the automatic license whitelisting buried in base.bbclass.

Fixes #1711