### PR TITLE
edk2-firmware-tegra: add backported patch for cpp issue

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-36.4.0.inc
@@ -35,6 +35,7 @@ SRC_URI += "\
     file://0001-Update-tools_def.template-for-toolchain-differences.patch \
     file://0002-L4TLauncher-allow-for-empty-missing-APPEND-line-in-e.patch;patchdir=../edk2-nvidia \
     file://0003-XusbControllerDxe-use-BaseMemoryLib-functions.patch;patchdir=../edk2-nvidia \
+    file://0004-MdePkg-Check-if-compiler-has-__has_builtin-before-tr.patch \
 "
 
 S = "${WORKDIR}/edk2-tegra/edk2"

--- a/recipes-bsp/uefi/files/0004-MdePkg-Check-if-compiler-has-__has_builtin-before-tr.patch
+++ b/recipes-bsp/uefi/files/0004-MdePkg-Check-if-compiler-has-__has_builtin-before-tr.patch
@@ -1,0 +1,36 @@
+From 9427b84cae3389cceeeaf52596d37b4c9601b4ca Mon Sep 17 00:00:00 2001
+From: Rebecca Cran <rebecca@bsdio.com>
+Date: Sun, 16 Jun 2024 02:55:33 -0600
+Subject: [PATCH] MdePkg: Check if compiler has __has_builtin before trying to
+ use it
+
+When building AArch64 code, cpp gets run with the `-undef` flag which on
+Fedora 40 with gcc version 14.1.1 20240607 (Red Hat 14.1.1-5) causes
+__has_builtin to be undefined. When running the check for
+__builtin_unreachable in Base.h it causes an error
+"missing binary operator before token "("".
+
+Check that we have __has_builtin before trying to use it.
+
+Upstream-Status: Backport [https://github.com/tianocore/edk2/pull/5781]
+Signed-off-by: Rebecca Cran <rebecca@bsdio.com>
+---
+ MdePkg/Include/Base.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/MdePkg/Include/Base.h b/MdePkg/Include/Base.h
+index e02970a052..7caebbeb1f 100644
+--- a/MdePkg/Include/Base.h
++++ b/MdePkg/Include/Base.h
+@@ -59,7 +59,7 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
+ /// up to the compiler to remove any code past that point.
+ ///
+ #define UNREACHABLE()  __builtin_unreachable ()
+-  #elif defined (__has_feature)
++  #elif defined (__has_builtin) && defined (__has_feature)
+     #if __has_builtin (__builtin_unreachable)
+ ///
+ /// Signal compilers and analyzers that this call is not reachable.  It is
+-- 
+2.43.0
+


### PR DESCRIPTION
when building on Fedora 40, and probably other newer-vintage distros.
