### PR TITLE
Add Upstream-Status into .patch files even for scarthgap-l4t-r35.x branch

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
@@ -3,6 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Fri, 11 Mar 2022 11:20:55 -0800
 Subject: [PATCH] Fixups for cross building in OE
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  python/CMakeLists.txt                | 9 ++-------
  python/include/ForwardDeclarations.h | 2 +-

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Mon, 13 Nov 2023 09:05:03 -0800
 Subject: [PATCH] CMakeLists.txt: fix cross compilation issues
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-fix-build-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0002-fix-build-issues.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Mon, 13 Nov 2023 09:07:38 -0800
 Subject: [PATCH] fix build issues
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>

--- a/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
@@ -10,6 +10,9 @@ the output mode but not issue a page flip.
 This change adds a default framebuffer to the egldevice driver for
 use with the initial calls to set the CRTC mode and plane.
 
+Upstream-Status: Pending
+Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>
+
 ---
  .../qeglfskmsegldevicescreen.cpp              | 66 +++++++++++++++++--
  .../qeglfskmsegldevicescreen.h                |  3 +

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
@@ -7,6 +7,7 @@ Subject: [PATCH 1/3] L4TLauncher: boot syslinux instead of extlinux for ostree
 Ostree uses syslinux.cfg instead of extlinux.conf for providing the
 required kernel/initrd/dtb files for the bootloader.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
@@ -7,6 +7,7 @@ Besides looking for the APP part-name (standard in emmc), also look for
 otaroot-based partitions when searching for extlinux configuration. This
 allows the device to boot from OTA-enabled rootfs.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
@@ -10,6 +10,7 @@ clear up the variables).
 This is to avoid forcing the device to boot in recovery after 3 boots
 without confirmation from nvbootctrl.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0001-Fix-mapping-of-library-paths-for-jetson-mounts.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0001-Fix-mapping-of-library-paths-for-jetson-mounts.patch
@@ -5,6 +5,8 @@ Subject: [PATCH 1/3] Fix mapping of library paths for jetson mounts
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+
+Upstream-Status: Pending
 ---
  src/jetson_mount.c | 70 ++++++++++++++++++++++++++++++++++++++++------
  src/jetson_mount.h |  2 +-

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0002-OE-cross-build-fixups.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0002-OE-cross-build-fixups.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 2/3] OE cross-build fixups
 Signed-off-by: Pablo Rodriguez Quesada <pablo.rodriguez-quesada@windriver.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  Makefile     | 40 ++++++++++++++++++++++------------------
  mk/common.mk |  4 ++--

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0003-Add-support-for-separate-pass-through-tree.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container-jetson/0003-Add-support-for-separate-pass-through-tree.patch
@@ -9,6 +9,8 @@ to avoid glibc and other shared library mismatches inside
 NVIDIA's containers.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  Makefile           |  3 +++
  src/jetson_mount.c | 57 +++++++++++++++++++++++++++++++++++++---------

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0001-OE-cross-build-fixups.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0001-OE-cross-build-fixups.patch
@@ -3,6 +3,8 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Sun, 8 Aug 2021 21:18:48 +0100
 Subject: [PATCH] OE cross-build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+
 Signed-off-by: Pablo Rodriguez Quesada <pablo.rodriguez-quesada@windriver.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-Expose-device-file-attrs.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-Expose-device-file-attrs.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 17 Apr 2022 05:20:32 -0700
 Subject: [PATCH] Expose device file attrs
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  deps/src/nvidia-modprobe-495.44/modprobe-utils/nvidia-modprobe-utils.c | 8 ++++----
  deps/src/nvidia-modprobe-495.44/modprobe-utils/nvidia-modprobe-utils.h | 1 +

--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
@@ -5,6 +5,7 @@ Subject: [PATCH] workaround to fix ld.bfd warning (binutils version 2.39)
 
 l31.elf has a LOAD segment with RWX permissions
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---
  Makefile | 4 ++--

