### PR TITLE
docs: announce upcoming L4T R39.2.0/JetPack 7.2 release

### DIFF
--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,6 +1,14 @@
-Welcome! Here you'll find some useful pages and notes on using the meta-tegra layer in your project. See the linked pages to have a look around!  You may want to start with [this page](Which-branch-should-I-use.md) for information on which branches support which platforms and L4T releases.
+# OpenEmbedded/Yocto for Nvidia Jetson devices
 
-If you are a new to the platform and don't have a specific set of layers you plan to use with meta-tegra, or if you are just interested in trying meta-tegra for the first time as quickly as possible, we highly recommend checking out [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) as a starting point.  See the README there for instructions to build one of several demo images which demonstrate the capabilities of meta-tegra and companion layers.
+Welcome! Here you'll find some useful pages and notes on using the meta-tegra layer in your project. See the linked pages to have a look around!
+
+# Getting started
+
+Start with [the branches and releases page](Which-branch-should-I-use.md) for information on which branches support which platforms and L4T releases.
+
+We highly recommend checking out [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) as a starting point.  See the README there for instructions to build one of several demo images which demonstrate the capabilities of meta-tegra and companion layers.
+
+# Getting help
 
 For real-time communication, the OE4T project uses [The OE4T Discord Community Server](https://discord.gg/wF75FRVjxm)
 * Ignore any historical references to slack as this repository is no longer available.

--- a/docs/Which-branch-should-I-use.md
+++ b/docs/Which-branch-should-I-use.md
@@ -11,6 +11,10 @@ For Jetson Linux (L4T) releases:
 * branches corresponding to regular (non-LTS) OE-Core release branches track the latest Jetson Linux release at the time the branch is created
 * branches corresponding to long-term support (LTS) OE-Core release branches are kept up-to-date with the Jetson Linux releases. When there is a significant Jetson Linux upgrade, an additional LTS branch is created for the older release series.
 
+Upcoming branches:
+* **master** - [L4T R39.2.0/JetPack 7.2](release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md) for AGX Thor/AGX Orin/Orin NX/Orin Nano
+* **wrynose** - [L4T R39.2.0/JetPack 7.2](release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md) for AGX Thor/AGX Orin/Orin NX/Orin Nano
+
 Active branches:
 * **master** - never stable, [L4T R36.5.0/JetPack 6.2.2](release-notes/JetPack-6.2.2-L4T-R36.5.0-Notes.md) for AGX Orin/Orin NX/Orin Nano
 * **master-l4t-r38.4.x** - never stable, [L4T R38.4.0/JetPack 7.1](release-notes/JetPack-7.1-L4T-R38.4.x-Notes.md) for AGX Thor

--- a/docs/release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md
+++ b/docs/release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md
@@ -1,0 +1,6 @@
+
+# Changes from L4T R39.2.0/JetPack 7.2
+
+This will be an officially supported Nvidia release. This release supports both Orin and Thor.
+
+* **Jetson Linux R39.2.0 release notes** will be coming soon.


### PR DESCRIPTION
Add release notes page, list master and wrynose as upcoming branches, and reorganize the Home page into getting started/help sections.