### PR TITLE
setup-nv-boot-control: add COMPAT_TARGET

### DIFF
--- a/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
+++ b/recipes-bsp/tools/setup-nv-boot-control/setup-nv-boot-control.sh.in
@@ -1,5 +1,6 @@
 #!/bin/sh
 TARGET="@TARGET@"
+COMPAT_TARGET="@COMPAT_TARGET@"
 BOOTDEV="@BOOTDEV@"
 sysconfdir="@sysconfdir@"
 controlfile="${sysconfdir}/nv_boot_control.conf"
@@ -24,8 +25,8 @@ compatspec=$(echo "$boardspec" | gen_compat_spec)
 if [ -z "$compatspec" ]; then
     compatsed="-e/^COMPATIBLE_SPEC/d"
 else
-    compatsed="-es,@COMPATIBLE_SPEC@,${compatspec}-${TARGET}-,"
-    set_efi_var "TegraPlatformCompatSpec" "781e084c-a330-417c-b678-38e696380cb9" "${compatspec}-${TARGET}-" "write-once" || rc=1
+    compatsed="-es,@COMPATIBLE_SPEC@,${compatspec}-${COMPAT_TARGET}-,"
+    set_efi_var "TegraPlatformCompatSpec" "781e084c-a330-417c-b678-38e696380cb9" "${compatspec}-${COMPAT_TARGET}-" "write-once" || rc=1
 fi
 sed -e"s,@TNSPEC@,${boardspec}-${TARGET}-${BOOTDEV}," $compatsed \
     "${sysconfdir}/nv_boot_control.template" > "$controlfile" || rc=1

--- a/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
+++ b/recipes-bsp/tools/setup-nv-boot-control_1.0.bb
@@ -18,6 +18,7 @@ ESPMOUNT ?= "/boot/efi"
 NVIDIA_ESPMOUNT ?= "/opt/nvidia/esp"
 ESPMOUNTUNIT ?= "${@'-'.join(d.getVar('ESPMOUNT').split('/')[1:])}.mount"
 ESPVARDIR ?= "${ESPMOUNT}/EFI/NVDA/Variables"
+TNSPEC_COMPAT_MACHINE ??= "${TNSPEC_MACHINE}"
 
 S = "${WORKDIR}"
 B = "${WORKDIR}/build"
@@ -26,6 +27,7 @@ inherit systemd update-rc.d
 
 do_compile() {
     sed -e's,@TARGET@,${TNSPEC_MACHINE},g' \
+        -e's,@COMPAT_TARGET@,${TNSPEC_COMPAT_MACHINE},g' \
         -e's,@BOOTDEV@,${TNSPEC_BOOTDEV},g' \
         -e's,@sysconfdir@,${sysconfdir},g' \
         ${S}/setup-nv-boot-control.sh.in >${B}/setup-nv-boot-control.sh


### PR DESCRIPTION
Found when testing https://github.com/OE4T/tegra-demo-distro/pull/320 with the test procedure there on AGX Xavier devices.  I believe it's necessary for this commit or something like it on any Jetpack 5 AGX Xavier based targets to be applied and implemented before slot switching through nvbootctrl to work properly.

I considered defining `TNSPEC_COMPAT_MACHINE` in the include file for agx-xavier but not sure we want to make that change, especially on a stable branch, at this point, because I'm not sure what side effect changing the compatible spec will have for already deployed devices.

Also based on the discussion at https://forums.developer.nvidia.com/t/nvbootctrl-hardcoded-to-only-handle-agx-xavier/270411/4 I suspect this probably only applies to AGX Xavier.

I think I may just make a note about this in https://github.com/OE4T/meta-tegra/wiki/Creating-a-custom-MACHINE.

I've only tested on kirkstone thus far but if this is the right change it should probably go to `scarthgap-l4t-r35.x` as well.

# Commit Comment
From discussion at [1], NVIDIA hard-codes a check for COMPATIBLE_SPEC into nvbootctrl in order to determine whether to use EFI variables in emmc.

For custom MACHINEs which use a custom TARGET that doesn't match the `unify_name` value in the
`nv-l4t-bootloader-config.sh` script, this means any attempt to set bootloader slot from nvbootctrl, for instance the attempt to set slots as an alternative to capsule update with [2], fail with
```
Error: open fail errno = 30 reason = Read-only file system
Error: write variable BootChainFwNext failed!
```

Add a COMPAT_TARGET to the setup-nv-boot-control script which by default is set to TARGET.  However, if using a custom MACHINE/TARGET which is based on
`jetson_agx_xavier_devkit` you can define:
```
TNSPEC_COMPAT_MACHINE = "jetson-agx-xavier-devkit"
```
in your machine configuration and nvbootctrl will
work as expected, where `jetson-agx-xavier-devkit` is the value of `unify_name` in `nv-l4t-bootloader-config.sh` in the Jetpack release sources from nvidia for
`jetson_agx_xavier_devkit` target.

1: https://forums.developer.nvidia.com/t/nvbootctrl-hardcoded-to-only-handle-agx-xavier/270411/4
2: https://github.com/OE4T/tegra-demo-distro/pull/320