--- a/recipes-bsp/cboot/nvdisp-init/0001-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0001-Drop-mistaken-global-variable-definition-in-sdmmc_de.patch
@@ -8,6 +8,8 @@ code actually uses the struct tag in all declarations,
 so dropping the type name is OK.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  bootloader/partner/common/drivers/sdmmc/tegrabl_sdmmc_defs.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-bsp/cboot/nvdisp-init/0002-Convert-Python-scripts-to-Python3.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0002-Convert-Python-scripts-to-Python3.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Wed, 22 Jan 2020 06:57:17 -0800
 Subject: [PATCH 02/17] Convert Python scripts to Python3
 
+
+Upstream-Status: Pending
 ---
  bootloader/partner/t18x/cboot/build/get_branch_name.py    | 4 ++--
  bootloader/partner/t18x/cboot/scripts/add_version_info.py | 4 ++--

--- a/recipes-bsp/cboot/nvdisp-init/0003-macros.mk-fix-GNU-make-4.3-compatibility.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0003-macros.mk-fix-GNU-make-4.3-compatibility.patch
@@ -7,6 +7,8 @@ Backport of lk upstream commit
 77f5dac5252a9c1a28baab6224431a06b475dba1.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  bootloader/partner/t18x/cboot/make/macros.mk | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/recipes-bsp/cboot/nvdisp-init/0004-Restore-version-number-to-L4T-builds.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0004-Restore-version-number-to-L4T-builds.patch
@@ -13,6 +13,8 @@ that omits it, so it's easier to tell what version of cboot
 is being used.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  bootloader/partner/t18x/cboot/make/build.mk | 4 ----
  1 file changed, 4 deletions(-)

--- a/recipes-bsp/cboot/nvdisp-init/0005-nvdisp-init.patch
+++ b/recipes-bsp/cboot/nvdisp-init/0005-nvdisp-init.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Pending
+
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: LicenseRef-NvidiaProprietary
 #

--- a/recipes-bsp/tegra-binaries/files/0003-Convert-BUP_generator.py-to-Python3.patch
+++ b/recipes-bsp/tegra-binaries/files/0003-Convert-BUP_generator.py-to-Python3.patch
@@ -7,6 +7,8 @@ Ran it through 2to3 for the conversion, then
 made some additional fixes not caught by the tool.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  bootloader/BUP_generator.py | 26 +++++++++++++-------------
  1 file changed, 13 insertions(+), 13 deletions(-)

--- a/recipes-bsp/tegra-binaries/files/0004-Convert-gen_tos_part_img.py-to-Python3.patch
+++ b/recipes-bsp/tegra-binaries/files/0004-Convert-gen_tos_part_img.py-to-Python3.patch
@@ -1,7 +1,11 @@
 From 83e9fa94ea79bc00d0ac9bfc8e003c5335a29aef Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Wed, 22 Jan 2020 06:35:59 -0800
-Subject: [PATCH 4/4] Convert gen_tos_part_img.py to Python3
+Subject: [PATCH] Convert gen_tos_part_img.py to Python3
+
+Upstream-Status: Inappropriate [OE specific]
+
+Signed-off-by: Matt Madison <matt@madison.systems>
 
 %% original patch: 0004-Convert-gen_tos_part_img.py-to-Python3.patch
 ---

--- a/recipes-bsp/tegra-binaries/files/0006-Update-tegra-python-scripts-for-Python3.patch
+++ b/recipes-bsp/tegra-binaries/files/0006-Update-tegra-python-scripts-for-Python3.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] Update tegra python scripts for Python3
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+
+Upstream-Status: Pending
 ---
  ...ate-tegra-python-scripts-for-Python3.patch | 126 ++++++++++++++++++
  bootloader/tegraflash_impl_t234.py            |   7 +-

--- a/recipes-bsp/tegra-binaries/files/0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch
+++ b/recipes-bsp/tegra-binaries/files/0009-Remove-xxd-dependency-from-l4t_sign_image.sh.patch
@@ -6,6 +6,8 @@ Subject: [PATCH] Remove xxd dependency from l4t_sign_image.sh
 since it's not necessarily available in the build environment.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  l4t_sign_image.sh | 3 +--
  1 file changed, 1 insertion(+), 2 deletions(-)

