### PR TITLE
libnvidia-container: fix go build on 36.4.3

### DIFF
--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-fix-building-with-go-1-24.patch
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container/0002-fix-building-with-go-1-24.patch
@@ -1,0 +1,50 @@
+From 1c680195fdc85948d635286b72a6ad9f823b5987 Mon Sep 17 00:00:00 2001
+From: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+Date: Thu, 13 Feb 2025 10:18:59 +0100
+Subject: [PATCH] Fix building with Go 1.24
+
+Go 1.24 does not allow defining methods on C types anymore, so make convert a function, not a method.
+
+Fixes the following error when building with Go 1.24:
+`./main.go:35:10: cannot define new methods on non-local type CDeviceRule`
+
+Upstream-Status: Backport [https://github.com/NVIDIA/libnvidia-container/pull/297]
+
+Signed-off-by: Dmitry Sharshakov <dmitry.sharshakov@siderolabs.com>
+Signed-off-by: Dan Walkes <dan.walkes@trellis-logic.com>
+
+---
+ src/nvcgo/main.go | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/nvcgo/main.go b/src/nvcgo/main.go
+index 1523a06d..ed43be8e 100644
+--- a/src/nvcgo/main.go
++++ b/src/nvcgo/main.go
+@@ -32,7 +32,7 @@ func main() {}
+ type CDeviceRule = C.struct_device_rule
+ 
+ // Convert a C-based DeviceRule to a Go-based cgroup.DeviceRule
+-func (r *CDeviceRule) convert() cgroup.DeviceRule {
++func convert(r *CDeviceRule) cgroup.DeviceRule {
+ 	return cgroup.DeviceRule{
+ 		Allow:  bool(r.allow),
+ 		Type:   C.GoString(r._type),
+@@ -67,7 +67,7 @@ func GetDeviceCGroupMountPath(version C.int, procRootPath *C.char, pid C.pid_t,
+ 		return -1
+ 	}
+ 	*cgroupMountPath = C.CString(p)
+-	*cgroupRootPrefix= C.CString(r)
++	*cgroupRootPrefix = C.CString(r)
+ 
+ 	return 0
+ }
+@@ -100,7 +100,7 @@ func AddDeviceRules(version C.int, cgroupPath *C.char, crules []CDeviceRule, rer
+ 
+ 	rules := make([]cgroup.DeviceRule, len(crules))
+ 	for i, cr := range crules {
+-		rules[i] = cr.convert()
++		rules[i] = convert(&cr)
+ 	}
+ 
+ 	err = api.AddDeviceRules(C.GoString(cgroupPath), rules)

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.16.2.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.16.2.bb
@@ -42,6 +42,7 @@ NVIDIA_MODPROBE_SRCURI_DESTSUFFIX = "${@os.path.join(os.path.basename(d.getVar('
 SRC_URI = "git://github.com/NVIDIA/libnvidia-container.git;protocol=https;name=libnvidia;branch=main \
            git://github.com/NVIDIA/nvidia-modprobe.git;protocol=https;branch=main;name=modprobe;destsuffix=${NVIDIA_MODPROBE_SRCURI_DESTSUFFIX} \
            file://0001-OE-cross-build-fixups.patch \
+           file://0002-fix-building-with-go-1-24.patch \
 "
 
 # tag: v1.16.2


### PR DESCRIPTION
With backported patch at https://github.com/NVIDIA/libnvidia-container/pull/297 supporting go 1.24+.

Resolves
```
| # nvcgo
| ./main.go:35:10: cannot define new methods on non-local type CDeviceRule
| make[2]: *** [Makefile:40: libnvidia-container-go.so] Error 1
```