### PR TITLE
SDK fixes for CUDA 12

### DIFF
--- a/recipes-devtools/cuda/cuda-cudart_12.6.68-1.bb
+++ b/recipes-devtools/cuda/cuda-cudart_12.6.68-1.bb
@@ -28,5 +28,5 @@ FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/${baselib}/*.a \
                     ${@' ${prefix}/local/cuda-${CUDA_VERSION}/lib64' if d.getVar('baselib') != 'lib64' and d.getVar('SITEINFO_BITS') == '64' else ''}"
 FILES:${PN}-staticdev = ""
 INSANE_SKIP:${PN}-dev += "staticdev"
-RDEPENDS:${PN}-dev:append:class-target = " cuda-nvcc-headers cuda-cccl cuda-target-environment cuda-crt"
+RDEPENDS:${PN}-dev:append:class-target = " cuda-nvcc-headers cuda-cccl cuda-target-environment cuda-crt-dev"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvcc_12.6.68-1.bb
+++ b/recipes-devtools/cuda/cuda-nvcc_12.6.68-1.bb
@@ -17,6 +17,6 @@ FILES:${PN}-dev = ""
 INSANE_SKIP:${PN} += "dev-so dev-deps"
 RDEPENDS:${PN} = "${BPN}-headers"
 RDEPENDS:${PN}:append:class-target = " cuda-nvvm-dev cuda-crt-dev"
-RDEPENDS:${PN}:append:class-nativesdk = " nativesdk-cuda-environment"
+RDEPENDS:${PN}:append:class-nativesdk = " nativesdk-cuda-environment nativesdk-cuda-nvvm"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
* Fix cuda-cudart-dev RDEPENDS to reference cuda-crt-dev instead of cuda-crt
* Add cuda-nvvm as runtime dependency for nativesdk nvcc so cicc gets installed

Fixes #1839 