--- a/recipes-bsp/tegra-binaries/files/0010-Rework-logging-in-l4t_sign_image.sh.patch
+++ b/recipes-bsp/tegra-binaries/files/0010-Rework-logging-in-l4t_sign_image.sh.patch
@@ -8,6 +8,8 @@ builds, which wasn't happy about the output redirection
 cloning that the script was using.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  l4t_sign_image.sh | 20 +++++++-------------
  1 file changed, 7 insertions(+), 13 deletions(-)

--- a/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
+++ b/recipes-bsp/tegra-binaries/files/0013-Fix-location-of-bsp_version-file-in-l4t_bup_gen.func.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Mon, 7 Jun 2021 04:22:40 -0700
 Subject: [PATCH] Fix location of bsp_version file in l4t_bup_gen.func
 
+
+Upstream-Status: Pending
 ---
  bootloader/l4t_bup_gen.func | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)

--- a/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch
+++ b/recipes-bsp/tegra-binaries/files/0014-odmsign.func-fix-ODMDATA-and-overlay-DTB-handling-fo.patch
@@ -8,6 +8,8 @@ bootloader DTB so it can incorporate the ODMDATA and any DTB
 overlays into the signed bootloader DTB.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  bootloader/odmsign.func | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-bsp/tegra-binaries/tegra-configs/0001-Patch-udev-rules-for-OE-use.patch
+++ b/recipes-bsp/tegra-binaries/tegra-configs/0001-Patch-udev-rules-for-OE-use.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Wed, 28 Feb 2024 23:08:26 +0000
 Subject: [PATCH 1/2] Patch udev rules for OE use
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  etc/udev/rules.d/99-tegra-devices.rules | 5 -----

--- a/recipes-bsp/tegra-binaries/tegra-configs/0002-Patch-nv.sh-script-for-OE-use.patch
+++ b/recipes-bsp/tegra-binaries/tegra-configs/0002-Patch-nv.sh-script-for-OE-use.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Wed, 28 Feb 2024 23:12:36 +0000
 Subject: [PATCH 2/2] Patch nv.sh script for OE use
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  etc/systemd/nv.sh | 264 ----------------------------------------------

--- a/recipes-bsp/tegra-binaries/tegra-nvpower/0001-Drop-bc-usage-and-remove-symlink-creation-functions.patch
+++ b/recipes-bsp/tegra-binaries/tegra-nvpower/0001-Drop-bc-usage-and-remove-symlink-creation-functions.patch
@@ -4,6 +4,9 @@ Date: Fri, 25 Mar 2022 12:51:57 -0700
 Subject: [PATCH] Drop bc usage and remove symlink creation functions
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+
+Upstream-Status: Pending
 ---
  etc/systemd/nvpower.sh | 81 +-----------------------------------------
  1 file changed, 1 insertion(+), 80 deletions(-)

--- a/recipes-bsp/uefi/files/0001-Use-bfd-linker.patch
+++ b/recipes-bsp/uefi/files/0001-Use-bfd-linker.patch
@@ -15,6 +15,8 @@ Builds fails when using gold linker:
 | collect2: error: ld returned 1 exit status
 
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+
+Upstream-Status: Pending
 ---
  BaseTools/Conf/tools_def.template | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-bsp/uefi/files/0002-Fix-RCM-boot-detection.patch
+++ b/recipes-bsp/uefi/files/0002-Fix-RCM-boot-detection.patch
@@ -26,6 +26,8 @@ easier to debug with a regular DEBUG mode build.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
+
+Upstream-Status: Pending
 ---
  .../PlatformBootOrderLib.c                    | 37 ++++++++-----------
  .../PlatformBootOrderLib.inf                  |  1 +

--- a/recipes-bsp/uefi/files/0003-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch
+++ b/recipes-bsp/uefi/files/0003-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch
@@ -1,9 +1,9 @@
 From 9e77fe4f3a34eda6d131e33f9a5f11fbaa34d423 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Sat, 4 Feb 2023 06:31:24 -0800
