### PR TITLE
l4t_sign_image.sh patch: fix missing 'echo' in logging line

### DIFF
--- a/recipes-bsp/tegra-binaries/files/0010-Rework-logging-in-l4t_sign_image.sh.patch
+++ b/recipes-bsp/tegra-binaries/files/0010-Rework-logging-in-l4t_sign_image.sh.patch
@@ -36,7 +36,7 @@ index cff2872..f4cb962 100755
  	local sig_file="${1}"
 -	echo "${CMD} --chip ${chip} ${options[*]} --cmd sign ${sig_file} ${ftype}" >&5
 -	output="$("${CMD}" --chip "${chip}" "${options[@]}" --cmd "sign \"${sig_file}\" \"${ftype}\"" | tee >(cat - >&5))"
-+	[ $quiet -eq 1 ] || "${CMD} --chip ${chip} ${options[*]} --cmd sign ${file} ${ftype}"
++	[ $quiet -eq 1 ] || echo "${CMD} --chip ${chip} ${options[*]} --cmd sign ${file} ${ftype}"
 +	output="$("${CMD}" --chip "${chip}" "${options[@]}" --cmd "sign \"${file}\" \"${ftype}\"")"
 +	[ $quiet -eq 1 ] || echo $output
  	if [ -n "${encryptkey}" ]; then


### PR DESCRIPTION
The patch for l4t_sign_image.sh seems to have removed "echo" from the logging line. I've had a patch for this patch file in my BSP layer for a while and I decided I would get it submitted.