### PR TITLE
l4t.csv: add tegra-egl/libEGL_nvidia.so.0

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-configs/l4t.csv
+++ b/recipes-bsp/tegra-binaries/tegra-configs/l4t.csv
@@ -123,6 +123,7 @@ lib, /usr/lib/aarch64-linux-gnu/tegra/nvidia_icd.json
 lib, /usr/lib/libcuda.so.1.1
 lib, /usr/lib/libdrm.so.2
 lib, /usr/lib/libEGL_nvidia.so.0
+lib, /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0
 lib, /usr/lib/libGLESv1_CM_nvidia.so.1
 lib, /usr/lib/libGLESv2_nvidia.so.2
 lib, /usr/lib/libGLX_nvidia.so.0


### PR DESCRIPTION
Fixes `(Argus) Error InvalidState: Failed to load EGL library`  issue described here:
https://github.com/OE4T/meta-tegra/issues/1518

by mounting /usr/lib/aarch64-linux-gnu/tegra-egl/libEGL_nvidia.so.0 into the container