-Subject: [PATCH 3/4] L4TLauncher: allow for empty/missing APPEND line in
- extlinux.conf
+Subject: [PATCH 2/3] L4TLauncher: allow for empty/missing APPEND line in extlinux.conf
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/recipes-bsp/uefi/files/0004-Ext4Pkg-Advertise-CSUM_SEED-as-supported.patch
+++ b/recipes-bsp/uefi/files/0004-Ext4Pkg-Advertise-CSUM_SEED-as-supported.patch
@@ -15,7 +15,7 @@ Detected by attempting to mount a relatively new mkfs.ext4'd filesystem.
 Cc: Marvin Häuser <mhaeuser@posteo.de>
 Signed-off-by: Pedro Falcato <pedro.falcato@gmail.com>
 Reviewed-by: Marvin Häuser <mhaeuser@posteo.de>
-Upstream-Status: Backport[https://github.com/tianocore/edk2-platforms/commit/92479808e7227017cdfb19815605bb1fa877d19f]
+Upstream-Status: Backport [https://github.com/tianocore/edk2-platforms/commit/92479808e7227017cdfb19815605bb1fa877d19f]
 ---
  Features/Ext4Pkg/Ext4Dxe/Superblock.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0001-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0001-CVE-2021-35465.patch
@@ -20,7 +20,7 @@ gcc:
 	the command line.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3929bca9ca95de9d35e82ae8828b188029e3eb70]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3929bca9ca95de9d35e82ae8828b188029e3eb70]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0002-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0002-CVE-2021-35465.patch
@@ -15,7 +15,7 @@ libgcc:
 	Add vlldm erratum work-around.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=574e7950bd6b34e9e2cacce18c802b45505d1d0a]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=574e7950bd6b34e9e2cacce18c802b45505d1d0a]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0003-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0003-CVE-2021-35465.patch
@@ -16,7 +16,7 @@ gcc:
 	use when erratum mitigation is needed.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=30461cf8dba3d3adb15a125e4da48800eb2b9b8f]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=30461cf8dba3d3adb15a125e4da48800eb2b9b8f]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-64-bit-multilib-hack.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-64-bit-multilib-hack.patch
@@ -23,7 +23,7 @@ Do same for riscv64 and aarch64
 
 RP 15/8/11
 
-Upstream-Status: Inappropriate[OE-Specific]
+Upstream-Status: Inappropriate [OE-Specific]
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-CVE-2021-35465.patch
@@ -17,7 +17,7 @@ gcc/testsuite:
 	* gcc.target/arm/cmse/mainline/8_1m/softfp/cmse-8a.c: Likewise.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=809330ab8450261e05919b472783bf15e4b000f7]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=809330ab8450261e05919b472783bf15e4b000f7]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gie/files/0001-Makefile-fix-cross-compilation-issues.patch
+++ b/recipes-devtools/gie/files/0001-Makefile-fix-cross-compilation-issues.patch
@@ -4,6 +4,8 @@ Date: Thu, 24 Feb 2022 01:53:30 +0000
 Subject: [PATCH] Makefile: fix cross compilation issues
 
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+
+Upstream-Status: Pending
 ---
  Makefile.config | 29 +++++++++++++++++++----------
  1 file changed, 19 insertions(+), 10 deletions(-)

--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0001-Fix-stdbool.h-inclusion-check.patch
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0001-Fix-stdbool.h-inclusion-check.patch
@@ -4,6 +4,8 @@ Date: Mon, 4 Apr 2022 21:19:32 +0100
 Subject: [PATCH 1/2] Fix stdbool.h inclusion check
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  nvgldemo/nvgldemo_win_egldevice.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0002-weston-dmabuf-formats-cross-build-fixes.patch
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0002-weston-dmabuf-formats-cross-build-fixes.patch
@@ -4,6 +4,8 @@ Date: Wed, 9 Aug 2023 23:26:36 +0100
 Subject: [PATCH 2/2] weston-dmabuf-formats cross-build fixes
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  weston-dmabuf-formats/Makefile | 42 ++++++++++++++++++++++++++++------
  1 file changed, 35 insertions(+), 7 deletions(-)

