### PR TITLE
nvidia-kernel-oot: fix linux-yocto build

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-nvidia-kernel-oot-handle-of_property_for_each_u32-ap.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0001-nvidia-kernel-oot-handle-of_property_for_each_u32-ap.patch
@@ -1,0 +1,82 @@
+From c833d387665922f619cb4c6a551a4d993e38bbb6 Mon Sep 17 00:00:00 2001
+From: Matt Porter <mporter@konsulko.com>
+Date: Wed, 14 May 2025 11:32:21 -0400
+Subject: [PATCH] nvidia-kernel-oot: handle of_property_for_each_u32() api
+ changes
+
+of_property_for_each_u32() changed in 6.11 to drop the internal use
+only arguments and this change was backported to 6.6.75. Backport
+the support for abstracting this API change from 575.51.02.
+
+Upstream-Status: Backport [https://github.com/NVIDIA/open-gpu-kernel-modules/commit/41595798880394d9c6fa5e76b37ffc1bc428cfb2#diff-32da369dcd8cd223fa47c8b86028f1a7572ed699c33f2057f4702e4b36f13dd5R5483]
+Signed-off-by: Matt Porter <mporter@konsulko.com>
+---
+ nvdisplay/kernel-open/conftest.sh             | 25 +++++++++++++++++++
+ .../nvidia/nv-dsi-parse-panel-props.c         |  4 +++
+ nvdisplay/kernel-open/nvidia/nvidia.Kbuild    |  1 +
+ 3 files changed, 30 insertions(+)
+
+diff --git a/nvdisplay/kernel-open/conftest.sh b/nvdisplay/kernel-open/conftest.sh
+index 2ee8d8d..7a810bc 100644
+--- a/nvdisplay/kernel-open/conftest.sh
++++ b/nvdisplay/kernel-open/conftest.sh
+@@ -5291,6 +5291,31 @@ compile_test() {
+             fi
+         ;;
+ 
++        of_property_for_each_u32_has_internal_args)
++            #
++            # Determine if the internal arguments for the macro
++            # of_property_for_each_u32() are present.
++            #
++            # Commit 9722c3b66e21 ("of: remove internal arguments from
++            # of_property_for_each_u32()") removes two arguments from
++            # of_property_for_each_u32() which are used internally within
++            # the macro and so do not need to be passed. This change was
++            # made for Linux v6.11.
++            #
++            CODE="
++            #include <linux/of.h>
++            void conftest_of_property_for_each_u32(struct device_node *np,
++                                                   char *propname) {
++                struct property *iparam1;
++                const __be32 *iparam2;
++                u32 val;
++
++                of_property_for_each_u32(np, propname, iparam1, iparam2, val);
++            }"
++
++            compile_check_conftest "$CODE" "NV_OF_PROPERTY_FOR_EACH_U32_HAS_INTERNAL_ARGS" "" "types"
++        ;;
++
+         of_property_read_variable_u8_array)
+             #
+             # Determine if of_property_read_variable_u8_array is present
+diff --git a/nvdisplay/kernel-open/nvidia/nv-dsi-parse-panel-props.c b/nvdisplay/kernel-open/nvidia/nv-dsi-parse-panel-props.c
+index 9ac5866..b0d06de 100644
+--- a/nvdisplay/kernel-open/nvidia/nv-dsi-parse-panel-props.c
++++ b/nvdisplay/kernel-open/nvidia/nv-dsi-parse-panel-props.c
+@@ -493,7 +493,11 @@ static int parse_dsi_properties(const struct device_node *np_dsi, DSI_PANEL_INFO
+         "nvidia,dsi-lvds-bridge", &temp))
+         dsi->dsi2lvds_bridge_enable = (bool)temp;
+ 
++#if defined(NV_OF_PROPERTY_FOR_EACH_U32_HAS_INTERNAL_ARGS)
+     of_property_for_each_u32(np_dsi_panel, "nvidia,dsi-dpd-pads", prop, p, temp)
++#else
++    of_property_for_each_u32(np_dsi_panel, "nvidia,dsi-dpd-pads", temp)
++#endif
+         dsi->dpd_dsi_pads |= (u32)temp;
+ 
+     if (!of_property_read_u32(np_dsi_panel,
+diff --git a/nvdisplay/kernel-open/nvidia/nvidia.Kbuild b/nvdisplay/kernel-open/nvidia/nvidia.Kbuild
+index c87daf3..45e9638 100644
+--- a/nvdisplay/kernel-open/nvidia/nvidia.Kbuild
++++ b/nvdisplay/kernel-open/nvidia/nvidia.Kbuild
+@@ -249,6 +249,7 @@ NV_CONFTEST_TYPE_COMPILE_TESTS += num_registered_fb
+ NV_CONFTEST_TYPE_COMPILE_TESTS += pci_driver_has_driver_managed_dma
+ NV_CONFTEST_TYPE_COMPILE_TESTS += vm_area_struct_has_const_vm_flags
+ NV_CONFTEST_TYPE_COMPILE_TESTS += memory_failure_has_trapno_arg
++NV_CONFTEST_TYPE_COMPILE_TESTS += of_property_for_each_u32_has_internal_args
+ 
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += dom0_kernel_present
+ NV_CONFTEST_GENERIC_COMPILE_TESTS += nvidia_vgpu_kvm_build

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.4.3.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_36.4.3.bb
@@ -13,9 +13,10 @@ unpack_makefile_from_bsp() {
 do_unpack[postfuncs] += "unpack_makefile_from_bsp"
 
 SRC_URI += "file://0001-Makefile-update-for-OE-builds.patch \
-            file://0002-Fix-nvdisplay-modules-builds.patch \
-            file://0001-tegra-virt-alt-Remove-leading-from-include-path-from.patch \
-"
+           file://0002-Fix-nvdisplay-modules-builds.patch \
+           file://0001-tegra-virt-alt-Remove-leading-from-include-path-from.patch \
+           file://0001-nvidia-kernel-oot-handle-of_property_for_each_u32-ap.patch \
+           "
 
 S = "${WORKDIR}/${BPN}"
 


### PR DESCRIPTION
of_property_for_each_u32() only takes three arguments in newer kernels.