### PR TITLE
nvidia-kernel-oot: support module symbol reuse

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -69,6 +69,7 @@ do_install() {
     install -d ${D}/boot/devicetree
     install -m 0644 ${B}/kernel-devicetree/generic-dts/dtbs/* ${D}/boot/devicetree/
     install -d ${D}${includedir}/${BPN}
+    ln -s ${BPN} ${D}${includedir}/kernel-module-${BPN}
     find ${B} -name Module.symvers -type f | xargs sed -e's:${B}/::g' >${D}${includedir}/${BPN}/Module.symvers
 
     cp -R ${S}/nvidia-oot/include/* ${D}/${includedir}/${BPN}
@@ -85,9 +86,11 @@ KERNEL_MODULE_PROBECONF = "nvgpu"
 module_conf_nvgpu = 'options nvgpu devfreq_timer="delayed"'
 
 PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}-wifi ${PN}-canbus ${PN}-virtualization ${PN}-alsa ${PN}-test ${PN}-base ${PN}-extra"
+PROVIDES += "kernel-module-${BPN}"
 FILES:${PN}-devicetrees = "/boot/devicetree"
 FILES:${PN}-dev = "\
     ${includedir}/${BPN} \
+    ${includedir}/kernel-module-${BPN} \
     /usr/src/device-tree \
 "
 ALLOW_EMPTY:${PN}-display = "1"


### PR DESCRIPTION
The module media and other modules are reusable for other modules, the package
should expose symbols to other packages.
    
The `module.bbclass` expects `kernel-module-` prefix package name and matching
include directory to trigger the dependency mechanism.
    
```
        python __anonymous () {
            depends = d.getVar('DEPENDS')
            extra_symbols = []
            for dep in depends.split():
                if dep.startswith("kernel-module-"):
                    extra_symbols.append("${STAGING_INCDIR}/" + dep + "/Module.symvers")
            d.setVar('KBUILD_EXTRA_SYMBOLS', " ".join(extra_symbols))
        }
```
 
Add:
1. `kernel-module-nvidia-kernel-oot` `PROVIDES` alias.
2. Symlink of `/usr/include/kernel-module-nvidia-kernel-oot -> /usr/include/nvidia-kernel-oot`
    
A module that requires these modules can use the standard dependency such as:

```    
      DEPENDS += "kernel-module-nvidia-kernel-oot"
```

`module.bbclass` [fix](https://github.com/yoctoproject/poky/pull/21) is also required.