### PR TITLE
edk2-firmware-tegra: backport fix for compiler builtins

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0001-Update-tools_def.template-for-toolchain-differences.patch \
     file://0002-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch;patchdir=../edk2-nvidia \
     file://0003-XusbControllerDxe-use-BaseMemoryLib-functions.patch;patchdir=../edk2-nvidia \
+    file://0004-MdePkg-Base.h-handle-builtins-when-using-undef-flag.patch;patchdir=../edk2 \
 "
 
 S = "${WORKDIR}/edk2-tegra/edk2"

--- a/recipes-bsp/uefi/files/0004-MdePkg-Base.h-handle-builtins-when-using-undef-flag.patch
+++ b/recipes-bsp/uefi/files/0004-MdePkg-Base.h-handle-builtins-when-using-undef-flag.patch
@@ -1,0 +1,31 @@
+From 534f4b42e9821434448c1609f31253b1749062a0 Mon Sep 17 00:00:00 2001
+From: Jan Kircher <jan.kircher@leica-microsystems.com>
+Date: Thu, 5 Dec 2024 15:22:58 +0100
+Subject: [PATCH 1/1] MdePkg/Base.h: handle builtins when using -undef flag
+
+
+Upstream-Status: Pending
+
+---
+ MdePkg/Include/Base.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/MdePkg/Include/Base.h b/MdePkg/Include/Base.h
+index e02970a052..7caebbeb1f 100644
+
+Upstream-Status: Pending
+
+--- a/MdePkg/Include/Base.h
++++ b/MdePkg/Include/Base.h
+@@ -59,7 +59,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
+ /// up to the compiler to remove any code past that point.
+ ///
+ #define UNREACHABLE()  __builtin_unreachable ()
+-  #elif defined (__has_feature)
++  #elif defined (__has_builtin) && defined (__has_feature)
+     #if __has_builtin (__builtin_unreachable)
+ ///
+ /// Signal compilers and analyzers that this call is not reachable.  It is
+-- 
+2.47.0
+


### PR DESCRIPTION
We are currently facing some build issues with edk2-firmware-tegra:

```text
2024-11-12 00:12:19 - INFO     - | In file included from /opt/buildagent/work/343f6ef63a466a7c/build/tmp/work/jetson_agx_orin_orito-lms-linux/edk2-firmware-tegra/36.4.0/build/Build/Jetson/RELEASE_GCC5/AARCH64/Silicon/NVIDIA/Tegra/DeviceTree/DeviceTree/DEBUG/AutoGen.h:16,
2024-11-12 00:12:19 - INFO     - |                  from <command-line>:
2024-11-12 00:12:19 - INFO     - | /opt/buildagent/work/343f6ef63a466a7c/build/tmp/work/jetson_agx_orin_orito-lms-linux/edk2-firmware-tegra/36.4.0/edk2-tegra/edk2/MdePkg/Include/Base.h:63:23: error: missing binary operator before token "("
2024-11-12 00:12:19 - INFO     - |    63 |     #if __has_builtin (__builtin_unreachable)
2024-11-12 00:12:19 - INFO     - |       |                       ^
```

I copied the fix from [upstream EDK II](https://github.com/tianocore/edk2/commit/57a890fd03356350a1b7a2a0064c8118f44e9958).