### PR TITLE
p3737-0000-p3701-0004: fix KERNEL_DEVICETREE setting

### DIFF
--- a/conf/machine/p3737-0000-p3701-0004.conf
+++ b/conf/machine/p3737-0000-p3701-0004.conf
@@ -5,7 +5,7 @@
 TEGRA_BOARDSKU ?= "0004"
 TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0004;boardrev=;chipsku=00:00:00:D0;bup_type=bl \
                        fab=300;boardsku=0004;boardrev=;bup_type=kernel"
-KERNEL_DEVICETREE ?= "tegra234-p3701-0004-p3737-0000.dtb"
+KERNEL_DEVICETREE ?= "tegra234-p3737-0000+p3701-0004-nv.dtb"
 TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra234-mb1-bct-pmic-p3701-0005.dts"
 
 require conf/machine/include/agx-orin.inc


### PR DESCRIPTION
which missed getting updated for the OOT device trees that were switched to in L4T R36.x.

Fixes #1843 
