### PR TITLE
gcc-for-nvcc: force building with c++17

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-13.2.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-13.2.inc
@@ -118,3 +118,5 @@ EXTRA_OECONF_PATHS = "\
 
 CVE_STATUS[CVE-2021-37322] = "cpe-incorrect: Is a binutils 2.26 issue, not gcc"
 CVE_STATUS[CVE-2023-4039] = "fixed-version: Fixed via CVE-2023-4039.patch included here. Set the status explictly to deal with all recipes that share the gcc-source"
+
+CXX:append = " -std=gnu++17"


### PR DESCRIPTION
The gcc-13 code base isn't suitable for -std=c++20 compilation, which is the built-in default for the gcc-16 toolchain; work around that by appending -std=gnu++17 in the CXX definition.

See #2214 