### PR TITLE
linux-yocto: add ported pmc sysfs nodes patch to bbappend

### DIFF
--- a/recipes-kernel/linux/linux-yocto_6.6.bbappend
+++ b/recipes-kernel/linux/linux-yocto_6.6.bbappend
@@ -11,6 +11,7 @@ SRC_URI:append:tegra = " \
     file://0006-fbdev-simplefb-Support-memory-region-property.patch \
     file://0007-fbdev-simplefb-Add-support-for-generic-power-domains.patch \
     file://0008-UBUNTU-SAUCE-PCI-endpoint-Add-core_deinit-callback-s.patch \
+    file://0009-NVIDIA-SAUCE-soc-tegra-pmc-Add-sysfs-nodes-to-select.patch \
     file://tegra.cfg \
     file://tegra-drm.cfg \
     file://tegra-governors.cfg \


### PR DESCRIPTION
Patch was ported and committed but not the changes to the recipe.

Fixes 13d3075d7fec0fef920fd182e634a1ec8cf239c2

Refs #1833