### PR TITLE
linux-tegra: fix devicetree scripts dependency

### DIFF
--- a/recipes-kernel/linux/linux-tegra_5.10.bb
+++ b/recipes-kernel/linux/linux-tegra_5.10.bb
@@ -71,7 +71,7 @@ do_compile_devicetree_overlays() {
 do_compile_devicetree_overlays[dirs] = "${B}"
 do_compile_devicetree_overlays[depends] += "dtc-native:do_populate_sysroot"
 
-addtask compile_devicetree_overlays after do_compile before do_install
+addtask compile_devicetree_overlays after do_compile_kernelmodules before do_install
 
 do_apply_devicetree_overlays() {
 


### PR DESCRIPTION
I'm not sure why but I've hit this on two different projects this week, one using `kirkstone` branch and one using `dunfell`.

I wrote a script to attempt to reproduce on tegra-demo-distro and ran about 100 clean/rebuild steps overnight but could not reproduce.  I think it's got something to do with changes in proprietary layers on each of these projects which are causing subtle timing differences.  On one of the projects I can make this happen every time I run `bitbake -c cleansstate linux-tegra && bitbake linux-tegra`

Let me know if there's a better way to fix this, or if you'd prefer adding a dependency on `make-mod-scripts`.  It seems like we can't allow `do_compile_kernelmodules` and `do_compile_devicetree_overlays` to run in parallel though since they are both going to attempt to run parallel make commands on the scripts directory.

Error detail below:

When building with kernel-modules, there's a race condition which causes build errors during the link step for the modules scripts.  These take various forms but look something like

```
|   CC      scripts/mod/empty.o
|   MKELF   scripts/mod/elfconfig.h
|   HOSTCC  scripts/mod/modpost.o
|   CC      scripts/mod/devicetable-offsets.s
|   CHK     scripts/mod/devicetable-offsets.h
|   HOSTLD  scripts/mod/modpost
| /build/tmp/hosttools/ld: scripts/mod/modpost.o: in function `read_symbols':
| modpost.c:(.text+0x1f7a): undefined reference to `handle_moddevtable'
| /build/tmp/hosttools/ld: modpost.c:(.text+0x26ed): undefined reference to `maybe_frob_rcs_version'
| /build/tmp/hosttools/ld: modpost.c:(.text+0x2705): undefined reference to `get_src_version'
| /build/tmp/hosttools/ld: scripts/mod/modpost.o: in function `main':
| modpost.c:(.text.startup+0x73f): undefined reference to `add_moddevtable'
```
and occurs in either the do_compile_kernelmodules or do_compile_devicetree_overlays step, where the common thing with each failure happening during the HOSTLD scripts/mod/modpost step.

On kirkstone I've also seen an error which looks like this, also related to native scripts build:

```
| /bin/sh: 1: ERROR: oe_runmake failed
| WARNING: exit code 1 from a shell command.
| ./scripts/dtc/dtc: Permission denied
| make[2]: *** [/home/dan/proj/build/tmp/work-shared/proj-xavier/kernel-source/arch/arm64/boot/dts/Makefile:90: arch/arm64/boot/dts/_ddot_/_ddot_/_ddot_/_ddot_/nvidia/platform/t19x/jakku/kernel-dts/tegra194-p3668-all-p3509-0000-camera-imx219-dual.dtbo] Error 126
| make[1]: *** [arch/arm64/Makefile:179: dtb-overlays] Error 2
| make: *** [/home/dan/proj/build/tmp/work-shared/proj-xavier/kernel-source/Makefile:210: __sub-make] Error 2
ERROR: Task (/home/dan/proj/build/layers/meta-tegra/recipes-kernel/linux/linux-tegra_5.10.bb:do_compile_devicetree_overlays) failed with exit code '1'
```

To resolve, run do_compile_devicetree_overlays after do_compile_kernelmodules instead of after do_compile.  This ensures that the do_compile_devicetree_overlays step doesn't run concurrent with the scripts build of the do_compile_kernelmodules step and stomp on each other with kernel build output.

Alternatively, we could add a dependency on make-mod-scripts as done with the  `module-base.bbclass` at [1] which does the same thing at [2] to add the dependency on do_compile_kernelmodules

1: https://github.com/yoctoproject/poky/blob/63d05fc061006bf1a88630d6d91cdc76ea33fbf2/meta/classes/module-base.bbclass#L5
 2: https://github.com/yoctoproject/poky/blob/63d05fc061006bf1a88630d6d91cdc76ea33fbf2/meta/recipes-kernel/make-mod-scripts/make-mod-scripts_1.0.bb#L14