--- a/recipes-graphics/wayland/egl-wayland/0001-Fix-wayland-eglstream-protocols-pc-file.patch
+++ b/recipes-graphics/wayland/egl-wayland/0001-Fix-wayland-eglstream-protocols-pc-file.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Sat, 2 Feb 2019 06:59:41 -0800
 Subject: [PATCH] Fix wayland-eglstream-protocols pc file
 
+Upstream-Status: Pending
+Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  wayland-eglstream-protocols.pc.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-graphics/wayland/weston/0001-Drop-DRM-version-check-in-meson.build.patch
+++ b/recipes-graphics/wayland/weston/0001-Drop-DRM-version-check-in-meson.build.patch
@@ -10,6 +10,8 @@ not ours, so just drop the check entirely for tegra
 builds.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  meson.build | 6 ------
  1 file changed, 6 deletions(-)

--- a/recipes-graphics/wayland/weston/0002-gl-renderer-Add-EGL-client-support-for-EGLStream-fra.patch
+++ b/recipes-graphics/wayland/weston/0002-gl-renderer-Add-EGL-client-support-for-EGLStream-fra.patch
@@ -27,6 +27,8 @@ Signed-off-by: Erik Kurzinger <ekurzinger@nvidia.com>
 Reviewed-by: Adam Cheney <acheney@nvidia.com>
 Reviewed-by: James Jones <jajones@nvidia.com>
 
+
+Upstream-Status: Pending
 ---
  libweston/renderer-gl/egl-glue.c             |  20 +++
  libweston/renderer-gl/gl-renderer-internal.h |  15 ++

--- a/recipes-graphics/wayland/weston/0003-compositor-Process-stream-attach-requests-with-wl_eg.patch
+++ b/recipes-graphics/wayland/weston/0003-compositor-Process-stream-attach-requests-with-wl_eg.patch
@@ -31,6 +31,8 @@ requests.
 Signed-off-by: Ashutosh Agarwal <asagarwal@nvidia.com>
 Signed-off-by: Miguel A Vico Moya <mvicomoya@nvidia.com>
 
+
+Upstream-Status: Pending
 ---
  compositor/meson.build              |   1 +
  include/libweston/libweston.h       |  13 +++

--- a/recipes-kernel/kern-tools/kern-tools-tegra/0001-Add-kernel-overlays-support-to-kconfiglib.patch
+++ b/recipes-kernel/kern-tools/kern-tools-tegra/0001-Add-kernel-overlays-support-to-kconfiglib.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Sat, 8 Aug 2020 08:48:13 -0700
 Subject: [PATCH] Add kernel overlays support to kconfiglib
 
+
+Upstream-Status: Pending
 ---
  Kconfiglib/kconfiglib.py | 51 ++++++++++++++++++++++++++++++++++++++--
  1 file changed, 49 insertions(+), 2 deletions(-)

--- a/recipes-multimedia/argus/argus-samples/0001-argus-apps-camera-replace-xxd-invocation-with-shell-.patch
+++ b/recipes-multimedia/argus/argus-samples/0001-argus-apps-camera-replace-xxd-invocation-with-shell-.patch
@@ -7,6 +7,7 @@ The xxd command is part of vim, which isn't really a build
 tool.  Use a shell script to perform the header file creation
 instead.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  argus/apps/camera/ui/camera/CMakeLists.txt | 3 ++-

--- a/recipes-multimedia/argus/files/0001-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch
+++ b/recipes-multimedia/argus/files/0001-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch
@@ -6,6 +6,7 @@ Subject: [PATCH 1/8] Remove DO NOT USE declarations from v4l2_nv_extensions.h
 as they are now present in v4l2-controls.h and conflict
 with the definitions there.
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  include/v4l2_nv_extensions.h | 264 -----------------------------------

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0002-include-fix-jpeglib-header-inclusion.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0002-include-fix-jpeglib-header-inclusion.patch
@@ -5,7 +5,9 @@ Subject: [PATCH 2/8] include: fix jpeglib header inclusion
 
 To ensure that it's using the NVIDIA-specific header.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  include/NvJpegDecoder.h | 2 +-
  include/NvJpegEncoder.h | 2 +-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0003-tools-update-GetPixel.py-to-Python-3.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0003-tools-update-GetPixel.py-to-Python-3.patch
