### PR TITLE
docs: migrate from element to discord

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -2,11 +2,9 @@ Welcome! Here you'll find some useful pages and notes on using the meta-tegra la
 
 If you are a new to the platform and don't have a specific set of layers you plan to use with meta-tegra, or if you are just interested in trying meta-tegra for the first time as quickly as possible, we highly recommend checking out [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) as a starting point.  See the README there for instructions to build one of several demo images which demonstrate the capabilities of meta-tegra and companion layers.
 
-For real-time communication, the OE4T project uses [https://gitter.im/OE4T/community](https://gitter.im/OE4T/community)
- * See apps at [https://gitter.im/#apps](https://gitter.im/#apps)
- * Also available over IRC - see [https://gitlab.com/gitterHQ/irc-bridge/-/wikis/Client-configuration](https://gitlab.com/gitterHQ/irc-bridge/-/wikis/Client-configuration) for client configuration details
-
-Ignore any historical references to slack as this repository is no longer available.
+For real-time communication, the OE4T project uses [The OE4T Discord Community Server](https://discord.gg/wF75FRVjxm)
+* Ignore any historical references to slack as this repository is no longer available.
+* Element/gitter/matrix references are now read only.
 
 See the thread at [https://github.com/OE4T/meta-tegra/discussions/515](https://github.com/OE4T/meta-tegra/discussions/515) for monthly meeting schedules.
 


### PR DESCRIPTION
As discussed in the monthly meeting, move discussion to Discord and share discord invite from this page.