### PR TITLE
images_types_tegra: Support copying additional images

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -5,6 +5,7 @@ inherit ${TEGRA_UEFI_SIGNING_CLASS}
 TEGRA_UEFI_USE_SIGNED_FILES ??= "false"
 
 IMAGE_TYPES += "tegraflash.tar"
+TEGRA_ADDITIONAL_FS ??= " "
 
 IMAGE_ROOTFS_ALIGNMENT ?= "4"
 
@@ -325,6 +326,9 @@ create_tegraflash_pkg() {
     fi
     tegraflash_custom_pre
     cp "${IMAGE_TEGRAFLASH_ROOTFS}" ./${IMAGE_BASENAME}.${IMAGE_TEGRAFLASH_FS_TYPE}
+    for image in ${TEGRA_ADDITIONAL_FS}; do
+      cp "${image}" ./
+    done
     tegraflash_create_flash_config flash.xml.in ${LNXFILE}
     if grep -Eq '^[[:space:]]+<device type="sdcard"' flash.xml.in; then
         has_sdcard="yes"


### PR DESCRIPTION
Enable flashing of additional filesystems (e.g., split images generated with genimage).

Example usage:
IMAGE_TEGRAFLASH_ROOTFS = "${DEPLOY_DIR_IMAGE}/myrootfs.ext4" TEGRA_ADDITIONAL_FS = "${DEPLOY_DIR_IMAGE}/datafs.ext4 ${DEPLOY_DIR_IMAGE}/mountfs.ext4"

This configuration adds myrootfs, datafs, and mountfs to the tegraflash bundle. With a custom ${PARTITION_FILE_EXTERNAL}, all filesystems can be flashed to the device in a single step.

Tested with scarthgap