@@ -9,6 +9,7 @@ release.
 
 1: https://github.com/OE4T/meta-tegra/commit/0050144b2973e544237e53ecee65dee85e5cc8f9#diff-9d779250de06e384fc1e77959ef1a11165c69a34de15346d3c592d78f44f2ac9
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>
 ---
  tools/GetPixel.py | 2 +-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch
@@ -7,6 +7,7 @@ Subject: [PATCH 4/8] samples: classes: fix a data race in shutting down
 as well as a couple of other uses of pthread_join with
 a possibly null (and thus invalid) thread id.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  .../common/classes/NvApplicationProfiler.cpp  |  5 +++-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0005-samples-Rework-makefiles-and-rules.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0005-samples-Rework-makefiles-and-rules.patch
@@ -8,6 +8,7 @@ Subject: [PATCH 5/8] samples: Rework makefiles and rules
 * Allow for object detection (opencv/TRT) to be optional
 * Rework references to common classes and algorithms
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0006-trt_inference-use-smart-pointers-during-model-conver.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0006-trt_inference-use-smart-pointers-during-model-conver.patch
@@ -8,6 +8,7 @@ instead of the old, deprecated style of using raw pointers
 and calling the destroy methods of the various interfaces,
 which is causing segfaults.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  .../common/algorithm/trt/trt_inference.cpp    | 34 ++++++-------------

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0007-frontend-add-option-to-set-timeout.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0007-frontend-add-option-to-set-timeout.patch
@@ -6,6 +6,7 @@ Subject: [PATCH 7/8] frontend: add option to set timeout
 instead of requiring a human to type 'q' to quit,
 to allow the sample to be used as an automated test.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  samples/17_frontend/main.cpp | 15 ++++++++++++---

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0008-camera_v4l2_cuda-add-option-for-setting-max-frame-co.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0008-camera_v4l2_cuda-add-option-for-setting-max-frame-co.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 8/8] camera_v4l2_cuda: add option for setting max frame count
 
 to a allow for an automated timed run, instead of interactive.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  samples/12_v4l2_camera_cuda/camera_v4l2_cuda.cpp | 12 +++++++++++-

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc/0001-Build-fixups.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc/0001-Build-fixups.patch
@@ -3,6 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Thu, 16 Jul 2020 07:54:26 -0700
 Subject: [PATCH] Build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 28 ++++++++++++----------------
  1 file changed, 12 insertions(+), 16 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:30:53 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 23 +++++++++++------------
  1 file changed, 11 insertions(+), 12 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0002-Skip-map-frame-in-pad-prepare-to-fix-spurious-warnin.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0002-Skip-map-frame-in-pad-prepare-to-fix-spurious-warnin.patch
@@ -14,6 +14,8 @@ don't contain video data at all, but instead the nvbuffer pointers,
 which are obtained differently.
 
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
+
+Upstream-Status: Pending
 ---
  gstnvcompositor.c | 5 +----
  1 file changed, 1 insertion(+), 4 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:21:47 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 29 ++++++++++++++++-------------
  1 file changed, 16 insertions(+), 13 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0001-Makefile-fixes-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0001-Makefile-fixes-for-OE-builds.patch
@@ -5,6 +5,8 @@ Subject: [PATCH] Makefile fixes for OE builds
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+
+Upstream-Status: Pending
 ---
  Makefile                   | 45 +++++++++++++------
  pre-gen-source_64/config.h |  6 +--

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0002-Fix-builds-without-x11.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles/0002-Fix-builds-without-x11.patch
@@ -4,6 +4,8 @@ Date: Tue, 23 Aug 2022 10:17:08 -0700
 Subject: [PATCH] Fix builds without x11
 
 Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>
