### PR TITLE
nvidia-kernel-oot: Disable header-guard GCC15 warning

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -40,7 +40,7 @@ TEGRA_OOT_REPLACEMENT_DRIVERS = "\
 
 EXTRA_OEMAKE += '\
     IGNORE_PREEMPT_RT_PRESENCE=1 KERNEL_PATH="${STAGING_KERNEL_BUILDDIR}" \
-    CC="${KERNEL_CC} -std=gnu17" CXX="${KERNEL_CC} -x c++" LD="${KERNEL_LD}" AR="${KERNEL_AR}" \
+    CC="${KERNEL_CC} -std=gnu17 -Wno-error=header-guard" CXX="${KERNEL_CC} -x c++" LD="${KERNEL_LD}" AR="${KERNEL_AR}" \
     OBJCOPY="${KERNEL_OBJCOPY}" \
 '
 


### PR DESCRIPTION
Warnings are treated as errors and this warning is triggered when compiling git version of nvidia-kernel-oot module. Ignore the warning as error for now.

Fixes errors like

nvidia-oot/drivers/net/wireless/realtek/rtl8852ce/phl/hal_g6/phy/rf/halrf_8852c/../halrf_8852c/halrf_ops_rtl8852c.h:25: error: header guard '__HALRF_OPS_RTL8852C_H__' followed by '#define' of a different macro [-Werror=header-guard]