### PR TITLE
initrd-flash.sh: check if serial number has letters or leading zeros

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -506,7 +506,13 @@ if [ -z "$serial_number" ]; then
     echo "WARN: did not get device serial number at $(date -Is)" | tee -a "$logfile"
     session_id=
 else
-    session_id=$(printf "%x" "$serial_number" | tail -c8)
+	last8_characters=$(echo "$serial_number" | tail -c8)
+	digits_only=${last8_characters//[!0-9]/}
+	if [ -z "$digits_only" ]; then
+		session_id=0
+	else
+		session_id=$(printf '%x' "$((10#$digits_only))")
+	fi
 fi
 
 # Boot device flashing


### PR DESCRIPTION
If serial number contains letters or leading zeros like: ABC0066978 this code prevents the bash script from failing and assigns a valid session_id