### PR TITLE
cuda-compatibility-workarounds: Fix build with upcoming glibc 2.41

### DIFF
--- a/recipes-devtools/cuda/cuda-compatibility-workarounds/math-vector.h
+++ b/recipes-devtools/cuda/cuda-compatibility-workarounds/math-vector.h
@@ -1,3 +1,4 @@
 #include <bits/libm-simd-decl-stubs.h>
 #undef __ADVSIMD_VEC_MATH_SUPPORTED
 #undef __SVE_VEC_MATH_SUPPORTED
+#undef __GLIBC_USE_IEC_60559_FUNCS_EXT_C23


### PR DESCRIPTION
sinpi/cospi/sinpif/cospif are now defined in glibc as part of C23 extentions but they conflict with CUDA declrations, therefore use the glibc definitions when its provided by glibc

Fixes https://github.com/OE4T/meta-tegra/issues/1784