### PR TITLE
tegra-uefi-capsules: add minimal UEFI dependency

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.4.3.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.4.3.bb
@@ -99,4 +99,5 @@ do_compile[depends] += "python3-pyyaml-native:do_populate_sysroot lz4-native:do_
 do_compile[depends] += "tegra-bootfiles:do_populate_sysroot"
 do_compile[depends] += "coreutils-native:do_populate_sysroot virtual/secure-os:do_deploy"
 do_compile[depends] += "virtual/bootloader:do_deploy"
+do_compile[depends] += "edk2-firmware-tegra-minimal:do_deploy"
 do_compile[depends] += "${TEGRA_SIGNING_EXTRA_DEPS} ${DTB_EXTRA_DEPS}"


### PR DESCRIPTION
With https://github.com/OE4T/meta-tegra/commit/9b6a113255d552cd2c9db32cef93676e93b5e2c3 the image_types_tegra class was modifed to add the minimal uefi image, uefi_jetson_minimal, to the tegraflash package and added edk2-firmware-tegra-minimal:do_deploy to the do_image_tegraflash_tar[depends]

Since tegra-uefi-capsules also references tegraflash_populate_package it also needs the same dependency to avoid this build error:

```
| DEBUG: Executing shell function do_compile
| cp: cannot stat '/home/dan/trellis/oe4t/tegra-demo-distro/build-r36.4.3/tmp/deploy/images/jetson-orin-nano-devkit-nvme/uefi_jetson_minimal.bin': No such file or directory
| WARNING: exit code 1 from a shell command.
```

I considered a more complicated fix here to assign a new variable
```
TEGRAFLASH_POPULATE_DEPENDS = "virtual/bootloader:do_deploy edk2-firmware-tegra-minimal:do_deploy"
```
and then reference this var in both `tegra-uefi-capsules` `do_compile[depends]` and `do_image_tegraflash_tar[depends]` in `image_types_tegra`.  If you'd prefer this approach let me know and I will modify this PR accordingly.