### PR TITLE
l4t-extlinux-config: add support for OVERLAYS

### DIFF
--- a/lib/oe4t/dtbutils.py
+++ b/lib/oe4t/dtbutils.py
@@ -1,3 +1,35 @@
+
+def locate_dtb_files(dtbnames, d):
+    def find_file_under(fname, rootdir):
+        for dirname, _, f in os.walk(rootdir):
+            if fname in f:
+                return os.path.join(dirname, fname)
+        return None
+
+    result = []
+    extern_root = d.getVar('EXTERNAL_KERNEL_DEVICETREE')
+    imgdeploydir = d.getVar('DEPLOY_DIR_IMAGE')
+    for dtb in dtbnames:
+        if os.path.isabs(dtb):
+            result.append(dtb)
+            continue
+        if extern_root:
+            dtbpath = find_file_under(dtb, extern_root)
+            if dtbpath:
+                result.append(dtbpath)
+                continue
+        result.append(os.path.join(imgdeploydir, dtb))
+    return result
+
+def copy_dtb_files(overlays, outdir, d):
+    import shutil
+    """
+    Copy the list of overlays to outdir
+    """
+    infiles = locate_dtb_files(overlays.split(), d)
+    for infile in infiles:
+        shutil.copy(infile, outdir)
+
 def concat_dtb_overlays(dtbfile, overlays, outfile, d):
     """
     Produce an output DTB file that has zero or more
@@ -15,29 +47,8 @@ def concat_dtb_overlays(dtbfile, overlays, outfile, d):
     import os
     import bb.utils
 
-    def find_file_under(fname, rootdir):
-        for dirname, _, f in os.walk(rootdir):
-            if fname in f:
-                return os.path.join(dirname, fname)
-        return None
 
-    def locate_dtb_files(dtbnames):
-        result = []
-        extern_root = d.getVar('EXTERNAL_KERNEL_DEVICETREE')
-        imgdeploydir = d.getVar('DEPLOY_DIR_IMAGE')
-        for dtb in dtbnames:
-            if os.path.isabs(dtb):
-                result.append(dtb)
-                continue
-            if extern_root:
-                dtbpath = find_file_under(dtb, extern_root)
-                if dtbpath:
-                    result.append(dtbpath)
-                    continue
-            result.append(os.path.join(imgdeploydir, dtb))
-        return result
-
-    infiles = locate_dtb_files([dtbfile] + overlays.split())
+    infiles = locate_dtb_files([dtbfile] + overlays.split(), d)
     bb.note("Creating concatenated device tree: ", outfile)
     with open(outfile, "wb") as outf:
         for infile in infiles:

--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -52,6 +52,10 @@ python do_concat_dtb_overlays() {
         oe4t.dtbutils.concat_dtb_overlays(d.getVar('DTBFILE'),
                                           d.getVar('TEGRA_PLUGIN_MANAGER_OVERLAYS'),
                                           os.path.join(d.getVar('B'), d.getVar('DTBFILE')), d)
+
+   if d.getVar('UBOOT_EXTLINUX_OVERLAYS'):
+        oe4t.dtbutils.copy_dtb_files(d.getVar('UBOOT_EXTLINUX_OVERLAYS'),
+                                          d.getVar('B'), d)
 }
 do_concat_dtb_overlays[dirs] = "${B}"
 do_concat_dtb_overlays[depends] += "virtual/kernel:do_deploy"
@@ -71,6 +75,9 @@ do_sign_files() {
     if [ -n "${UBOOT_EXTLINUX_FDT}" ]; then
         files_to_sign="$files_to_sign ${DTBFILE}"
     fi
+    if [ -n "${UBOOT_EXTLINUX_OVERLAYS}" ]; then
+        files_to_sign="$files_to_sign ${UBOOT_EXTLINUX_OVERLAYS}"
+    fi
     if [ -n "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" != "1" ]; then
         files_to_sign="$files_to_sign initrd"
     fi
@@ -86,6 +93,11 @@ do_install() {
     install -m 0644 ${B}/${KERNEL_IMAGETYPE} ${D}/boot/
     if [ -n "${UBOOT_EXTLINUX_FDT}" ]; then
         install -m 0644 ${B}/${DTBFILE}* ${D}/boot/
+    fi
+    if [ -n "${UBOOT_EXTLINUX_OVERLAYS}" ]; then
+        for overlay in ${UBOOT_EXTLINUX_OVERLAYS}; do
+            install -m 0644 ${B}/$overlay ${D}/boot/
+        done
     fi
     if [ -n "${INITRAMFS_IMAGE}" -a "${INITRAMFS_IMAGE_BUNDLE}" != "1" ]; then
         install -m 0644 ${B}/initrd* ${D}/boot/


### PR DESCRIPTION
This PR adds support for OVERLAYS in extlinux.conf to meta-tegra.  I haven't found this feature officially documented anywhere but it's referenced in forums like https://forums.developer.nvidia.com/t/place-custom-overlay-file-via-extlinux-conf/298287.  This feature is useful for anyone who wants to be able to modify devicetree overlays listed in `TEGRA_PLUGIN_MANAGER_OVERLAYS` without the necessity to do a capsule update, either by hand modifying in their `/boot` directory or using the `TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT` feature of the [swupdate demo](https://github.com/OE4T/tegra-demo-distro/tree/master/layers/meta-tegrademo/dynamic-layers/meta-swupdate#tegra_swupdate_bootloader_install_only_if_different).

If/when this commit goes in I have a backport I'm planning for r35 branches which will also pull in a rebased commit from r36 branches of edk2-nvidia to support this on Jetpack 5 targets as well.  I've tested to ensure this works on kirkstone, see https://github.com/OE4T/meta-tegra/compare/kirkstone...Trellis-Logic:meta-tegra:kirkstone+overlays-extlinux-feature?expand=1 for preview. This means all device tree content should be able to be synchronized with rootfs content across the Jetpack 5/6 release series.

For those who don't specify `USE_OVERLAYS_IN_EXTLINUX = "1"` there should be no change with this PR, devicetree overlays will continue to come from spiflash only.

One thing I didn't take on with this task but could... I don't believe the logic in `do_concat_dtb_overlays` [here](https://github.com/OE4T/meta-tegra/blob/651e0898cb47ccc86c0ed5c7617fcfeadd7fda1f/recipes-bsp/uefi/l4t-launcher-extlinux.bb#L50-L55) actually is used by anything as far as I can tell. I could rename this function to reference its dual use for copying overlays or remove the concatenate part.

If/when this goes in I'll also reference it in the wiki page at https://github.com/OE4T/meta-tegra/wiki/Using-device-tree-overlays or I could work on a reorg/retitle of this page since it's about more than just devicetree overlays at this point.

# Commit Text
As discussed in [1], overlay source on JP5/6 targets appears to come only from the update capsule content in spi flash and not from either the content appended to the extlinux dtb.  This means if a slot switch occurs the devicetree overlay content used will match the last capsule update as opposed to the content overlayed on the dtb file referenced in extlinux.conf.  This also means slot switches don't apply dtb overlay changes when using slot switching instead of capsule update as a software update strategy for non bootloader components (see the TEGRA_SWUPDATE_BOOTLOADER_INSTALL_ONLY_IF_DIFFERENT feature at [2] for example).

With this patch, add support for writing the OVERLAYS value in the extlinux.conf file.  Specifiying

```
UBOOT_EXTLINUX_FDT = "/boot/${DTBFILE}"
USE_OVERLAYS_IN_EXTLINUX = "1"
```
in your local.conf or machine config will
* Copy all .dtbo files in TEGRA_PLUGIN_MANAGER_OVERLAYS list into the /boot directory of the rootfs when building the l4t-launcher-extlinux.
* Reference each .dtbo file in the extlinux.conf file, applying it as a part of the ExtLinuxBoot process in L4TLauncher.

1: https://matrix.to/#/!YBfWVpJwNVtkmqVCPS:gitter.im/$OJAkyoJCMQDfiamxJGULUseBv7vgH2fJy9cVLMbhh4g?via=gitter.im&via=matrix.org&via=3dvisionlabs.com
2: https://github.com/OE4T/tegra-demo-distro/tree/master/layers/meta-tegrademo/dynamic-layers/meta-swupdate#tegra_swupdate_bootloader_install_only_if_different

# Testing

Testing on master with jetson-orin-nano-devkit-nvme

1. Set in the local.conf:
```
UBOOT_EXTLINUX_FDT = "/boot/${DTBFILE}"
USE_OVERLAYS_IN_EXTLINUX = "1"
IMAGE_INSTALL:append = " dtc"
```

2. After boot, generate a DTS copy of the first overlay using logic like this:
```
cat /boot/extlinux/extlinux.conf | sed -n 's/.*OVERLAYS[[:space:]]\+\([^,]*\).*/\1/p' | xargs cat | dtc -I dtb -O dts >  /boot/first-overlay-original.dts && cp /boot/first-overlay-original.dts /boot/first-overlay-modified.dts
```
3. Modify the /boot/first-overlay-modified.dts by adding a line `test = "overlay-modified"`.  The resulting difference should look like this:
```
diff /boot/first-overlay-original.dts /boot/first-overlay-modified.dts
--- /boot/first-overlay-original.dts
+++ /boot/first-overlay-modified.dts
@@ -7,6 +7,7 @@
                target-path = "/";

                __overlay__ {
+                        test = "overlay-modified";

                        reserved-memory {
                                #address-cells = <0x02>;

```
4. Convert the modified dts file into the first overlay in the OVERLAYS list:
```
dtc -I dts -O dtb -o /boot/first-overlay-modified.dtbo  /boot/first-overlay-modified.dts 
cat /boot/extlinux/extlinux.conf | sed -n 's/.*OVERLAYS[[:space:]]\+\([^,]*\).*/\1/p' | xargs cp /boot/first-overlay-modified.dtbo
```
5. reboot
6. Verify the test marker is added to the device-tree from the overlay
```
root@jetson-orin-nano-devkit-nvme:~# cat /proc/device-tree/test
overlay-modified
```
