### PR TITLE
nvidia-kernel-oot: support external device-tree recipes

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.4.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.4.0.bb
@@ -96,9 +96,14 @@ do_install() {
     find ${B} -name Module.symvers -type f | xargs sed -e's:${B}/::g' >${D}${includedir}/${BPN}/Module.symvers
 
     cp -R ${S}/nvidia-oot/include/* ${D}/${includedir}/${BPN}
+
+    # include device-tree source for building external dtb
+    install -d ${D}/usr/src/device-tree
+    cp -R ${S}/hardware/nvidia/ ${D}/usr/src/device-tree
 }
 
 SYSROOT_DIRS += "/boot/devicetree"
+SYSROOT_DIRS += "/usr/src/device-tree"
 
 KERNEL_MODULE_PROBECONF = "nvgpu"
 module_conf_nvgpu = 'options nvgpu devfreq_timer="delayed"'
@@ -107,6 +112,7 @@ PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}
 FILES:${PN}-devicetrees = "/boot/devicetree"
 FILES:${PN}-dev = "\
     ${includedir}/${BPN} \
+    /usr/src/device-tree \
 "
 ALLOW_EMPTY:${PN}-display = "1"
 ALLOW_EMPTY:${PN}-cameras = "1"

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -79,9 +79,14 @@ do_install() {
     find ${B} -name Module.symvers -type f | xargs sed -e's:${B}/::g' >${D}${includedir}/${BPN}/Module.symvers
 
     cp -R ${S}/nvidia-oot/include/* ${D}/${includedir}/${BPN}
+
+    # include device-tree source for building external dtb
+    install -d ${D}/usr/src/device-tree
+    cp -R ${S}/hardware/nvidia/ ${D}/usr/src/device-tree
 }
 
 SYSROOT_DIRS += "/boot/devicetree"
+SYSROOT_DIRS += "/usr/src/device-tree"
 
 KERNEL_MODULE_PROBECONF = "nvgpu"
 module_conf_nvgpu = 'options nvgpu devfreq_timer="delayed"'
@@ -90,6 +95,7 @@ PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}
 FILES:${PN}-devicetrees = "/boot/devicetree"
 FILES:${PN}-dev = "\
     ${includedir}/${BPN} \
+    /usr/src/device-tree \
 "
 ALLOW_EMPTY:${PN}-display = "1"
 ALLOW_EMPTY:${PN}-cameras = "1"


### PR DESCRIPTION
When device-tree builds moved to nvidia-kernel-oot, the dtb files built from the platform dts files were getting stashed into the sysroot area for future use during image build, but the dts files themselves were *not* saved anywhere. This broke external device-tree recipes that wanted to include the platform dts and add modifications.

Add export of dts files into nvidia-kernel-oot sysroot area, under usr/src/device-tree subdir.