### PR TITLE
tegra-flash-helper: Allow PKC-only secure boot flashing

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
@@ -259,7 +259,13 @@ if [ -z "$CHIPREV" ]; then
     CHIPREV="${chipid:5:1}"
     skipuid="--skipuid"
     case $bootauth in
-        PKC|SBKPKC)
+        PKC)
+            if [ -z "$keyfile" ]; then
+                echo "ERR: Target is configured for secure boot ($bootauth); use -u option to specify key file" >&2
+                exit 1
+            fi
+            ;;
+        SBKPKC)
             if [ -z "$keyfile" -o -z "$sbk_keyfile" ]; then
                 echo "ERR: Target is configured for secure boot ($bootauth); use -u and -v options to specify key files" >&2
                 exit 1


### PR DESCRIPTION
Commit c523c2f93873d8d255c2e84ec390ccb4d3701c40 on master.

When flashing a board fused with PKC hash but no SBK, we should not supply a SBK key as that would encrypt the flash contents which would then not be able to be read by the board when booting, as the board won't know the SBK key.