### PR TITLE
Add Upstream-Status into .patch files even for scarthgap branch

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt/0001-Fixups-for-cross-building-in-OE.patch
@@ -5,6 +5,7 @@ Subject: [PATCH] Fixups for cross building in OE
 
 Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  python/CMakeLists.txt | 5 -----
  1 file changed, 5 deletions(-)

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Mon, 14 Oct 2024 04:13:16 -0700
 Subject: [PATCH] CMakeLists.txt: fix cross compilation issues
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>

--- a/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
+++ b/external/qt5-layer/recipes-qt/qt5/qtbase/0001-eglfs-add-a-default-framebuffer-to-NVIDIA-eglstreams.patch
@@ -10,6 +10,9 @@ the output mode but not issue a page flip.
 This change adds a default framebuffer to the egldevice driver for
 use with the initial calls to set the CRTC mode and plane.
 
+Upstream-Status: Pending
+Signed-off-by: Kurt Kiefer <kurt.kiefer@arthrex.com>
+
 ---
  .../qeglfskmsegldevicescreen.cpp              | 66 +++++++++++++++++--
  .../qeglfskmsegldevicescreen.h                |  3 +

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0001-L4TLauncher-boot-syslinux-instead-of-extlinux-for-os.patch
@@ -7,6 +7,7 @@ Subject: [PATCH 1/3] L4TLauncher: boot syslinux instead of extlinux for ostree
 Ostree uses syslinux.cfg instead of extlinux.conf for providing the
 required kernel/initrd/dtb files for the bootloader.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0002-l4tlauncher-support-booting-otaroot-based-partitions.patch
@@ -7,6 +7,7 @@ Besides looking for the APP part-name (standard in emmc), also look for
 otaroot-based partitions when searching for extlinux configuration. This
 allows the device to boot from OTA-enabled rootfs.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
+++ b/external/sota/recipes-bsp/uefi/edk2-firmware-tegra/0003-l4tlauncher-disable-a-b-rootfs-validation.patch
@@ -10,6 +10,7 @@ clear up the variables).
 This is to avoid forcing the device to boot in recovery after 3 boots
 without confirmation from nvbootctrl.
 
+Upstream-Status: Pending
 Signed-off-by: Ricardo Salveti <ricardo@foundries.io>
 Signed-off-by: Jose Quaresma <jose.quaresma@foundries.io>
 ---

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0001-OE-cross-build-fixups.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0001-OE-cross-build-fixups.patch
@@ -3,6 +3,8 @@ From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Tue, 5 Mar 2024 11:52:33 +0000
 Subject: [PATCH] OE cross-build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+
 Signed-off-by: Pablo Rodriguez Quesada <pablo.rodriguez-quesada@windriver.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-Expose-device-file-attrs.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-Expose-device-file-attrs.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 17 Apr 2022 05:20:32 -0700
 Subject: [PATCH] Expose device file attrs
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  deps/src/nvidia-modprobe-495.44/modprobe-utils/nvidia-modprobe-utils.c | 8 ++++----
  deps/src/nvidia-modprobe-495.44/modprobe-utils/nvidia-modprobe-utils.h | 1 +

--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware/0001-workaround-to-fix-ld.bfd-warning-binutils-version-2..patch
@@ -5,6 +5,7 @@ Subject: [PATCH] workaround to fix ld.bfd warning (binutils version 2.39)
 
 l31.elf has a LOAD segment with RWX permissions
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---
  Makefile | 4 ++--

--- a/recipes-bsp/tegra-binaries/files/0004-Convert-gen_tos_part_img.py-to-Python3.patch
+++ b/recipes-bsp/tegra-binaries/files/0004-Convert-gen_tos_part_img.py-to-Python3.patch
@@ -3,7 +3,7 @@ From: Matt Madison <matt@madison.systems>
 Date: Wed, 22 Jan 2020 06:35:59 -0800
 Subject: [PATCH] Convert gen_tos_part_img.py to Python3
 
-Upstream-Status: Inapproprate [OE specific]
+Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Matt Madison <matt@madison.systems>
 

