### PR TITLE
gcc-for-nvcc: backport buildpaths fixes from OE-Core gcc recipes

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
@@ -106,3 +106,29 @@ target_prefix ?= "${prefix}"
 # The real WORKDIR location isn't a dependency for the shared workdir.
 src_patches[vardepsexclude] = "WORKDIR"
 should_apply[vardepsexclude] += "PN"
+
+remove_sysroot_paths_from_configargs () {
+    replacement=${1}
+    # Prevent sysroot path from being used in configargs.h header, as it will
+    # be rewritten when used by other sysroots preventing support for gcc
+    # plugins. Additionally the path is embeddeded into the output binary, this
+    # prevents building a reproducible binary.
+    oe_runmake configure-gcc
+    sed -i "s@${STAGING_DIR_TARGET}@$replacement@g" ${B}/gcc/configargs.h
+    sed -i "s@${STAGING_DIR_HOST}@/$replacement@g" ${B}/gcc/configargs.h
+}
+
+remove_sysroot_paths_from_checksum_options () {
+    stagingdir=${1}
+    replacement=${2}
+    # Prevent sysroot/workdir paths from being used in checksum-options.
+    # checksum-options is used to generate a checksum which is embedded into
+    # the output binary.
+    oe_runmake TARGET-gcc=checksum-options all-gcc
+    sed -i "s@${DEBUG_PREFIX_MAP}@@g" ${B}/gcc/checksum-options
+    sed -i "s@$stagingdir@$replacement@g" ${B}/gcc/checksum-options
+}
+
+cleanup_installed_include_fixed () {
+    find ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed -type f -not -name "README" -not -name limits.h -not -name syslimits.h | xargs rm -f
+}

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross-canadian.inc
@@ -62,6 +62,9 @@ do_configure () {
 }
 
 do_compile () {
+	remove_sysroot_paths_from_configargs '/host'
+	remove_sysroot_paths_from_checksum_options '${STAGING_DIR_HOST}' '/host'
+
 	oe_runmake all-host configure-target-libgcc
 	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
 }
@@ -168,6 +171,8 @@ do_install () {
 			done
 		done
 	done
+
+	cleanup_installed_include_fixed
 }
 
 ELFUTILS = "nativesdk-elfutils"

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-cross.inc
@@ -61,19 +61,8 @@ do_compile () {
 	export CXXFLAGS_FOR_TARGET="${TARGET_CXXFLAGS}"
 	export LDFLAGS_FOR_TARGET="${TARGET_LDFLAGS}"
 
-	# Prevent native/host sysroot path from being used in configargs.h header,
-	# as it will be rewritten when used by other sysroots preventing support
-	# for gcc plugins
-	oe_runmake configure-gcc
-	sed -i 's@${STAGING_DIR_TARGET}@/host@g' ${B}/gcc/configargs.h
-	sed -i 's@${STAGING_DIR_HOST}@/host@g' ${B}/gcc/configargs.h
-
-	# Prevent sysroot/workdir paths from being used in checksum-options.
-	# checksum-options is used to generate a checksum which is embedded into
-	# the output binary.
-	oe_runmake TARGET-gcc=checksum-options all-gcc
-	sed -i 's@${DEBUG_PREFIX_MAP}@@g' ${B}/gcc/checksum-options
-	sed -i 's@${STAGING_DIR_HOST}@/host@g' ${B}/gcc/checksum-options
+	remove_sysroot_paths_from_configargs '/host'
+	remove_sysroot_paths_from_checksum_options '${STAGING_DIR_HOST}' '/host'
 
 	oe_runmake all-host configure-target-libgcc
 	(cd ${B}/${TARGET_SYS}/libgcc; oe_runmake enable-execute-stack.c unwind.h md-unwind-support.h sfp-machine.h gthr-default.h)
@@ -123,7 +112,7 @@ do_install () {
 	cp ${S}/libquadmath/quadmath.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
 	cp ${S}/libquadmath/quadmath_weak.h ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include/
 
-	find ${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed -type f -not -name "README" -not -name limits.h -not -name syslimits.h | xargs rm -f
+	cleanup_installed_include_fixed
 
 }
 

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
@@ -140,20 +140,8 @@ FILES:${PN}-doc = "\
 "
 
 do_compile () {
-	# Prevent full target sysroot path from being used in configargs.h header,
-	# as it will be rewritten when used by other sysroots preventing support
-	# for gcc plugins. Additionally the path is embeddeded into the output
-	# binary, this prevents building a reproducible binary.
-	oe_runmake configure-gcc
-	sed -i 's@${STAGING_DIR_TARGET}@/@g' ${B}/gcc/configargs.h
-	sed -i 's@${STAGING_DIR_HOST}@/@g' ${B}/gcc/configargs.h
-
-	# Prevent sysroot/workdir paths from being used in checksum-options.
-	# checksum-options is used to generate a checksum which is embedded into
-	# the output binary.
-	oe_runmake TARGET-gcc=checksum-options all-gcc
-	sed -i 's@${DEBUG_PREFIX_MAP}@@g' ${B}/gcc/checksum-options
-	sed -i 's@${STAGING_DIR_TARGET}@/@g' ${B}/gcc/checksum-options
+    remove_sysroot_paths_from_configargs '/'
+    remove_sysroot_paths_from_checksum_options '${STAGING_DIR_TARGET}' '/'
 
 	oe_runmake all-host
 }
@@ -202,37 +190,8 @@ do_install () {
 	ln -sf g++-${BINV} c++-${BINV}
 	ln -sf gcc-${BINV} cc-${BINV}
 	chown -R root:root ${D}
-}
 
-do_install:append () {
-        #
-        # Thefixinc.sh script, run on the gcc's compile phase, looks into sysroot header
-        # files and places the modified files into
-        # {D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed folder. This makes the
-        # build not deterministic. The following code prunes all those headers
-        # except those under include-fixed/linux, *limits.h and README, yielding
-        # the same include-fixed folders no matter what sysroot
-
-        include_fixed="${D}${libdir}/gcc/${TARGET_SYS}/${BINV}/include-fixed"
-        for f in $(find ${include_fixed} -type f); do
-                case $f in
-                */include-fixed/linux/*)
-                    continue
-                    ;;
-                */include-fixed/*limits.h)
-                    continue
-                    ;;
-                */include-fixed/README)
-                    continue
-                    ;;
-                *)
-                    # remove file and directory if empty
-                    bbdebug 2 "Pruning $f"
-                    rm $f
-                    find $(dirname $f) -maxdepth 0 -empty -exec rmdir {} \;
-                    ;;
-                esac
-        done
+	cleanup_installed_include_fixed
 }
 
 # Installing /usr/lib/gcc/* means we'd have two copies, one from gcc-cross


### PR DESCRIPTION
From OE-Core commits 350ff7d and 9221e4a

It's already applied in meta-tegra/scarthgap:
272eccd2 gcc-for-nvcc: backport buildpaths fixes from OE-Core gcc recipes
but wasn't in scarthgap-l4t-r35.x yet