### PR TITLE
optee-os: make build work in devtool

### DIFF
--- a/recipes-security/optee/optee-l4t.inc
+++ b/recipes-security/optee/optee-l4t.inc
@@ -23,7 +23,7 @@ EXTRA_OEMAKE = "\
     CFLAGS64='${TOOLCHAIN_OPTIONS} ${DEBUG_PREFIX_MAP}' \
     platform-aflags-generic='${DEBUG_PREFIX_MAP} -pipe' \
     TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
-    CFG_WITH_STMM_SP=y CFG_STMM_PATH=../build/standalone_mm_optee.bin \
+    CFG_WITH_STMM_SP=y CFG_STMM_PATH=${B}/standalone_mm_optee.bin \
 "
 
 do_compile:prepend() {


### PR DESCRIPTION
Make sure we have proper path to MM even when building from devtool workspace.