### PR TITLE
More fixes for getting initrd flashing to work with pre-signed binaries

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/tegra-flash-helper.sh
@@ -205,7 +205,7 @@ overlay_dtb_arg=
 rcm_overlay_dtb_arg=
 if [ -n "$overlay_dtb_files" ]; then
     overlay_dtb_arg="--overlay_dtb $overlay_dtb_files"
-    rcm_overlay_dtb_arg="--overlay_dtb $rcmbootcontrol_overlay$non_bootcontrol_overlays"
+    rcm_overlay_dtb_arg="--overlay_dtb $rcm_bootcontrol_overlay$non_bootcontrol_overlays"
 fi
 if [ -n "$DCE_OVERLAY" ]; then
     overlay_dtb_arg="$overlay_dtb_arg --dce_overlay_dtb $DCE_OVERLAY"

--- a/recipes-security/optee/optee-l4t.inc
+++ b/recipes-security/optee/optee-l4t.inc
@@ -23,7 +23,7 @@ EXTRA_OEMAKE = "\
     CFLAGS64='${TOOLCHAIN_OPTIONS} ${DEBUG_PREFIX_MAP}' \
     platform-aflags-generic='${DEBUG_PREFIX_MAP} -pipe' \
     TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
-    CFG_WITH_STMM_SP=y CFG_STMM_PATH=${B}/standalone_mm_optee.bin \
+    CFG_WITH_STMM_SP=y CFG_STMM_PATH=${@oe.path.relative(d.getVar('S'),d.getVar('B'))}/standalone_mm_optee.bin \
 "
 
 do_compile:prepend() {


### PR DESCRIPTION
* Fixed a typo that would omit some DTB overlays for some cases
* Reworked the use of the RCM boot blob signing in the `odmsign.func` functions so the signed files for RCM booting don't end up replacing the main signed files
* Signing step in initrd-flash now skips signing partitions on external storage devices
* Since booting using pre-signed boot firmware prevents us from reading the CVM EEPROM to get the serial number, added a mechanism for locating the right storage device based on the USB instance being in the device path

Tested with a secured and an unsecured device.

Fixes #1813 
Fixes #1803

Also includes a fix for the buildpath errors that were introduced with #1808 