--- a/recipes-bsp/uefi/files/0002-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch
+++ b/recipes-bsp/uefi/files/0002-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch
@@ -4,6 +4,7 @@ Date: Sat, 12 Oct 2024 06:43:52 -0700
 Subject: [PATCH] L4TLauncher: allow for empty/missing APPEND line in
  extlinux.conf
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  .../Application/L4TLauncher/L4TLauncher.c     | 30 ++++++++++---------

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0001-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0001-CVE-2021-35465.patch
@@ -20,7 +20,7 @@ gcc:
 	the command line.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3929bca9ca95de9d35e82ae8828b188029e3eb70]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=3929bca9ca95de9d35e82ae8828b188029e3eb70]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0002-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0002-CVE-2021-35465.patch
@@ -15,7 +15,7 @@ libgcc:
 	Add vlldm erratum work-around.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=574e7950bd6b34e9e2cacce18c802b45505d1d0a]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=574e7950bd6b34e9e2cacce18c802b45505d1d0a]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0003-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0003-CVE-2021-35465.patch
@@ -16,7 +16,7 @@ gcc:
 	use when erratum mitigation is needed.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=30461cf8dba3d3adb15a125e4da48800eb2b9b8f]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=30461cf8dba3d3adb15a125e4da48800eb2b9b8f]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-64-bit-multilib-hack.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-64-bit-multilib-hack.patch
@@ -23,7 +23,7 @@ Do same for riscv64 and aarch64
 
 RP 15/8/11
 
-Upstream-Status: Inappropriate[OE-Specific]
+Upstream-Status: Inappropriate [OE-Specific]
 
 Signed-off-by: Khem Raj <raj.khem@gmail.com>
 Signed-off-by: Elvis Dowson <elvis.dowson@gmail.com>

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-CVE-2021-35465.patch
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc/0004-CVE-2021-35465.patch
@@ -17,7 +17,7 @@ gcc/testsuite:
 	* gcc.target/arm/cmse/mainline/8_1m/softfp/cmse-8a.c: Likewise.
 
 CVE: CVE-2021-35465
-Upstream-Status: Backport[https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=809330ab8450261e05919b472783bf15e4b000f7]
+Upstream-Status: Backport [https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=809330ab8450261e05919b472783bf15e4b000f7]
 Signed-off-by: Pgowda <pgowda.cve@gmail.com>
 
 ---

--- a/recipes-graphics/mesa/egl-gbm/0001-gbm-display-handle-kms-display-only-devices-in-FindG.patch
+++ b/recipes-graphics/mesa/egl-gbm/0001-gbm-display-handle-kms-display-only-devices-in-FindG.patch
@@ -14,7 +14,7 @@ returned by eglQueryDevices in the case where the display device
 in question can't render on its own or isn't being returned by
 the egl implementation for any other reason.
 
-Upstream-Status: pending
+Upstream-Status: Pending
 
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
 ---

--- a/recipes-graphics/wayland/egl-wayland/0001-Fix-wayland-eglstream-protocols-pc-file.patch
+++ b/recipes-graphics/wayland/egl-wayland/0001-Fix-wayland-eglstream-protocols-pc-file.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Sat, 2 Feb 2019 06:59:41 -0800
 Subject: [PATCH] Fix wayland-eglstream-protocols pc file
 
+Upstream-Status: Pending
+Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  wayland-eglstream-protocols.pc.in | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)

--- a/recipes-kernel/kern-tools/kern-tools-tegra/0001-Add-kernel-overlays-support-to-kconfiglib.patch
+++ b/recipes-kernel/kern-tools/kern-tools-tegra/0001-Add-kernel-overlays-support-to-kconfiglib.patch
@@ -3,6 +3,8 @@ From: Matt Madison <matt@madison.systems>
 Date: Sat, 8 Aug 2020 08:48:13 -0700
 Subject: [PATCH] Add kernel overlays support to kconfiglib
 
