### PR TITLE
edk2-firmware-tegra: fix agx xavier peristent vars

### DIFF
--- a/recipes-bsp/uefi/edk2-firmware-tegra-35.6.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-35.6.0.inc
@@ -16,7 +16,7 @@ EDK2_NONOSI_SRC_URI = "git://github.com/NVIDIA/edk2-non-osi.git;protocol=https;b
 EDK2_NVIDIA_NONOSI_SRC_URI = "git://github.com/NVIDIA/edk2-nvidia-non-osi.git;protocol=https;branch=r35.6.0-updates"
 
 SRCREV_edk2-non-osi = "61662e8596dd9a64e3372f9a3ba6622d2628607c"
-SRCREV_edk2-nvidia = "78a917ecc3639c84097a180dedd33ad8482c6fb5"
+SRCREV_edk2-nvidia = "c101ba515b2737fb78d8929c2852f5c8f9607330"
 SRCREV_edk2-nvidia-non-osi = "3a123f53db225accabca01889d97fe2db43aceeb"
 SRCREV_edk2-platforms = "3c3b1168017073c2bb2d97336c5929ebae805be1"
 


### PR DESCRIPTION
As discussed in [1], [2], and [3], AGX Xavier targets are no longer able to write any persistent variables from edk boot, and are no longer to perform capsule updates after 355 reboots.

Pull in the patch in [4] which is confirmed to resolve this issue as tested on AGX Xavier with 500 reboots using the script at [5] plus a capsule update test.

1: https://forums.developer.nvidia.com/t/possible-uefi-memory-leak-and-partition-full/308540/43
2: https://forums.developer.nvidia.com/t/redundant-a-b-rootfs-not-switching-with-set-active-boot-slot-but-working-with-set-sr-br/306475/27
3: https://github.com/NVIDIA/edk2-nvidia/issues/114
4: https://github.com/NVIDIA/edk2-nvidia/commit/c101ba515b2737fb78d8929c2852f5c8f9607330
5: https://github.com/Trellis-Logic/linux-test-scripts/blob/main/tegra_uefi_reboot_test.py