### PR TITLE
gcc-for-nvcc: fix populate sdk

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-target.inc
@@ -193,7 +193,6 @@ do_install () {
 	ln -sf ${TARGET_PREFIX}cpp-${BINV} cpp-${BINV}
 	ln -sf ${TARGET_PREFIX}gcov-${BINV} gcov-${BINV}
 	ln -sf ${TARGET_PREFIX}gcov-tool-${BINV} gcov-tool-${BINV}
-	install -d ${D}${base_libdir}
 	ln -sf g++-${BINV} c++-${BINV}
 	ln -sf gcc-${BINV} cc-${BINV}
 	chown -R root:root ${D}


### PR DESCRIPTION
Since the commit gcc-for-nvcc: clean up after upgrade to 13.2 sha: 47b7d680d667a77b9fc1e231f9b6e53d2bc9941f

the command populate_sdk were not working.

I have removed the line causing this (do not create not used folder into the installation).

Should be merged into scarthgap, master, walnascar as well.

(for Walnascar, I saw that both commit 117b855d25783a0b10a4ca4404af1b5718af0279 & 47b7d680d667a77b9fc1e231f9b6e53d2bc9941f were not merged into this branch but only master).