+
+Upstream-Status: Pending
 ---
  Kconfiglib/kconfiglib.py | 51 ++++++++++++++++++++++++++++++++++++++--
  1 file changed, 49 insertions(+), 2 deletions(-)

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Fix-nvdisplay-modules-builds.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0002-Fix-nvdisplay-modules-builds.patch
@@ -8,6 +8,8 @@ that headers and symbols from the out-of-tree drivers can
 be found when building the display driver modules.
 
 Signed-off-by: Matt Madison <matt@madison.systems>
+
+Upstream-Status: Pending
 ---
  Makefile                          |  1 +
  nvdisplay/kernel-open/Kbuild      | 15 ++++++++-------

--- a/recipes-multimedia/argus/argus-samples/0001-argus-apps-camera-replace-xxd-invocation-with-shell-.patch
+++ b/recipes-multimedia/argus/argus-samples/0001-argus-apps-camera-replace-xxd-invocation-with-shell-.patch
@@ -7,6 +7,7 @@ The xxd command is part of vim, which isn't really a build
 tool.  Use a shell script to perform the header file creation
 instead.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  argus/apps/camera/ui/camera/CMakeLists.txt | 3 ++-

--- a/recipes-multimedia/argus/files/0001-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch
+++ b/recipes-multimedia/argus/files/0001-Remove-DO-NOT-USE-declarations-from-v4l2_nv_extensio.patch
@@ -6,6 +6,7 @@ Subject: [PATCH 1/9] Remove DO NOT USE declarations from v4l2_nv_extensions.h
 as they are now present in v4l2-controls.h and conflict
 with the definitions there.
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0002-include-fix-jpeglib-header-inclusion.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0002-include-fix-jpeglib-header-inclusion.patch
@@ -5,7 +5,9 @@ Subject: [PATCH 2/8] include: fix jpeglib header inclusion
 
 To ensure that it's using the NVIDIA-specific header.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  include/NvJpegDecoder.h | 2 +-
  include/NvJpegEncoder.h | 2 +-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0003-tools-update-GetPixel.py-to-Python-3.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0003-tools-update-GetPixel.py-to-Python-3.patch
@@ -9,6 +9,7 @@ release.
 
 1: https://github.com/OE4T/meta-tegra/commit/0050144b2973e544237e53ecee65dee85e5cc8f9#diff-9d779250de06e384fc1e77959ef1a11165c69a34de15346d3c592d78f44f2ac9
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>
 ---
  tools/GetPixel.py | 2 +-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0004-samples-classes-fix-a-data-race-in-shutting-down-deq.patch
@@ -7,6 +7,7 @@ Subject: [PATCH 4/8] samples: classes: fix a data race in shutting down
 as well as a couple of other uses of pthread_join with
 a possibly null (and thus invalid) thread id.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  .../common/classes/NvApplicationProfiler.cpp  |  5 +++-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0005-samples-Rework-makefiles-and-rules.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0005-samples-Rework-makefiles-and-rules.patch
@@ -8,6 +8,7 @@ Subject: [PATCH 5/8] samples: Rework makefiles and rules
 * Allow for object detection (opencv/TRT) to be optional
 * Rework references to common classes and algorithms
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0007-frontend-add-option-to-set-timeout.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0007-frontend-add-option-to-set-timeout.patch
@@ -6,6 +6,7 @@ Subject: [PATCH 7/8] frontend: add option to set timeout
 instead of requiring a human to type 'q' to quit,
 to allow the sample to be used as an automated test.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  samples/17_frontend/main.cpp | 15 ++++++++++++---

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0008-camera_v4l2_cuda-add-option-for-setting-max-frame-co.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0008-camera_v4l2_cuda-add-option-for-setting-max-frame-co.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 8/8] camera_v4l2_cuda: add option for setting max frame count
 
 to a allow for an automated timed run, instead of interactive.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 ---
  samples/12_v4l2_camera_cuda/camera_v4l2_cuda.cpp | 12 +++++++++++-

