### PR TITLE
Add Minimal UEFI support

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -14,7 +14,9 @@ UBOOT_EXTLINUX_INITRD ?= "${@'/boot/initrd' if d.getVar('INITRAMFS_IMAGE') != ''
 
 NVIDIA_BOARD ?= "generic"
 
-TEGRA_BOOTCONTROL_OVERLAYS ?= "L4TConfiguration.dtbo"
+TEGRA_UEFI_MINIMAL ?= "0"
+TEGRA_BOOTCONTROL_MINIMAL_UEFI ?= "${@'BootOrderEmmc.dtbo' if bb.utils.to_boolean(d.getVar('TEGRA_UEFI_MINIMAL')) else ''}"
+TEGRA_BOOTCONTROL_OVERLAYS ?= "L4TConfiguration.dtbo ${TEGRA_BOOTCONTROL_MINIMAL_UEFI}"
 TEGRA_BOOTCONTROL_OVERLAYS += "${@'L4TConfiguration-RootfsRedundancyLevelABEnable.dtbo' if bb.utils.to_boolean(d.getVar('USE_REDUNDANT_FLASH_LAYOUT')) else ''}"
 TEGRA_PLUGIN_MANAGER_OVERLAYS ??= ""
 TEGRA_DCE_OVERLAYS ??= ""

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.init.in
@@ -6,9 +6,6 @@ case "$1" in
   start|restart)
       echo -n "Running $DESC: "
       mkdir -p -m0755 /run/nv_boot_control
-      if ! mountpoint -q @ESPMOUNT@; then
-	  mount -t vfat /dev/disk/by-partlabel/esp @ESPMOUNT@
-      fi
       @bindir@/setup-nv-boot-control
       echo "[OK]"
       ;;

--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.service.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.service.in
@@ -2,7 +2,6 @@
 Description=Set up redundant boot configuration
 DefaultDependencies=no
 Before=nv_update_verifier.service
-RequiresMountsFor=@ESPMOUNT@
 
 [Service]
 RuntimeDirectory=nv_boot_control

--- a/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/uefi_common.func.in
@@ -1,5 +1,4 @@
 #!/bin/sh
-ESPMOUNT="@ESPMOUNT@"
 
 fab=
 boardsku=

--- a/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
+++ b/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
@@ -28,13 +28,10 @@ do_compile() {
         -e's,@BOOTDEV@,${TNSPEC_BOOTDEV},g' \
         -e's,@sysconfdir@,${sysconfdir},g' \
         ${S}/setup-nv-boot-control.sh.in >${B}/setup-nv-boot-control.sh
-    sed -e's,@ESPMOUNT@,${ESPMOUNT},g' \
-        ${S}/uefi_common.func.in >${B}/uefi_common.func
+    cp ${S}/uefi_common.func.in ${B}/uefi_common.func
     sed -e's,@bindir@,${bindir},g' \
-        -e's,@ESPMOUNT@,${ESPMOUNT},g' \
         ${S}/setup-nv-boot-control.service.in >${B}/setup-nv-boot-control.service
     sed -e's,@bindir@,${bindir},g' \
-        -e's,@ESPMOUNT@,${ESPMOUNT},g' \
         ${S}/setup-nv-boot-control.init.in >${B}/setup-nv-boot-control.init
     sed -e's,@ESPMOUNT@,${ESPMOUNT},g' \
         ${S}/esp.mount.in >${B}/${ESPMOUNTUNIT}

--- a/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
@@ -76,10 +76,16 @@ do_compile[dirs] =+ "${B}/nvidia-config/Jetson"
 
 PACKAGES_PATH = "${@nvidia_edk2_packages_path(d)}"
 
+TEGRA_UEFI_MINIMAL ??= "0"
+def nvidia_edk2_build_ids(d):
+    if bb.utils.to_boolean(d.getVar('TEGRA_UEFI_MINIMAL')):
+        return "-D BUILD_GUID=f98bcf32-fd20-4ba9-ada4-e0406947ca3c -DBUILD_NAME=JetsonMinimal"
+    else:
+        return "-D BUILD_GUID=49a79a15-8f69-4be7-a30c-a172f44abce7 -DBUILD_NAME=Jetson"
+
 # BUILD_* taken from Silicon/NVIDIA/edk2nv/stuart/settings.py and
 #                    builder.py, plus Platform/NVIDIA/Jetson/PlatformBuild.py
-EDK2_EXTRA_BUILD = '-D "BUILDID_STRING=v${PV}" -D "BUILD_DATE_TIME=${@format_build_date(d)}" -D "BUILD_PROJECT_TYPE=EDK2" \
-                    -D BUILD_GUID=49a79a15-8f69-4be7-a30c-a172f44abce7 -DBUILD_NAME=Jetson'
+EDK2_EXTRA_BUILD = '-D "BUILDID_STRING=v${PV}" -D "BUILD_DATE_TIME=${@format_build_date(d)}" -D "BUILD_PROJECT_TYPE=EDK2" ${@nvidia_edk2_build_ids(d)}'
 
 def format_build_date(d):
     import datetime


### PR DESCRIPTION
Adds support for the [minimal UEFI](https://docs.nvidia.com/jetson/archives/r36.4/DeveloperGuide/SD/Bootloader/UEFI.html#building-the-miniuefi) configuration.

Also updates the flash helper script to do 'sparse' updates of the SPI flash by default, which is handy for testing UEFI builds.