### PR TITLE
linux-tegra_5.10.bb: fix sign_bootimg

### DIFF
--- a/recipes-kernel/linux/linux-tegra_5.10.bb
+++ b/recipes-kernel/linux/linux-tegra_5.10.bb
@@ -158,6 +158,8 @@ do_deploy:append() {
 
 sign_bootimg() {
     tegra_uefi_attach_sign "$1"
+    rm "$1"
+    mv "$1.signed" "$1"
 }
 
 bootimg_from_bundled_initramfs() {


### PR DESCRIPTION
- This matches the behavior in classes/image_types_cboot.bbclass whereby the signed kernel image is copied over the top of the original unsigned kernel image.