--- a/recipes-multimedia/argus/tegra-mmapi-samples/0010-NvJpegDecoder-remove-unused-header-file.patch
+++ b/recipes-multimedia/argus/tegra-mmapi-samples/0010-NvJpegDecoder-remove-unused-header-file.patch
@@ -4,6 +4,8 @@ Date: Tue, 21 Nov 2023 09:09:10 +0000
 Subject: [PATCH 10/10] NvJpegDecoder: remove unused header file
 
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+
+Upstream-Status: Pending
 ---
  samples/common/classes/NvJpegDecoder.cpp | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc/0001-Build-fixups.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc/0001-Build-fixups.patch
@@ -3,6 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Thu, 16 Jul 2020 07:54:26 -0700
 Subject: [PATCH] Build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 28 ++++++++++++----------------
  1 file changed, 12 insertions(+), 16 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:30:53 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 23 +++++++++++------------
  1 file changed, 11 insertions(+), 12 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvdrmvideosink/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:21:47 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 29 ++++++++++++++++-------------
  1 file changed, 16 insertions(+), 13 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg/use-nvjpeg-for-plugin-name.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvjpeg/use-nvjpeg-for-plugin-name.patch
@@ -1,3 +1,5 @@
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
 Index: gstjpeg_src/gst-jpeg/gst-jpeg-1.0/ext/jpeg/Makefile.am
 ===================================================================
 --- gstjpeg_src/gst-jpeg/gst-jpeg-1.0.orig/ext/jpeg/Makefile.am

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvtee/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 06:05:24 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 24 ++++++++++++------------
  1 file changed, 12 insertions(+), 12 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0001-Build-fixups.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0001-Build-fixups.patch
@@ -3,6 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Thu, 16 Jul 2020 06:28:39 -0700
 Subject: [PATCH] Build fixups
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 23 ++++++++++-------------
  1 file changed, 10 insertions(+), 13 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0002-Clean-up-compiler-warnings.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc/0002-Clean-up-compiler-warnings.patch
@@ -4,6 +4,10 @@ Date: Thu, 16 Jul 2020 10:43:09 -0700
 Subject: [PATCH] Clean up compiler warnings
 
 from a compilation pass with -Wall -Wpedantic.
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvv4l2camerasrc.cpp | 18 +++++++-----------
  1 file changed, 7 insertions(+), 11 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv-1.20.5-r36.4.0/0003-Update-allocator-to-use-actual-frame-sizes.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv-1.20.5-r36.4.0/0003-Update-allocator-to-use-actual-frame-sizes.patch
@@ -5,7 +5,9 @@ Subject: [PATCH] Update allocator to use actual frame sizes
 
 rather than the size of the buffer-tracking structure.
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvvconv.c | 11 ++++++++---
  1 file changed, 8 insertions(+), 3 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0001-Update-makefile-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0001-Update-makefile-for-OE-builds.patch
@@ -3,7 +3,9 @@ From: Matt Madison <matt@madison.systems>
 Date: Sun, 31 Jan 2021 05:48:15 -0800
 Subject: [PATCH] Update makefile for OE builds
 
+Upstream-Status: Inappropriate [OE-specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  Makefile | 20 +++++++++-----------
  1 file changed, 9 insertions(+), 11 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0002-Use-filter-function-for-fixating-caps.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv/0002-Use-filter-function-for-fixating-caps.patch
@@ -5,6 +5,9 @@ Subject: [PATCH] Use filter function for fixating caps
 
 To fix SIGSEGVs during caps negotiation.
 
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Matt Madison <matt@madison.systems>
+
 ---
  gstnvvconv.c | 51 ++++++++++++++++++++++++++++-----------------------
  1 file changed, 28 insertions(+), 23 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0001-v4l2videoenc-Fix-negotiation-caps-leak.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 1/7] v4l2videoenc: Fix negotiation caps leak
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0002-v4l2allocator-Fix-data-offset-bytesused-size-validat.patch
@@ -9,6 +9,7 @@ sized buffer do not cause a warning.
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0003-v4l2bufferpool-Avoid-set_flushing-warning.patch
@@ -9,6 +9,7 @@ similar to what we do in gst_v4l2_object_unlock().
 
 Part-of: <https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649>
 
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gst-plugins-good/-/merge_requests/649]
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0004-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0004-gstv4l2videodec-use-ifdef-macro-for-consistency-with.patch
@@ -4,6 +4,7 @@ Date: Fri, 17 Nov 2023 12:57:10 +0000
 Subject: [PATCH 4/7] gstv4l2videodec: use ifdef macro for consistency with the
   rest of the code
 
