### PR TITLE
tegra-uefi-capsules: fix signing with external server

### DIFF
--- a/recipes-bsp/uefi/tegra-uefi-capsules_36.4.0.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_36.4.0.bb
@@ -26,7 +26,9 @@ do_compile() {
     # BUP generator really wants to use 'boot.img' for the LNX
     # partition contents
     tegraflash_populate_package ${IMAGE_TEGRAFLASH_KERNEL} boot.img ${@tegra_bootcontrol_overlay_list(d, bup=True)}
-    mv generate_bup_payload.sh doflash.sh
+    if [ "${TEGRA_SIGNING_EXCLUDE_TOOLS}" != "1" ]; then
+        mv generate_bup_payload.sh doflash.sh
+    fi
     tegraflash_create_flash_config flash.xml.in boot.img ${STAGING_DATADIR}/tegraflash/bupgen-internal-flash.xml
     . ./flashvars
     tegraflash_custom_sign_bup


### PR DESCRIPTION
 - 'mv generate_bup_payload.sh doflash.sh' should be conditional on TEGRA_SIGNING_EXCLUDE_TOOLS.  Those who use external signing servers will set this to "1" which skips the generation of generate_bup_payload.sh.  See invocations of tegraflash_generate_bupgen_script in image_types_tegra.bbclass.