### PR TITLE
Add an SDK recipe for the signing tools

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-flashtools_36.4.3.bb
+++ b/recipes-bsp/tegra-binaries/tegra-flashtools_36.4.3.bb
@@ -1,9 +1,14 @@
-require tegra-binaries-${PV}.inc
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=2d48d198004cfe9c3bc0df31c1b89805 \
+                    file://nv_tegra/LICENSE.brcm_patchram_plus;md5=38fb07f0dacf4830bc57f40a0fb7532e"
 
-WORKDIR = "${TMPDIR}/work-shared/L4T-native-${PV}-${PR}"
-SSTATE_SWSPEC = "sstate:tegra-binaries-native::${PV}:${PR}::${SSTATE_VERSION}:"
-STAMP = "${STAMPS_DIR}/work-shared/L4T-native-${PV}-${PR}"
-STAMPCLEAN = "${STAMPS_DIR}/work-shared/L4T-native-${PV}-*"
+SRC_URI = "\
+    ${L4T_URI_BASE}/${L4T_BSP_PREFIX}_Linux_R${L4T_VERSION}_aarch64.tbz2 \
+"
+
+SRC_URI[sha256sum] = "949a44049c4ce6a8efdf572ea0820c874f6ee5d41ca3e4935b9f0e38d11873d2"
+
+inherit l4t_bsp
 
 SRC_URI += "\
            file://0003-Convert-BUP_generator.py-to-Python3.patch \
@@ -16,18 +21,15 @@ SRC_URI += "\
 S = "${WORKDIR}/Linux_for_Tegra"
 B = "${WORKDIR}/build"
 
-COMPATIBLE_MACHINE = ""
-
-inherit_defer native
+COMPATIBLE_HOST = "(x86_64.*)"
+COMPATIBLE_HOST:class-native = ""
 
 INHIBIT_DEFAULT_DEPS = "1"
-DEPENDS = "tegra-helper-scripts-native python3-pyyaml-native"
+DEPENDS = "tegra-helper-scripts python3-pyyaml"
 
 do_compile[noexec] = "1"
 
 BINDIR = "${bindir}/tegra-flash"
-
-addtask preconfigure after do_patch before do_configure
 
 do_install() {
     install -d ${D}${BINDIR}
@@ -65,4 +67,12 @@ do_install() {
     sed -i -e's,^\(L4T_BOOTLOADER_DIR=.*\)/bootloader,\1,' ${D}${BINDIR}/l4t_sign_image.sh
 }
 
+RDEPENDS:${PN} = "tegra-helper-scripts python3-pyyaml bash"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
+# Some of the prebuilt tools are for 32-bit x86 instead of x86-64
+INSANE_SKIP:${PN} = "arch"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts_36.4.3.bb
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts_36.4.3.bb
@@ -4,8 +4,6 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 INHIBIT_DEFAULT_DEPS = "1"
 
-inherit_defer native
-
 SRC_URI = " \
     file://tegra-flash-helper.sh \
     file://nvflashxmlparse.py \
@@ -29,3 +27,6 @@ do_install() {
     install -m 0755 ${S}/rewrite-tegraflash-args.py ${D}${bindir}/tegra-flash/rewrite-tegraflash-args
     install -m 0755 ${S}/initrd-flash.sh ${D}${bindir}/tegra-flash/initrd-flash
 }
+
+RDEPENDS:${PN} = "bash python3-core"
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-core/meta/tegra-signing-tools.bb
+++ b/recipes-core/meta/tegra-signing-tools.bb
@@ -1,0 +1,60 @@
+DESCRIPTION = "SDK type target for building a standalone tarball containing tools needed for \
+signing Jetson boot firmware files"
+LICENSE = "MIT"
+
+TOOLCHAIN_TARGET_TASK = ""
+
+TOOLCHAIN_HOST_TASK = "\
+    nativesdk-tegra-flashtools \
+    nativesdk-tegra-helper-scripts \
+    nativesdk-sdk-provides-dummy \
+"
+MULTIMACH_TARGET_SYS = "${SDK_ARCH}-nativesdk${SDK_VENDOR}-${SDK_OS}"
+PACKAGE_ARCH = "${SDK_ARCH}_${SDK_OS}"
+PACKAGE_ARCHS = ""
+TARGET_ARCH = "none"
+TARGET_OS = "none"
+
+#SDK_PACKAGE_ARCHS += "buildtools-dummy-${SDKPKGSUFFIX}"
+
+TOOLCHAIN_OUTPUTNAME ?= "${SDK_ARCH}-tegra-signing-tools-${DISTRO_VERSION}"
+
+SDK_TITLE = "Tegra signing tools"
+
+RDEPENDS = "${TOOLCHAIN_HOST_TASK}"
+
+inherit populate_sdk toolchain-scripts-base nopackages
+deltask install
+deltask populate_sysroot
+do_populate_sdk[stamp-extra-info] = "${PACKAGE_ARCH}"
+
+REAL_MULTIMACH_TARGET_SYS = "none"
+INHIBIT_DEFAULT_DEPS = "1"
+
+create_sdk_files:append () {
+	rm -f ${SDK_OUTPUT}/${SDKPATH}/site-config-*
+	rm -f ${SDK_OUTPUT}/${SDKPATH}/environment-setup-*
+	rm -f ${SDK_OUTPUT}/${SDKPATH}/version-*
+
+	# Generate new (mini) sdk-environment-setup file
+	script=${1:-${SDK_OUTPUT}/${SDKPATH}/environment-setup-${SDK_SYS}}
+	touch $script
+	echo 'export PATH="${SDKPATHNATIVE}${bindir_nativesdk}:${SDKPATHNATIVE}${sbindir_nativesdk}:${SDKPATHNATIVE}${base_bindir_nativesdk}:${SDKPATHNATIVE}${base_sbindir_nativesdk}:$PATH"' >> $script
+	echo 'export OECORE_NATIVE_SYSROOT="${SDKPATHNATIVE}"' >> $script
+
+	toolchain_create_sdk_version ${SDK_OUTPUT}/${SDKPATH}/version-${SDK_SYS}
+
+	cat >> $script <<EOF
+if [ -d "\$OECORE_NATIVE_SYSROOT/environment-setup.d" ]; then
+	for envfile in \$OECORE_NATIVE_SYSROOT/environment-setup.d/*.sh; do
+		. \$envfile
+	done
+fi
+EOF
+
+	if [ "${SDKMACHINE}" = "i686" ]; then
+		echo 'export NO32LIBS="0"' >>$script
+		echo 'echo "$BB_ENV_PASSTHROUGH_ADDITIONS" | grep -q "NO32LIBS"' >>$script
+		echo '[ $? != 0 ] && export BB_ENV_PASSTHROUGH_ADDITIONS="NO32LIBS $BB_ENV_PASSTHROUGH_ADDITIONS"' >>$script
+	fi
+}


### PR DESCRIPTION
The goal with this patch series is to simplify the setup of an external signing server. It combines the NVIDIA flashing tools and our helper scripts into an SDK package, eliminating some of the manual steps for getting a server set up.
