### PR TITLE
libdrm: move dependency on nvidia-drm out of weston-init

### DIFF
--- a/recipes-graphics/drm/libdrm_%.bbappend
+++ b/recipes-graphics/drm/libdrm_%.bbappend
@@ -1,1 +1,3 @@
+PACKAGE_ARCH:tegra = "${TEGRA_PKGARCH}"
+
 RRECOMMENDS:${PN}:tegra = "kernel-module-nvidia-drm nvidia-drm-loadconf"

--- a/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf/nvidia-drm-modprobe.conf
+++ b/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf/nvidia-drm-modprobe.conf
@@ -1,1 +1,0 @@
-options nvidia-drm modeset=1 fbdev=1

--- a/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf/nvidia-drm-modprobe.conf.in
+++ b/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf/nvidia-drm-modprobe.conf.in
@@ -1,0 +1,1 @@
+options nvidia-drm modeset=@MODESET@ fbdev=@FBDEV@

--- a/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf_1.0.bb
+++ b/recipes-kernel/nvidia-drm-loadconf/nvidia-drm-loadconf_1.0.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "\
-    file://nvidia-drm-modprobe.conf \
+    file://nvidia-drm-modprobe.conf.in \
 "
 
 S = "${WORKDIR}/sources"
@@ -11,8 +11,25 @@ UNPACKDIR = "${S}"
 
 COMPATIBLE_MACHINE = "(tegra234)"
 
+# enable modesetting and fbdev support by default
+NVIDIA_DRM_MODESET ?= "1"
+NVIDIA_DRM_FBDEV ?= "1"
+
+do_compile() {
+    sed -e 's,@MODESET@,${NVIDIA_DRM_MODESET},' \
+        -e 's,@FBDEV@,${NVIDIA_DRM_FBDEV},' \
+        ${S}/nvidia-drm-modprobe.conf.in > ${B}/nvidia-drm-modprobe.conf
+}
+
 do_install() {
     install -d ${D}${sysconfdir}/modprobe.d ${D}${sysconfdir}/modules-load.d
-    install -m 0644 ${UNPACKDIR}/nvidia-drm-modprobe.conf ${D}${sysconfdir}/modprobe.d/nvidia-drm.conf
+    install -m 0644 ${B}/nvidia-drm-modprobe.conf ${D}${sysconfdir}/modprobe.d/nvidia-drm.conf
     echo "nvidia-drm" > ${D}${sysconfdir}/modules-load.d/nvidia-drm.conf
 }
+
+PACKAGES =+ "${PN}-modeset"
+FILES:${PN}-modeset = "${sysconfdir}/modprobe.d"
+RRECOMMENDS:${PN} = "${PN}-modeset"
+
+# if modesetting was enabled at build time, don't include the modprobe conf at runtime alongside nvidia's XSERVER packages
+RCONFLICTS:${PN}-modeset = "xserver-xorg-video-nvidia"


### PR DESCRIPTION
The nvidia-drm kernel module and associated load config are needed by libdrm but were only getting picked up by weston-init.

There are valid configurations (headless, egl-only) that need libdrm but do not pull in weston, so the runtime recommendation is moved to the libdrm bbappend.