### PR TITLE
uefi signing: tracks UEFI DB files with file-checksums 

### DIFF
--- a/classes-recipe/tegra-uefi-signing.bbclass
+++ b/classes-recipe/tegra-uefi-signing.bbclass
@@ -6,11 +6,18 @@ def tegra_uefi_signing_deps(d, tasks=False):
         return ' '.join([d + ':do_populate_sysroot' for d in deps])
     return ' '.join(deps)
 
+def tegra_uefi_signing_filechecksums(d):
+    if not d.getVar('TEGRA_UEFI_DB_KEY') or not d.getVar('TEGRA_UEFI_DB_CERT'):
+        return ''
+    files = ['${TEGRA_UEFI_DB_KEY}', '${TEGRA_UEFI_DB_CERT}']
+    return ' '.join([f + ':True' for f in files])
+
 TEGRA_UEFI_DB_KEY ??= ""
 TEGRA_UEFI_DB_CERT ??= ""
 TEGRA_UEFI_SIGNING_TASKDEPS ?= "${@tegra_uefi_signing_deps(d, tasks=True)}"
 TEGRA_UEFI_SIGNING_DEPENDS ?= "${@tegra_uefi_signing_deps(d)}"
 TEGRA_UEFI_USE_SIGNED_FILES ?= "${@'true' if d.getVar('TEGRA_UEFI_DB_KEY') and d.getVar('TEGRA_UEFI_DB_CERT') else 'false'}"
+TEGRA_UEFI_SIGNING_FILECHECKSUMS ?= "${@tegra_uefi_signing_filechecksums(d)}"
 
 # Standard signing, input file modified with signature
 tegra_uefi_sbsign() {

--- a/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_36.4.4.bb
+++ b/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_36.4.4.bb
@@ -31,6 +31,7 @@ do_sign_efi_launcher() {
 }
 do_sign_efi_launcher[dirs] = "${B}"
 do_sign_efi_launcher[depends] += "${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_sign_efi_launcher[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 addtask sign_efi_launcher after do_compile before do_install
 

--- a/recipes-bsp/uefi/edk2-firmware-tegra_36.4.4.bb
+++ b/recipes-bsp/uefi/edk2-firmware-tegra_36.4.4.bb
@@ -60,6 +60,7 @@ do_sign_efi_launcher() {
 }
 do_sign_efi_launcher[dirs] = "${B}"
 do_sign_efi_launcher[depends] += "${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_sign_efi_launcher[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 addtask sign_efi_launcher after do_compile before do_install
 

--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -84,6 +84,7 @@ do_sign_files() {
 }
 do_sign_files[dirs] = "${B}"
 do_sign_files[depends] += "${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_sign_files[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 addtask sign_files after do_compile do_create_extlinux_config do_copy_dtb_overlays before do_install
 

--- a/recipes-kernel/linux/tegra-kernel.inc
+++ b/recipes-kernel/linux/tegra-kernel.inc
@@ -19,6 +19,7 @@ do_sign_kernel() {
 }
 do_sign_kernel[dirs] = "${B}"
 do_sign_kernel[depends] += "${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_sign_kernel[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 addtask sign_kernel after do_compile before do_install
 
@@ -72,6 +73,7 @@ do_deploy:append() {
 }
 
 do_deploy[depends] += "tegra-flashtools-native:do_populate_sysroot ${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_deploy[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base = ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -60,6 +60,7 @@ do_sign_dtbs() {
 }
 do_sign_dtbs[dirs] = "${B}"
 do_sign_dtbs[depends] += "${TEGRA_UEFI_SIGNING_TASKDEPS}"
+do_sign_dtbs[file-checksums] += "${TEGRA_UEFI_SIGNING_FILECHECKSUMS}"
 
 addtask sign_dtbs after do_compile before do_install
 


### PR DESCRIPTION
This makes it possible for the build to track key/cert files defined by TEGRA_UEFI_DB_KEY/TEGRA_UEFI_DB_CERT.

Changes made to those files are kept up to date in the build.

For this to work, instead of specifying the full path for the key/cert files in TEGRA_UEFI_DB_KEY/TEGRA_UEFI_DB_CERT user must specify the file names.
The path for where key/cert are located must be provided in the variable TEGRA_UEFI_DB_PATH