+
+Upstream-Status: Pending
 ---
  gst-egl/ext/eglgles/gsteglglessink.c | 2 ++
  1 file changed, 2 additions(+)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg/use-nvjpeg-for-plugin-name.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg/use-nvjpeg-for-plugin-name.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
 Index: gstjpeg_src/gst-jpeg/gst-jpeg-1.0/ext/jpeg/Makefile.am
 ===================================================================
 --- gstjpeg_src/gst-jpeg/gst-jpeg-1.0.orig/ext/jpeg/Makefile.am

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:05:24 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 24 ++++++++++++------------
  1 file changed, 12 insertions(+), 12 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0001-Build-fixups.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0001-Build-fixups.patch
@@ -3,6 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Thu, 16 Jul 2020 06:28:39 -0700
 Subject: [PATCH] Build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 23 ++++++++++-------------
  1 file changed, 10 insertions(+), 13 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0002-Clean-up-compiler-warnings.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0002-Clean-up-compiler-warnings.patch
@@ -4,6 +4,10 @@ Date: Thu, 16 Jul 2020 10:43:09 -0700
 Subject: [PATCH] Clean up compiler warnings
 
 from a compilation pass with -Wall -Wpedantic.
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvv4l2camerasrc.cpp | 18 +++++++-----------
  1 file changed, 7 insertions(+), 11 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv-1.20.5-r35.6.0/0003-Update-allocator-to-use-actual-frame-sizes.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv-1.20.5-r35.6.0/0003-Update-allocator-to-use-actual-frame-sizes.patch
@@ -5,7 +5,9 @@ Subject: [PATCH] Update allocator to use actual frame sizes
 
 rather than the size of the buffer-tracking structure.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvvconv.c | 11 ++++++++---
  1 file changed, 8 insertions(+), 3 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 05:48:15 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 20 +++++++++-----------
  1 file changed, 9 insertions(+), 11 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0002-Use-filter-function-for-fixating-caps.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0002-Use-filter-function-for-fixating-caps.patch
@@ -5,6 +5,9 @@ Subject: [PATCH] Use filter function for fixating caps
 
 To fix SIGSEGVs during caps negotiation.
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvvconv.c | 51 ++++++++++++++++++++++++++++-----------------------
  1 file changed, 28 insertions(+), 23 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 1/7] v4l2videoenc: Fix negotiation caps leak
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
@@ -9,6 +9,7 @@ sized buffer do not cause a warning.
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
@@ -9,6 +9,7 @@ similar to what we do in gst_v4l2_object_unlock().
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0004-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0004-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
@@ -4,6 +4,7 @@ Date: Sun, 8 Nov 2020 01:53:55 +0000
 Subject: [PATCH 4/7] gstv4l2videodec: use ifdef macro for consistency with the
  rest of the code
 
+Upstream-Status: Pending
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0005-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0005-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
@@ -19,6 +19,8 @@ otherwise nvv4l2decoder will hang forever waiting for capture_plane_stopped.
 
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+
+Upstream-Status: Pending
 ---
  gst-v4l2/gstv4l2videodec.c | 15 +++++++++------
  1 file changed, 9 insertions(+), 6 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0006-Fix-resource-leak-in-nvv4l2decoder.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0006-Fix-resource-leak-in-nvv4l2decoder.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 6/7] Fix resource leak in nvv4l2decoder
 
 See: https://forums.developer.nvidia.com/t/175198/11
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0007-Makefile-fixes-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r35.6.0/0007-Makefile-fixes-for-OE-builds.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Thu, 26 Jan 2023 00:06:19 +0000
 Subject: [PATCH 7/7] Makefile fixes for OE builds
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/nvgstapps/0001-Fix-compiler-warnings.patch
+++ b/recipes-multimedia/gstreamer/nvgstapps/0001-Fix-compiler-warnings.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Fri, 17 Jul 2020 05:12:44 -0700
 Subject: [PATCH] Fix compiler warnings
 
+
+Upstream-Status: Pending
 ---
  nvgst_sample_apps/nvgstplayer-1.0/nvgst_asound_common.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/recipes-multimedia/gstreamer/nvgstapps/0002-Fix-stringop-truncation-warning.patch
