### PR TITLE
fix: update image_types_tegra task dependency for uefi keys dtb

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -25,7 +25,7 @@ def tegra_dtb_extra_deps(d):
     if d.getVar('PREFERRED_PROVIDER_virtual/dtb'):
         deps.append('virtual/dtb:do_populate_sysroot')
     if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
-        deps.append('tegra-uefi-keys-dtb:do_populate_sysroot')
+        deps.append('tegra-uefi-keys-dtb:do_deploy')
     return ' '.join(deps)
 
 def tegra_bootcontrol_overlay_list(d, bup=False, separator=','):


### PR DESCRIPTION
This change addresses an issue where the `image_types_tegra.bbclass` was incorrectly depending on the `do_populate_sysroot` task of `tegra-uefi-keys-dtb` package while looking for files from that recipe in the `DEPLOYDIR` directory.  Without an explicit dependency on do_deploy, those files are not correctly 'staged' and builds will fail IF `tegra-uefi-keys-dtb:do_deploy` has not yet run.  By adding the `do_deploy` task as a dependency, it ensures the files are correctly staged for the image recipe to succeed.