### PR TITLE
nvidia-kernel-oot: build in B with Devtool

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -385,3 +385,5 @@ python oot_update_rprovides() {
             d.setVar('RDEPENDS:' + oot_pkg, newdepstr)
 }
 PACKAGESPLITFUNCS += "oot_update_rprovides"
+
+EXTERNALSRC_BUILD ?= "${B}"


### PR DESCRIPTION
Enable external builds, such as those initiated by Devtools, to utilize the B directory for building instead of modifying the source code directory. This prevents the source code from being tainted by build artifacts, which currently results in issues like the following:

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        hwpm/drivers/tegra/hwpm/.Module.symvers.cmd
        hwpm/drivers/tegra/hwpm/.modules.order.cmd
        hwpm/drivers/tegra/hwpm/.nvhwpm.ko.cmd
        hwpm/drivers/tegra/hwpm/.nvhwpm.mod.cmd
        hwpm/drivers/tegra/hwpm/.nvhwpm.mod.o.cmd
        hwpm/drivers/tegra/hwpm/.nvhwpm.o.cmd
        hwpm/drivers/tegra/hwpm/Module.symvers
        hwpm/drivers/tegra/hwpm/common/.allowlist.o.cmd
        hwpm/drivers/tegra/hwpm/common/.aperture.o.cmd
        hwpm/drivers/tegra/hwpm/common/.init.o.cmd
        hwpm/drivers/tegra/hwpm/common/.ip.o.cmd
        hwpm/drivers/tegra/hwpm/common/.resource.o.cmd
        hwpm/drivers/tegra/hwpm/common/allowlist.o
        hwpm/drivers/tegra/hwpm/common/aperture.o
```