### PR TITLE
nvidia-l4t-optee: update libteec version

### DIFF
--- a/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.4.0.bb
+++ b/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.4.0.bb
@@ -27,14 +27,14 @@ PROVIDES += "optee-client optee-test optee-nvsamples"
 do_install() {
     install -d ${D}${libdir} ${D}${libdir}/tee-supplicant/plugins
     install -m 0644 ${S}/usr/lib/libckteec.so.0.1.0 ${D}${libdir}
-    install -m 0644 ${S}/usr/lib/libteec.so.1.0.0 ${D}${libdir}
+    install -m 0644 ${S}/usr/lib/libteec.so.2.0.0 ${D}${libdir}
     install -m 0644 ${S}/usr/lib/libteeacl.so.0.1.0 ${D}${libdir}
     ln -s libckteec.so.0.1.0 ${D}${libdir}/libckteec.so.0.1
     ln -s libckteec.so.0.1 ${D}${libdir}/libckteec.so.0
     ln -s libckteec.so.0 ${D}${libdir}/libckteec.so
-    ln -s libteec.so.1.0.0 ${D}${libdir}/libteec.so.1.0
-    ln -s libteec.so.1.0.0 ${D}${libdir}/libteec.so.1
-    ln -s libteec.so.1 ${D}${libdir}/libteec.so
+    ln -s libteec.so.2.0.0 ${D}${libdir}/libteec.so.2.0
+    ln -s libteec.so.2.0.0 ${D}${libdir}/libteec.so.2
+    ln -s libteec.so.2 ${D}${libdir}/libteec.so
     ln -s libteeacl.so.0.1.0 ${D}${libdir}/libteeacl.so.0.1
     ln -s libteeacl.so.0.1 ${D}${libdir}/libteeacl.so.0
     ln -s libteeacl.so.0 ${D}${libdir}/libteeacl.so


### PR DESCRIPTION
File in `meta-tegra/recipes-bsp/tegra-binaries/nvidia-l4t-optee_36.4.0.bb` contains wrong references to new version of `libteec`

Error:
```
| install: cannot stat 'build/tmp-glibc/work/armv8a_tegra-oe-linux/nvidia-l4t-optee/36.4.0-20240912212859/nvidia-l4t-optee-36.4.0-20240912212859/usr/lib/libteec.so.1.0.0': No such file or directory
```

Here is the new content of `nvidia-l4t-optee` for `36.4.0`
```
libckteec.so -> libckteec.so.0
libckteec.so.0 -> libckteec.so.0.1
libckteec.so.0.1 -> libckteec.so.0.1.0
libckteec.so.0.1.0
libteeacl.so -> libteeacl.so.0
libteeacl.so.0 -> libteeacl.so.0.1
libteeacl.so.0.1 -> libteeacl.so.0.1.0
libteeacl.so.0.1.0
libteec.so -> libteec.so.2
libteec.so.2 -> libteec.so.2.0.0
libteec.so.2.0 -> libteec.so.2.0.0
libteec.so.2.0.0
```

@ichergui created a new PR for master, not sure if it was what you were expecting