+Upstream-Status: Pending
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0005-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0005-gstv4l2videodec-check-if-we-have-a-pool-before-the-l.patch
@@ -19,6 +19,8 @@ otherwise nvv4l2decoder will hang forever waiting for capture_plane_stopped.
 
 Signed-off-by: Jose Quaresma <quaresma.jose@gmail.com>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
+
+Upstream-Status: Pending
 ---
  gstv4l2videodec.c | 15 +++++++++------
  1 file changed, 9 insertions(+), 6 deletions(-)

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0006-Fix-resource-leak-in-nvv4l2decoder.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0006-Fix-resource-leak-in-nvv4l2decoder.patch
@@ -5,6 +5,7 @@ Subject: [PATCH 6/7] Fix resource leak in nvv4l2decoder
 
 See: https://forums.developer.nvidia.com/t/175198/11
 
+Upstream-Status: Pending
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0007-Makefile-fixes-for-OE-builds.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2-1.14.0-r36.4.0/0007-Makefile-fixes-for-OE-builds.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ichergui@nvidia.com>
 Date: Fri, 17 Nov 2023 13:00:06 +0000
 Subject: [PATCH 7/7] Makefile fixes for OE builds
 
+Upstream-Status: Inappropriate [OE-Specific]
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---

--- a/recipes-multimedia/gstreamer/nvgstapps/0002-Fix-stringop-truncation-warning.patch
+++ b/recipes-multimedia/gstreamer/nvgstapps/0002-Fix-stringop-truncation-warning.patch
@@ -3,6 +3,7 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Fri, 15 Apr 2022 12:36:09 +0100
 Subject: [PATCH] Fix stringop-truncation warning
 
+Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 ---
  nvgst_sample_apps/nvgstplayer-1.0/nvgstplayer.c | 1 +

--- a/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
@@ -19,6 +19,7 @@ https://github.com/intel/luv-yocto/tree/master/meta-luv/recipes-devtools/sbsignt
 
 Corrected typo error and ported to version 0.9.2
 
+Upstream-Status: Inappropriate [Backport]
 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  configure.ac | 7 +++++--

--- a/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
@@ -10,7 +10,7 @@ under /usr/include and /usr/lib.
 Prepend these paths with a placeholder that can be replaced with the
 actual paths once they are resolved.
 
-Upstream status: inappropriate [OE specific]
+Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 
@@ -19,7 +19,6 @@ https://github.com/intel/luv-yocto/tree/master/meta-luv/recipes-devtools/sbsignt
 
 Corrected typo error and ported to version 0.9.2
 
-Upstream-Status: Inappropriate [Backport]
 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  configure.ac | 7 +++++--

--- a/recipes-support/sbsigntool/sbsigntool/0002-fix-openssl-3-0.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0002-fix-openssl-3-0.patch
@@ -9,7 +9,7 @@ only if the `ASN1_ITEM_rptr()` macro is used.
 This change passes `make check` with both openssl 1.1 and 3.0.
 
 Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
-Upstream-status: Submited [https://groups.io/g/sbsigntools/topic/patch_fix_openssl_3_0_issue/85903418]
+Upstream-Status: Submitted [https://groups.io/g/sbsigntools/topic/patch_fix_openssl_3_0_issue/85903418]
 ---
  src/idc.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)


### PR DESCRIPTION
Merging this will allow to use meta-tegra in
those DISTROs which already added patch-status into ERROR_QA
before it was enabled by default in Styhead with:
https://git.openembedded.org/openembedded-core/commit/?h=styhead&id=b7fb91c797ab37a029b8dd1eb7277a7468bc97ed