### PR TITLE
tegra-eeprom-tool: update v2.0.1 -> v2.0.2

### DIFF
--- a/recipes-bsp/tools/tegra-eeprom-tool_2.0.2.bb
+++ b/recipes-bsp/tools/tegra-eeprom-tool_2.0.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=22c98979a7dd9812d2455ff5dbc88771"
 DEPENDS = "libedit"
 
 SRC_URI = "https://github.com/OE4T/${BPN}/releases/download/v${PV}/${BP}.tar.gz"
-SRC_URI[sha256sum] = "53a5b69d6a4f8835192622c6dbcfa10af562fb198b5ad7e46e7aac2b73fa2248"
+SRC_URI[sha256sum] = "56e8e3d73a23d919e80b5398903f68e60dda71c4f9ca289cecf043bb496989f3"
 
 inherit cmake pkgconfig
 


### PR DESCRIPTION
tegra-eeprom-tool is broken in scarthgap since eeprom is defined as read-only on L4T R36.4.0/JetPack 6.1.