### PR TITLE
remove leftover mentions of EMMC_SIZE

### DIFF
--- a/conf/machine/include/agx-orin.inc
+++ b/conf/machine/include/agx-orin.inc
@@ -4,7 +4,6 @@ require conf/machine/include/tegra234.inc
 
 KERNEL_ARGS ?= "mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 nospectre_bhb video=efifb:off console=tty0"
 
-EMMC_SIZE ?= "31276924928"
 EMMC_DEVSECT_SIZE ?= "512"
 BOOTPART_SIZE ?= "8388608"
 BOOTPART_LIMIT ?= "10485760"

--- a/conf/machine/include/orin-nano.inc
+++ b/conf/machine/include/orin-nano.inc
@@ -18,7 +18,6 @@ KERNEL_ARGS ?= "mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/et
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8168 kernel-module-r8169 kernel-module-realtek"
 MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
 
-EMMC_SIZE ?= ""
 BOOTPART_SIZE ?= "8388608"
 ROOTFSPART_SIZE_DEFAULT ?= "30064771072"
 ODMDATA ?= "gbe-uphy-config-8,hsstp-lane-map-3,hsio-uphy-config-0"

--- a/conf/machine/include/orin-nx.inc
+++ b/conf/machine/include/orin-nx.inc
@@ -22,7 +22,6 @@ KERNEL_ARGS ?= "mminit_loglevel=4 console=ttyTCU0,115200 firmware_class.path=/et
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8168 kernel-module-r8169 kernel-module-realtek"
 MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
 
-EMMC_SIZE ?= ""
 BOOTPART_SIZE ?= "8388608"
 # 55GiB default rootfs size
 ROOTFSPART_SIZE_DEFAULT ?= "59055800320"

--- a/conf/machine/jetson-agx-orin-devkit-industrial.conf
+++ b/conf/machine/jetson-agx-orin-devkit-industrial.conf
@@ -6,7 +6,6 @@ TEGRA_BOARDSKU ?= "0008"
 TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0008;boardrev=;chipsku=00:00:00:90;bup_type=bl \
                        fab=300;boardsku=0008;boardrev=;bup_type=kernel"
 KERNEL_DEVICETREE ?= "tegra234-p3737-0000+p3701-0008-nv.dtb"
-EMMC_SIZE ?= "63652757504"
 ROOTFSPART_SIZE_DEFAULT ?= "59055800320"
 EMMC_BCT ?= "tegra234-p3701-0008-sdram-l4t.dts"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi_sdmmc_industrial.xml"


### PR DESCRIPTION
EMMC_SIZE has been superseded by ROOTFSPART_SIZE for defining the size of the root filesystem partitions directly.

This commit removes leftover assignments in the machine configurations.