### PR TITLE
tegra-uefi-capsules: add dependency on lz4-native

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.4.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.4.0.bb
@@ -95,7 +95,7 @@ addtask deploy after do_install
 
 do_compile[depends] += "${@bup_dependency(d)} ${TEGRA_UEFI_CAPSULE_SIGNING_EXTRA_DEPS}"
 do_compile[depends] += "virtual/kernel:do_deploy tegra-flashtools-native:do_populate_sysroot dtc-native:do_populate_sysroot"
-do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot"
+do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot lz4-native:do_populate_sysroot"
 do_compile[depends] += "tegra-bootfiles:do_populate_sysroot"
 do_compile[depends] += "coreutils-native:do_populate_sysroot virtual/secure-os:do_deploy"
 do_compile[depends] += "virtual/bootloader:do_deploy"


### PR DESCRIPTION
* HOSTTOOLS is now using lz4 instead of lz4c since: https://git.openembedded.org/openembedded-core/commit/?id=fe167e082cbde1c6d186ecdda531abef610ac2ac and tegra-uefi-capsules do_compile is failing with: tegra-uefi-capsules/35.6.0/recipe-sysroot-native/usr/lib/python3.13/subprocess.py", line 1966, in _execute_child raise child_exception_type(errno_num, err_msg, err_filename) FileNotFoundError: [Errno 2] No such file or directory: 'lz4c' tegra-uefi-capsules/35.6.0/temp/run.do_compile.2229307:369 exit 1 from './doflash.sh'

* I've seen this only with scarthgap-l4t-r35.x branch modified to build for walnascar (master), but it looks like the same is needed in master branch (which has surprisingly to me older version 36.4.0 while scarthgap-l4t-r35.x has 36.6.0, but I don't really use any nvidia MACHINEs, only sometimes building world for them, so maybe it's expected)