### PR TITLE
Fix device tree file check in nvidia-kernel-oot-dtb

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_36.4.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_36.4.0.bb
@@ -14,7 +14,7 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 do_deploy() {
     for dtb in ${KERNEL_DEVICETREE}; do
         dtbf="${STAGING_DIR_HOST}/boot/devicetree/$dtb"
-        if [ -z "$dtbf" ]; then
+        if [ ! -f "$dtbf" ]; then
             bbfatal "Not found: $dtbf"
         fi
     done


### PR DESCRIPTION
Currently the device tree file check in `nvidia-kernel-oot-dtb` will always return true because it checks if the filepath is non-empty instead of checking if the file exists at that path.

Fixed by replacing `-z` with `! -f` so it will check if the file actually exists. This will ensure the build session correctly exits if the desired device tree file cannot be found.

Tested by building for the off-the-shelf `jetson-agx-orin-devkit` successfully, then changing `KERNEL_DEVICETREE` to some random string that doesn't exist in the kernel source, and the build would exit instead of continuing.