### PR TITLE
sbsigntool: Fix Upstream-Status format

### DIFF
--- a/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
+++ b/recipes-support/sbsigntool/sbsigntool/0001-configure-Fixup-build-dependencies-for-cross-compili.patch
@@ -10,7 +10,7 @@ under /usr/include and /usr/lib.
 Prepend these paths with a placeholder that can be replaced with the
 actual paths once they are resolved.
 
-Upstream status: inappropriate [OE specific]
+Upstream-Status: Inappropriate [OE specific]
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 
@@ -19,7 +19,6 @@ https://github.com/intel/luv-yocto/tree/master/meta-luv/recipes-devtools/sbsignt
 
 Corrected typo error and ported to version 0.9.2
 
-Upstream-Status: Inappropriate [Backport]
 Signed-off-by: Naveen Saini <naveen.kumar.saini@intel.com>
 ---
  configure.ac | 7 +++++--


### PR DESCRIPTION
* drop the one which says 'Inappropriate [Backport]' as it's either Backport or Inappropriate, but cannot be both