### PR TITLE
nvidia-kernel-oot: install headers to sysroot-only

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.3.0.bb
@@ -93,6 +93,8 @@ do_install() {
     install -m 0644 ${B}/nvidia-oot/device-tree/platform/generic-dts/dtbs/* ${D}/boot/devicetree/
     install -d ${D}${includedir}/${BPN}
     find ${B} -name Module.symvers -type f | xargs sed -e's:${B}/::g' >${D}${includedir}/${BPN}/Module.symvers
+
+    cp -R ${S}/nvidia-oot/include/* ${D}/${includedir}/${BPN}
 }
 
 SYSROOT_DIRS += "/boot/devicetree"
@@ -102,6 +104,9 @@ module_conf_nvgpu = 'options nvgpu devfreq_timer="delayed"'
 
 PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}-wifi ${PN}-canbus ${PN}-virtualization ${PN}-alsa ${PN}-test ${PN}-base"
 FILES:${PN}-devicetrees = "/boot/devicetree"
+FILES:${PN}-dev = "\
+    ${includedir}/${BPN} \
+"
 ALLOW_EMPTY:${PN}-display = "1"
 ALLOW_EMPTY:${PN}-cameras = "1"
 ALLOW_EMPTY:${PN}-bluetooth = "1"


### PR DESCRIPTION
This pull request adds the following features:

Revision 2
########

This pull request adds the following features:

* Allow NVIDIA Kernel OOT headers to be staged, so that the users can import NVIDIA Tegra headers after defining the dependency on this package. These headers are added to the `nvidia-kernel-oot-dev` package.

Testing:

* The NVIDIA Kernel OOT headers are successfully staged in the recipe sysroot of recipes that DEPENDS on `nvidia-kernel-oot`. The files looks like the following in a recipe-sysroot:

```
...recipe-sysroot/usr/include/nvidia-kernel-oot/
drivers-private  dt-bindings  linux  media  Module.symvers  soc  tegra_virt_storage_spec.h  trace  uapi  video
```

* The NVIDIA Kernel OOT development Debian package looks like the following:
```
dpkg-deb  -c ...nvidia-kernel-oot-dev_36.3.0-r0_arm64.deb
drwxrwxrwx root/root         0 2024-05-06 17:20 ./
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/
-rw-r--r-- root/root     65633 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/Module.symvers
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/devfreq/
-rw-r--r-- root/root      3302 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/devfreq/governor.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/devfreq/k519/
-rw-r--r-- root/root      4085 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/devfreq/k519/governor.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/pinctrl/
-rw-r--r-- root/root      8145 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/pinctrl/core.h
-rw-r--r-- root/root      1717 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/pinctrl/pinctrl-utils.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/
-rw-r--r-- root/root     19362 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/ufs.h
-rw-r--r-- root/root      4373 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/ufs_quirks.h
-rw-r--r-- root/root     42152 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/ufshcd.h
-rw-r--r-- root/root     14144 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/ufshci.h
-rw-r--r-- root/root      9469 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k515/unipro.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/
-rw-r--r-- root/root     19690 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/ufs.h
-rw-r--r-- root/root      4373 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/ufs_quirks.h
-rw-r--r-- root/root     43719 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/ufshcd.h
-rw-r--r-- root/root     14120 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/ufshci.h
-rw-r--r-- root/root      9469 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k516/unipro.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k61/
-rw-r--r-- root/root      8882 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k61/ufshcd-priv.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k67/
-rw-r--r-- root/root     11890 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/k67/ufshcd-priv.h
-rw-r--r-- root/root      1376 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/ufshcd-pltfrm.h
-rw-r--r-- root/root       500 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/ufshcd-priv.h
-rw-r--r-- root/root       517 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/ufshcd.h
-rw-r--r-- root/root       461 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/ufshci.h
-rw-r--r-- root/root       457 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/scsi/ufs/unipro.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/codecs/
-rw-r--r-- root/root     75655 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/codecs/rt5640.h
-rw-r--r-- root/root     64833 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/codecs/rt5659.h
-rw-r--r-- root/root     12549 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/codecs/sgtl5000.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/tegra/
-rw-r--r-- root/root      1950 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/tegra/tegra_cif.h
-rw-r--r-- root/root      1331 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/drivers-private/sound/soc/tegra/tegra_pcm.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/interconnect/
-rw-r--r-- root/root      1797 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/interconnect/tegra_icc_id.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/mfd/
-rw-r--r-- root/root      5041 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/mfd/max77851.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/thermal/
-rw-r--r-- root/root      1025 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/dt-bindings/thermal/tegra234-soctherm.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/
-rw-r--r-- root/root       630 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/arm64-barrier.h
-rw-r--r-- root/root      2528 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/arm64-ras.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/devfreq/
-rw-r--r-- root/root      1765 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/devfreq/tegra_wmark.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/mfd/
-rw-r--r-- root/root     95988 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/mfd/max77851.h
-rw-r--r-- root/root      4775 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/mfd/nvidia-vrs-pseq.h
-rw-r--r-- root/root      5459 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nv-p2p.h
-rw-r--r-- root/root      9371 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvhost.h
-rw-r--r-- root/root       767 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvhost_t194.h
-rw-r--r-- root/root      3154 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvmap.h
-rw-r--r-- root/root       706 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvmap_t19x.h
-rw-r--r-- root/root       519 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvpps.h
-rw-r--r-- root/root      7926 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvscierror.h
-rw-r--r-- root/root      1681 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/nvsciipc_interface.h
-rw-r--r-- root/root      5051 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/pcie_dma.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/
-rw-r--r-- root/root      5423 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/actmon_common.h
-rw-r--r-- root/root       869 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/bwmgr_mc.h
-rw-r--r-- root/root      1466 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/common.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/dce/
-rw-r--r-- root/root      2283 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/dce/dce-client-ipc.h
-rw-r--r-- root/root     10433 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/emc_bwmgr.h
-rw-r--r-- root/root       549 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/iso_client.h
-rw-r--r-- root/root      6408 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/isomgr.h
-rw-r--r-- root/root     11097 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/latency_allowance.h
-rw-r--r-- root/root      2729 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/mc_utils.h
-rw-r--r-- root/root      1448 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/ptp-notifier.h
-rw-r--r-- root/root      3526 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/t23x_ari.h
-rw-r--r-- root/root      4561 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/platform/tegra/tegra-mce.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/spi/
-rw-r--r-- root/root       462 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/spi/spi-tegra124-slave.h
-rw-r--r-- root/root       254 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-aon.h
-rw-r--r-- root/root       804 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-camera-rtcpu.h
-rw-r--r-- root/root      4385 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-capture-ivc.h
-rw-r--r-- root/root      2503 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-firmwares.h
-rw-r--r-- root/root      1646 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-gte.h
-rw-r--r-- root/root       976 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-hsp-combo.h
-rw-r--r-- root/root      3398 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-hsp.h
-rw-r--r-- root/root      3570 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-ivc-bus.h
-rw-r--r-- root/root      1740 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-ivc-instance.h
-rw-r--r-- root/root     13235 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-ivc.h
-rw-r--r-- root/root       674 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-oot-prod.h
-rw-r--r-- root/root     10842 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-pcie-edma-test-common.h
-rw-r--r-- root/root      5511 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-pcie-edma.h
-rw-r--r-- root/root      4667 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-prod-legacy-dummy.h
-rw-r--r-- root/root      2013 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-prod-upstream-dummy.h
-rw-r--r-- root/root       463 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-rtcpu-monitor.h
-rw-r--r-- root/root       607 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra-rtcpu-trace.h
-rw-r--r-- root/root       978 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra_gr_comm.h
-rw-r--r-- root/root     10771 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra_nvadsp.h
-rw-r--r-- root/root      9167 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/linux/tegra_vnet.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/
-rw-r--r-- root/root     12286 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/camera_common.h
-rw-r--r-- root/root      1262 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/camera_version_utils.h
-rw-r--r-- root/root       463 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/cdi-dev.h
-rw-r--r-- root/root       931 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/cdi-mgr.h
-rw-r--r-- root/root      4842 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/csi.h
-rw-r--r-- root/root      6838 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/csi4_registers.h
-rw-r--r-- root/root      1160 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/csi5_registers.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/
-rw-r--r-- root/root      6786 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/capture-common.h
-rw-r--r-- root/root      3238 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/capture-isp-channel.h
-rw-r--r-- root/root     10753 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/capture-isp.h
-rw-r--r-- root/root      6012 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/capture-vi-channel.h
-rw-r--r-- root/root     14347 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/fusa-capture/capture-vi.h
-rw-r--r-- root/root      2724 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/gmsl-link.h
-rw-r--r-- root/root       692 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/imx219.h
-rw-r--r-- root/root      1416 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/imx274.h
-rw-r--r-- root/root      1255 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/imx318.h
-rw-r--r-- root/root      1354 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/imx477.h
-rw-r--r-- root/root       453 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/isc-dev.h
-rw-r--r-- root/root       923 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/isc-mgr.h
-rw-r--r-- root/root      2330 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/max9295.h
-rw-r--r-- root/root      4755 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/max9296.h
-rw-r--r-- root/root     14886 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/mc_common.h
-rw-r--r-- root/root       241 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/nv_hawk_owl.h
-rw-r--r-- root/root      2939 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/nvc.h
-rw-r--r-- root/root      2192 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/nvc_focus.h
-rw-r--r-- root/root      1475 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/ov5693.h
-rw-r--r-- root/root      1103 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/sensor_common.h
-rw-r--r-- root/root      5998 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegra-v4l2-camera.h
-rw-r--r-- root/root      3159 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegra_camera_core.h
-rw-r--r-- root/root      1328 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegra_camera_dev_mfi.h
-rw-r--r-- root/root      2766 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegra_camera_platform.h
-rw-r--r-- root/root       913 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegra_v4l2_camera.h
-rw-r--r-- root/root      1494 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegracam_core.h
-rw-r--r-- root/root      1107 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/tegracam_utils.h
-rw-r--r-- root/root      3096 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/vi.h
-rw-r--r-- root/root      8219 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/vi2_registers.h
-rw-r--r-- root/root      7792 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/media/vi4_registers.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/
-rw-r--r-- root/root    117492 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/bpmp-abi.h
-rw-r--r-- root/root     73053 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-capture-messages.h
-rw-r--r-- root/root    198230 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-capture.h
-rw-r--r-- root/root      2955 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-channels.h
-rw-r--r-- root/root      7033 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-commands.h
-rw-r--r-- root/root      1634 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-common.h
-rw-r--r-- root/root     12865 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-dbg-messages.h
-rw-r--r-- root/root     15396 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/camrtc-trace.h
-rw-r--r-- root/root      1187 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/fuse-helper.h
-rw-r--r-- root/root       244 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/ivc-priv.h
-rw-r--r-- root/root      4294 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/ivc_ext.h
-rw-r--r-- root/root       401 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/kfuse.h
-rw-r--r-- root/root      1988 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/tegra-i2c-rtcpu.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/virt/
-rw-r--r-- root/root     12092 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/virt/hv-ivc.h
-rw-r--r-- root/root     11944 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/virt/syscalls.h
-rw-r--r-- root/root       413 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/virt/tegra_hv_pm_ctl.h
-rw-r--r-- root/root      3842 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/soc/tegra/virt/tegra_hv_sysmgr.h
-rw-r--r-- root/root      9862 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/tegra_virt_storage_spec.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/
-rw-r--r-- root/root      5156 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/camera_common.h
-rw-r--r-- root/root      2596 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/dce_events.h
-rw-r--r-- root/root     16637 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/freertos.h
-rw-r--r-- root/root       788 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/imx185.h
-rw-r--r-- root/root      2266 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/nvdla_ftrace.h
-rw-r--r-- root/root      5865 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/nvhost_podgov.h
-rw-r--r-- root/root     20101 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/nvmap.h
-rw-r--r-- root/root     10508 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/nvpva_ftrace.h
-rw-r--r-- root/root       790 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/ov5693.h
-rw-r--r-- root/root      5654 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/tegra_capture.h
-rw-r--r-- root/root     15469 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/trace/events/tegra_rtcpu.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/
-rw-r--r-- root/root      1298 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvdev_fence.h
-rw-r--r-- root/root      5909 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_events.h
-rw-r--r-- root/root     13649 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_ioctl.h
-rw-r--r-- root/root      1063 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_isp_ioctl.h
-rw-r--r-- root/root      2195 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_nvcsi_ioctl.h
-rw-r--r-- root/root      7161 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_nvdla_ioctl.h
-rw-r--r-- root/root       734 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhost_vi_ioctl.h
-rw-r--r-- root/root       587 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvhvivc_mempool_ioctl.h
-rw-r--r-- root/root     10809 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvmap.h
-rw-r--r-- root/root      1561 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvpps_ioctl.h
-rw-r--r-- root/root     16223 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvpva_ioctl.h
-rw-r--r-- root/root      2714 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/nvsciipc_ioctl.h
-rw-r--r-- root/root       982 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/tegra-fsicom.h
-rw-r--r-- root/root      1282 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/tegra-gte-ioctl.h
-rw-r--r-- root/root      1104 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/tegra-ivc-dev.h
-rw-r--r-- root/root       674 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/linux/tegra_hv_vcpu_yield_ioctl.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/
-rw-r--r-- root/root       235 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/cam_fsync.h
-rw-r--r-- root/root      2284 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/camera_device.h
-rw-r--r-- root/root      1124 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/cdi-dev.h
-rw-r--r-- root/root      2337 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/cdi-mgr.h
-rw-r--r-- root/root      1603 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/imx219.h
-rw-r--r-- root/root      1216 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/imx274.h
-rw-r--r-- root/root      2037 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/imx318.h
-rw-r--r-- root/root       509 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/isc-dev.h
-rw-r--r-- root/root      1461 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/isc-mgr.h
-rw-r--r-- root/root      5940 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/nvc.h
-rw-r--r-- root/root      6169 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/nvc_image.h
-rw-r--r-- root/root      3135 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/ov5693.h
-rw-r--r-- root/root       489 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/media/tegra_camera_platform.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/misc/
-rw-r--r-- root/root      1473 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/misc/adsp_console_ioctl.h
-rw-r--r-- root/root     59724 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/misc/mods.h
-rw-r--r-- root/root      6830 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/misc/nvscic2c-pcie-ioctl.h
-rw-r--r-- root/root     15207 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/misc/tegra-nvvse-cryptodev.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/scsi/
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/scsi/ufs/
-rw-r--r-- root/root      1808 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/uapi/scsi/ufs/ioctl.h
drwxr-xr-x root/root         0 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/video/
-rw-r--r-- root/root      1217 2024-05-06 17:20 ./usr/include/nvidia-kernel-oot/video/vi4.h
```

Revision 1
########
* Allow NVIDIA Kernel OOT headers to be staged, so that the users can import NVIDIA Tegra headers with:

```
EXTRA_CFLAGS:append = "\
    -I${STAGING_DIR_HOST}/sysroot-only/nvidia-oot/include \
"

do_compile[depends] += "nvidia-kernel-oot:do_populate_sysroot"
```

Testing:

* The NVIDIA Kernel OOT headers are successfully staged in the recipe sysroot of recipes that DEPENDS on `nvidia-kernel-oot`