### PR TITLE
make-sdcard: Improve script to create filesystems if needed

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -148,7 +148,7 @@ create_filesystems() {
     for pline in "${PARTS[@]}"; do
 	eval "$pline"
 	if [ -z "$partfile" ] && [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
-	    printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber"
+	    printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber\n"
 	    mke2fscmd="mkfs.$fstype /dev/$DEVNAME$PARTSEP$partnumber"
 	    if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
 		    echo "ERR: filesystem failed" >&2

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -141,6 +141,27 @@ make_partitions() {
     return 0
 }
 
+create_filesystems() {
+    local partnumber
+    local pline mke2fscmd fstype
+		local errlog=$(mktemp)
+    for pline in "${PARTS[@]}"; do
+			eval "$pline"
+	    if [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
+				printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber"
+				$mke2fscmd="mke2fs -t $fstype /dev/$DEVNAME$PARTSEP$partnumber"
+				if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
+					echo "ERR: filesystem failed" >&2
+					cat "$errlog" >&2
+					rm -f "$errlog"
+					return 1
+				fi
+			fi
+    done
+    rm -f "$errlog"
+    return 0
+}
+
 copy_to_device() {
     local src="$1"
     local dst="$2"
@@ -451,6 +472,7 @@ if ! sgdisk "$output" --verify >/dev/null 2>&1; then
     echo "ERR: verification failed for $output" >&2
     exit 1
 fi
+create_filesystems || exit 1
 if [ -b "$output" ]; then
     sleep 1
     if ! $SUDO partprobe "$output" >/dev/null 2>&1; then

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -68,7 +68,7 @@ compute_size() {
 }
 
 find_finalpart() {
-    local blksize partnumber partname partsize partfile partguid partfilltoend
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
     local appidx app_b_idx pline i
     if [ -n "$ignore_finalpart" ]; then
 	FINALPART=999
@@ -102,7 +102,7 @@ find_finalpart() {
 }
 
 make_partitions() {
-    local blksize partnumber partname partsize partfile partguid partfilltoend start_location
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
     local i pline alignarg sgdiskcmd parttype
     if [ "$use_start_locations" = "yes" ]; then
 	alignarg="-a 1"
@@ -192,7 +192,7 @@ unmount_device() {
 }
 
 write_partitions_to_device() {
-    local blksize partnumber partname partsize partfile partguid partfilltoend
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
     local i dest pline destsize filesize n_written
     n_written=0
     i=0
@@ -269,7 +269,7 @@ write_partitions_to_device() {
 
 write_partitions_to_image() {
     local -a partstart
-    local blksize partnumber partname partsize partfile partguid partfilltoend
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
     local i s e stuff partstart partend pline
 
     while read partnumber s e stuff; do

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -144,19 +144,19 @@ make_partitions() {
 create_filesystems() {
     local partnumber
     local pline mke2fscmd fstype
-		local errlog=$(mktemp)
+    local errlog=$(mktemp)
     for pline in "${PARTS[@]}"; do
-			eval "$pline"
-	    if [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
-				printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber"
-				$mke2fscmd="mke2fs -t $fstype /dev/$DEVNAME$PARTSEP$partnumber"
-				if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
-					echo "ERR: filesystem failed" >&2
-					cat "$errlog" >&2
-					rm -f "$errlog"
-					return 1
-				fi
-			fi
+	eval "$pline"
+	if [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
+	    printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber"
+	    mke2fscmd="mkfs.$fstype /dev/$DEVNAME$PARTSEP$partnumber"
+	    if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
+		    echo "ERR: filesystem failed" >&2
+		    cat "$errlog" >&2
+		    rm -f "$errlog"
+		    return 1
+	    fi
+	fi
     done
     rm -f "$errlog"
     return 0
@@ -472,7 +472,6 @@ if ! sgdisk "$output" --verify >/dev/null 2>&1; then
     echo "ERR: verification failed for $output" >&2
     exit 1
 fi
-create_filesystems || exit 1
 if [ -b "$output" ]; then
     sleep 1
     if ! $SUDO partprobe "$output" >/dev/null 2>&1; then
@@ -480,6 +479,7 @@ if [ -b "$output" ]; then
 	exit 1
     fi
     sleep 1
+    create_filesystems || exit 1
 fi
 if type -p bmaptool >/dev/null 2>&1; then
     HAVEBMAPTOOL=yes

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -142,8 +142,8 @@ make_partitions() {
 }
 
 create_filesystems() {
-    local partnumber
-    local pline mke2fscmd fstype
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
+    local pline mke2fscmd
     local errlog=$(mktemp)
     for pline in "${PARTS[@]}"; do
 	eval "$pline"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -147,7 +147,7 @@ create_filesystems() {
     local errlog=$(mktemp)
     for pline in "${PARTS[@]}"; do
 	eval "$pline"
-	if [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
+	if [ -z "$partfile" ] && [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
 	    printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber"
 	    mke2fscmd="mkfs.$fstype /dev/$DEVNAME$PARTSEP$partnumber"
 	    if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
@@ -104,7 +104,7 @@ class Partition(object):
         self.filename = "" if fname is None or fname.text is None else fname.text.strip()
         logging.info("Partition {}: id={}, type={}, start={}, size={}, parttype={}, fstype={}".format(self.name, self.id, self.type,
                                                                                           self.start_location, self.size,
-                                                                                          self.parttype, self.fstype)
+                                                                                          self.parttype, self.fstype))
 
     def filltoend(self):
         return (self.alloc_attr & 0x800) == 0x800

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
@@ -60,6 +60,9 @@ class Partition(object):
         parttype = element.find('partition_type_guid')
         self.parttype = "" if parttype is None else parttype.text.strip()
 
+        fstype = element.find('filesystem_type')
+        self.fstype = "" if fstype is None else fstype.text.strip()
+
         alignment = element.find('align_boundary')
         if alignment is not None:
             alignval = int(alignment.text.strip(), base=0) # in bytes
@@ -99,9 +102,9 @@ class Partition(object):
 
         fname = element.find('filename')
         self.filename = "" if fname is None or fname.text is None else fname.text.strip()
-        logging.info("Partition {}: id={}, type={}, start={}, size={} parttype={}".format(self.name, self.id, self.type,
+        logging.info("Partition {}: id={}, type={}, start={}, size={}, parttype={}, fstype={}".format(self.name, self.id, self.type,
                                                                                           self.start_location, self.size,
-                                                                                          self.parttype))
+                                                                                          self.parttype, self.fstype)
 
     def filltoend(self):
         return (self.alloc_attr & 0x800) == 0x800
@@ -466,7 +469,7 @@ Extracts/manipulates partition information in an NVIDIA flash layout XML file
     blksize = layout.devices[args.type].sector_size
     for n, part in enumerate(partitions):
         print("blksize={};partnumber={};partname=\"{}\";start_location={};partsize={};"
-              "partfile=\"{}\";partguid=\"{}\";parttype=\"{}\";partfilltoend={}".format(blksize,
+              "partfile=\"{}\";partguid=\"{}\";parttype=\"{}\";fstype=\"{}\";partfilltoend={}".format(blksize,
                                                                                         part.id,
                                                                                         part.name,
                                                                                         part.start_location,
@@ -474,6 +477,7 @@ Extracts/manipulates partition information in an NVIDIA flash layout XML file
                                                                                         part.filename,
                                                                                         part.partguid,
                                                                                         part.parttype,
+                                                                                        part.fstype,
                                                                                         1 if part.filltoend() else 0),
               file=outf)
     outf.close()


### PR DESCRIPTION
If the `filesystem_type` field in the NVIDIA XML layout is set to a value other than `'basic'`, the script will prepare the partition using the specified type.

According to the [official documentation](https://docs.nvidia.com/jetson/archives/r36.4.4/DeveloperGuide/AR/BootArchitecture/PartitionConfiguration.html#partition-child-elements), only 'basic' is expected, and support for ext2 is deprecated. However, with this modification, other filesystem types remain supported.

This change can be particularly useful for users who need to define custom partition types beyond what the default layout allows.