### PR TITLE
cuda: add nativesdk-cuda-driver-stubs to runtime dependencies for cud…

### DIFF
--- a/recipes-devtools/cuda/cuda-gdb_12.6.68-1.bb
+++ b/recipes-devtools/cuda/cuda-gdb_12.6.68-1.bb
@@ -15,4 +15,9 @@ FILES:${PN}-dev += "${prefix}/local/cuda-${CUDA_VERSION}/share/gdb"
 RDEPENDS:${PN} += "gmp"
 RDEPENDS:${PN}-dev += "python3"
 INSANE_SKIP:${PN}-dev += "staticdev"
+# cuda-gdb ships pre-built TUI binaries for multiple Python versions (3.8-3.12)
+# linked against libpython3.x, libncurses and libcrypt from the host OS.
+# There are no nativesdk providers for these system libraries — they are
+# expected to be satisfied by the developer's host at runtime.
+INSANE_SKIP:${PN}:class-nativesdk += "file-rdeps"
 BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/cuda/cuda-nvprof_12.6.68-1.bb
+++ b/recipes-devtools/cuda/cuda-nvprof_12.6.68-1.bb
@@ -6,6 +6,7 @@ COMPATIBLE_HOST:tegra = "(-)"
 
 MAINSUM = "6b0171bb815ff6d62cb84f51868afa12975d71f2ba60d43be0dd6a29a7a989d4"
 
+RDEPENDS:${PN}:class-nativesdk += "nativesdk-cuda-driver-stubs"
 DEPENDS = "cuda-cupti"
 ALLOW_EMPTY:${PN} = "1"
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
When populateing sdk with:
`TOOLCHAIN_HOST_TASK:append = " nativesdk-cuda-nvprof nativesdk-cuda-gdb "`
an error occirs during `package_qa `step with  `file-rdeps` missing dependencies.

This PR fixes these QA issues for both recipes.

**NOTE** : not sure if the sip is the best option for `cuda-gdb`