### PR TITLE
tegra-binaries: refactor per-SoC vs. common deb package handling

### DIFF
--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_36.4.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_36.4.0.bb
@@ -10,6 +10,7 @@ DEPENDS = "\
 "
 
 L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-gstreamer"
+L4T_DEB_IS_COMMON = "1"
 
 require tegra-debian-libraries-common.inc
 

--- a/recipes-bsp/tegra-binaries/tegra-debian-libraries-common.inc
+++ b/recipes-bsp/tegra-binaries/tegra-debian-libraries-common.inc
@@ -1,15 +1,23 @@
-HOMEPAGE = "https://developer.nvidia.com/embedded"
+HOMEPAGE = "https://developer.nvidia.com/embedded-computing"
 LICENSE = "Proprietary"
 
 L4T_DEB_COPYRIGHT_MD5 ??= ""
 L4T_DEB_TRANSLATED_BPN ?= "${@d.getVar('BPN').replace('tegra-libraries-', 'nvidia-l4t-')}"
 LIC_FILES_CHKSUM = "file://usr/share/doc/${L4T_DEB_TRANSLATED_BPN}/copyright;md5=${L4T_DEB_COPYRIGHT_MD5}"
+L4T_DEB_IS_COMMON ?= "0"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
 inherit l4t_deb_pkgfeed
 
-SRC_SOC_DEBS = "${@l4t_deb_pkgname(d, d.getVar('L4T_DEB_TRANSLATED_BPN'))};subdir=${BP};name=main"
+def format_deb_uri(d, do_common):
+    is_common = bb.utils.to_boolean(d.getVar('L4T_DEB_IS_COMMON'))
+    if do_common == is_common:
+        return l4t_deb_pkgname(d, d.getVar('L4T_DEB_TRANSLATED_BPN')) + ";subdir=${BP};name=main"
+    return ""
+
+SRC_SOC_DEBS = "${@format_deb_uri(d, False)}"
+SRC_COMMON_DEBS = "${@format_deb_uri(d, True)}"
 SRC_URI[main.sha256sum] = "${MAINSUM}"
 
 PV = "${L4T_VERSION}${@l4t_bsp_debian_version_suffix(d)}"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-dla-compiler_36.4.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-dla-compiler_36.4.0.bb
@@ -1,38 +1,16 @@
 SUMMARY = "NVIDIA DLA Compiler"
-HOMEPAGE = "http://developer.nvidia.com/jetson"
-LICENSE = "Proprietary"
-LIC_FILES_CHKSUM = "file://usr/share/doc/nvidia-l4t-dla-compiler/copyright;md5=45d9a257d98fb290f71e4f5f87f805b4"
+L4T_DEB_COPYRIGHT_MD5 = "45d9a257d98fb290f71e4f5f87f805b4"
 
-inherit l4t_deb_pkgfeed
+L4T_DEB_IS_COMMON = "1"
 
-SRC_COMMON_DEBS = "nvidia-l4t-dla-compiler_${PV}_arm64.deb;subdir=${BPN}"
-PV .= "${@l4t_bsp_debian_version_suffix(d, pkgname='nvidia-l4t-dla-compiler')}"
+require tegra-debian-libraries-common.inc
 
-SRC_URI[sha256sum] = "31cd17e859590332c17e26ed0b6d3ca4dce604a366b5b724cad89a08fd1b368a"
+MAINSUM = "31cd17e859590332c17e26ed0b6d3ca4dce604a366b5b724cad89a08fd1b368a"
 
-COMPATIBLE_MACHINE = "(tegra)"
-PACKAGE_ARCH = "${TEGRA_PKGARCH}"
-
-S = "${WORKDIR}/${BPN}"
-B = "${S}"
-
-COMPATIBLE_MACHINE = "(tegra)"
-
-do_configure() {
-    :
-}
-
-do_compile() {
-    :
-}
-
-do_install() {
-    install -d ${D}${libdir}
-    install -m 0644 usr/lib/aarch64-linux-gnu/nvidia/libnvdla_compiler.so ${D}${libdir}
-}
-
-RDEPENDS:${PN} = "tegra-libraries-core"
+TEGRA_LIBRARIES_TO_INSTALL = "\
+    nvidia/libnvdla_compiler.so \
+"
 
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
-INSANE_SKIP:${PN} = "already-stripped"
+RDEPENDS:${PN} = "tegra-libraries-core"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-nvdsseimeta_36.4.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-nvdsseimeta_36.4.0.bb
@@ -4,6 +4,7 @@ L4T_DEB_COPYRIGHT_MD5 = "20bbd485b9b57fbc0b55d6efc08e3f4a"
 DEPENDS = "glib-2.0 gstreamer1.0"
 
 L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-gstreamer"
+L4T_DEB_IS_COMMON = "1"
 
 require tegra-debian-libraries-common.inc
 


### PR DESCRIPTION
With the R36 series, the nvidia-l4t-gstreamer package now comes off the 'common' feed instead of the per-SoC feed, which affects multiple recipes.

Add a new variable, L4T_DEB_IS_COMMON, to the include file we use for the BSP recipes, to let them specify that the main package should come from the common feed. Update the recipes for the binary-only gstreamer plugins, nvdsseimeta, and the DLA compiler to use this new mechanism.

Supersedes #1781 