+++ b/recipes-multimedia/gstreamer/nvgstapps/0002-Fix-stringop-truncation-warning.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Fri, 15 Apr 2022 12:36:09 +0100
 Subject: [PATCH] Fix stringop-truncation warning
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---
  nvgst_sample_apps/nvgstplayer-1.0/nvgstplayer.c | 1 +

--- a/recipes-multimedia/gstreamer/nvgstapps/0003-Fix-indentation-in-nvgstplayer.c.patch
+++ b/recipes-multimedia/gstreamer/nvgstapps/0003-Fix-indentation-in-nvgstplayer.c.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Mon, 13 Dec 2021 05:47:45 -0800
 Subject: [PATCH] Fix indentation in nvgstplayer.c
 
+
+Upstream-Status: Pending
 ---
  nvgst_sample_apps/nvgstplayer-1.0/nvgstplayer.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/recipes-security/optee/optee-client/0001-Update-Makefile-for-OE-compatibility.patch
+++ b/recipes-security/optee/optee-client/0001-Update-Makefile-for-OE-compatibility.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] Update Makefile for OE compatibility
 
 * Use install instead of cp for installing files
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  optee/optee_client/Makefile | 36 ++++++++++++++++++------------------

--- a/recipes-security/optee/optee-nvsamples/0001-Update-makefiles-for-OE-builds.patch
+++ b/recipes-security/optee/optee-nvsamples/0001-Update-makefiles-for-OE-builds.patch
@@ -7,6 +7,7 @@ Subject: [PATCH] Update makefiles for OE builds
 - Use install instead of cp to install host programs
 - Add LDFLAGS to nvhwkey-app build
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---

--- a/recipes-security/optee/optee-os/0002-core-arm.mk-add-fcommon-to-cflags.patch
+++ b/recipes-security/optee/optee-os/0002-core-arm.mk-add-fcommon-to-cflags.patch
@@ -8,6 +8,8 @@ introduces some global variables that require this
 flag, which is on by default in older versions.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  core/arch/arm/arm.mk | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
@@ -19,6 +19,7 @@ https://github.com/intel/luv-yocto/tree/master/meta-luv/recipes-devtools/sbsignt
 
 Corrected typo error and ported to version 0.9.2
 
+Upstream-Status: Inappropriate [Backport]
 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  configure.ac | 7 +++++--

--- a/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
@@ -10,7 +10,7 @@ under /usr/include and /usr/lib.
 Prepend these paths with a placeholder that can be replaced with the
 actual paths once they are resolved.
 
-Upstream status: inappropriate [OE specific]
+Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 
@@ -19,7 +19,6 @@ https://github.com/intel/luv-yocto/tree/master/meta-luv/recipes-devtools/sbsignt
 
 Corrected typo error and ported to version 0.9.2
 
-Upstream-Status: Inappropriate [Backport]
 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  configure.ac | 7 +++++--

--- a/recipes-support/sbsigntool/sbsigntool/0002-fix-openssl-3-0.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0002-fix-openssl-3-0.patch
@@ -9,7 +9,7 @@ only if the `ASN1_ITEM_rptr()` macro is used.
 This change passes `make check` with both openssl 1.1 and 3.0.
 
 Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
-Upstream-status: Submited [https://groups.io/g/sbsigntools/topic/patch_fix_openssl_3_0_issue/85903418]
+Upstream-Status: Submitted [https://groups.io/g/sbsigntools/topic/patch_fix_openssl_3_0_issue/85903418]
 ---
  src/idc.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
Merging this will allow to use meta-tegra in
those DISTROs which already added patch-status into ERROR_QA
before it was enabled by default in Styhead with:
https://git.openembedded.org/openembedded-core/commit/?h=styhead&id=b7fb91c797ab37a029b8dd1eb7277a7468bc97ed

Similar PR for regular scarthgap branch:
https://github.com/OE4T/meta-tegra/pull/1750
one issue left in styhead and master branches:
styhed: https://github.com/OE4T/meta-tegra/pull/1751
master: https://github.com/OE4T/meta-tegra/pull/1752