### PR TITLE
patches used to fix issue of nvidia-kernel-oot

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -100,6 +100,8 @@ COMMON_PATCHES = "\
     file://0084-video-tegra-pva-use-DMA-IOVA-API-for-contiguous-sync.patch;patchdir=nvidia-oot \
     file://0085-video-tegra-pva-add-missing-nvhost-syncpt-interface-.patch;patchdir=nvidia-oot \
     file://0086-video-tegra-nvcsi-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
+    file://0087-video-tegra-isp5-fix-use-after-free-on-module-unload.patch;patchdir=nvidia-oot \
+    file://0088-video-tegra-isp5-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -89,6 +89,7 @@ COMMON_PATCHES = "\
     file://0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch;patchdir=nvdisplay \
     file://0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch;patchdir=nvdisplay \
     file://0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch;patchdir=nvidia-oot \
+    file://0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -86,6 +86,7 @@ COMMON_PATCHES = "\
     file://0070-drivers-capture-common-only-create-memory-cache-at-t.patch;patchdir=nvidia-oot \
     file://0071-usb-typec-release-resource-when-removing-usb-driver-.patch;patchdir=nvidia-oot \
     file://0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch;patchdir=nvdisplay \
+    file://0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch;patchdir=nvdisplay \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -88,6 +88,7 @@ COMMON_PATCHES = "\
     file://0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch;patchdir=nvdisplay \
     file://0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch;patchdir=nvdisplay \
     file://0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch;patchdir=nvdisplay \
+    file://0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -84,6 +84,7 @@ COMMON_PATCHES = "\
     file://0068-usb-typec-remove-IRQF_ONESHOT-flag.patch;patchdir=nvidia-oot \
     file://0069-host1x-fence-call-fput-to-avoid-memory-leak.patch;patchdir=nvidia-oot \
     file://0070-drivers-capture-common-only-create-memory-cache-at-t.patch;patchdir=nvidia-oot \
+    file://0071-usb-typec-release-resource-when-removing-usb-driver-.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -92,6 +92,8 @@ COMMON_PATCHES = "\
     file://0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch;patchdir=nvidia-oot \
     file://0077-drivers-nvethernet-speed-10-is-not-supported-while-a.patch;patchdir=nvidia-oot \
     file://0078-nvdisplay-replace-lock-sync-with-wait-event-mechanis.patch;patchdir=nvdisplay \
+    file://0079-nvgpu-dma-use-unlocked-variant-function-to-process-d.patch;patchdir=nvgpu \
+    file://0080-nvdisplay-dma-use-unlocked-variant-function-when-map.patch;patchdir=nvdisplay \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -94,6 +94,7 @@ COMMON_PATCHES = "\
     file://0078-nvdisplay-replace-lock-sync-with-wait-event-mechanis.patch;patchdir=nvdisplay \
     file://0079-nvgpu-dma-use-unlocked-variant-function-to-process-d.patch;patchdir=nvgpu \
     file://0080-nvdisplay-dma-use-unlocked-variant-function-when-map.patch;patchdir=nvdisplay \
+    file://0081-gpu-nvgpu-probe-clock-availability-during-acquisitio.patch;patchdir=nvgpu \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -107,6 +107,7 @@ COMMON_PATCHES = "\
     file://0091-media-tegra-vi-fix-NULL-pointer-dereference-in-chann.patch;patchdir=nvidia-oot \
     file://0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch;patchdir=nvidia-oot \
     file://0093-media-tegra-vi-fix-memory-leak-in-media-v4l2-cleanup.patch;patchdir=nvidia-oot \
+    file://0094-video-tegra-capture-support-fix-resource-leak-on-mod.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -102,6 +102,7 @@ COMMON_PATCHES = "\
     file://0086-video-tegra-nvcsi-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
     file://0087-video-tegra-isp5-fix-use-after-free-on-module-unload.patch;patchdir=nvidia-oot \
     file://0088-video-tegra-isp5-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
+    file://0089-video-tegra-vi5-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -103,6 +103,9 @@ COMMON_PATCHES = "\
     file://0087-video-tegra-isp5-fix-use-after-free-on-module-unload.patch;patchdir=nvidia-oot \
     file://0088-video-tegra-isp5-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
     file://0089-video-tegra-vi5-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
+    file://0090-media-tegra-capture-vi-fix-use-after-free-on-module-.patch;patchdir=nvidia-oot \
+    file://0091-media-tegra-vi-fix-NULL-pointer-dereference-in-chann.patch;patchdir=nvidia-oot \
+    file://0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -99,6 +99,7 @@ COMMON_PATCHES = "\
     file://0083-video-tegra-pva-use-dma_map_phys-for-RAM-backed-carv.patch;patchdir=nvidia-oot \
     file://0084-video-tegra-pva-use-DMA-IOVA-API-for-contiguous-sync.patch;patchdir=nvidia-oot \
     file://0085-video-tegra-pva-add-missing-nvhost-syncpt-interface-.patch;patchdir=nvidia-oot \
+    file://0086-video-tegra-nvcsi-fix-resource-leak-on-module-unload.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -87,6 +87,7 @@ COMMON_PATCHES = "\
     file://0071-usb-typec-release-resource-when-removing-usb-driver-.patch;patchdir=nvidia-oot \
     file://0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch;patchdir=nvdisplay \
     file://0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch;patchdir=nvdisplay \
+    file://0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch;patchdir=nvdisplay \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -108,6 +108,7 @@ COMMON_PATCHES = "\
     file://0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch;patchdir=nvidia-oot \
     file://0093-media-tegra-vi-fix-memory-leak-in-media-v4l2-cleanup.patch;patchdir=nvidia-oot \
     file://0094-video-tegra-capture-support-fix-resource-leak-on-mod.patch;patchdir=nvidia-oot \
+    file://0095-net-can-mttcan-fix-use-after-free-issue-of-skb.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -91,6 +91,7 @@ COMMON_PATCHES = "\
     file://0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch;patchdir=nvidia-oot \
     file://0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch;patchdir=nvidia-oot \
     file://0077-drivers-nvethernet-speed-10-is-not-supported-while-a.patch;patchdir=nvidia-oot \
+    file://0078-nvdisplay-replace-lock-sync-with-wait-event-mechanis.patch;patchdir=nvdisplay \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -90,6 +90,7 @@ COMMON_PATCHES = "\
     file://0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch;patchdir=nvdisplay \
     file://0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch;patchdir=nvidia-oot \
     file://0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch;patchdir=nvidia-oot \
+    file://0077-drivers-nvethernet-speed-10-is-not-supported-while-a.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -80,6 +80,7 @@ COMMON_PATCHES = "\
     file://0064-nvdisplay-nvidia-drm-support-fbdev-on-Linux-6.11-ker.patch;patchdir=nvdisplay \
     file://0065-nvdisplay-nvidia-drm-trigger-connector-detect-on-hot.patch;patchdir=nvdisplay \
     file://0066-nvdisplay-nvidia-drm-update-legacy-modeset-state-on-.patch;patchdir=nvdisplay \
+    file://0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -81,6 +81,7 @@ COMMON_PATCHES = "\
     file://0065-nvdisplay-nvidia-drm-trigger-connector-detect-on-hot.patch;patchdir=nvdisplay \
     file://0066-nvdisplay-nvidia-drm-update-legacy-modeset-state-on-.patch;patchdir=nvdisplay \
     file://0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch;patchdir=nvidia-oot \
+    file://0068-usb-typec-remove-IRQF_ONESHOT-flag.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -95,6 +95,10 @@ COMMON_PATCHES = "\
     file://0079-nvgpu-dma-use-unlocked-variant-function-to-process-d.patch;patchdir=nvgpu \
     file://0080-nvdisplay-dma-use-unlocked-variant-function-when-map.patch;patchdir=nvdisplay \
     file://0081-gpu-nvgpu-probe-clock-availability-during-acquisitio.patch;patchdir=nvgpu \
+    file://0082-gpu-host1x-Do-not-setup-DMA-for-virtual-devices.patch;patchdir=nvidia-oot \
+    file://0083-video-tegra-pva-use-dma_map_phys-for-RAM-backed-carv.patch;patchdir=nvidia-oot \
+    file://0084-video-tegra-pva-use-DMA-IOVA-API-for-contiguous-sync.patch;patchdir=nvidia-oot \
+    file://0085-video-tegra-pva-add-missing-nvhost-syncpt-interface-.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -83,6 +83,7 @@ COMMON_PATCHES = "\
     file://0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch;patchdir=nvidia-oot \
     file://0068-usb-typec-remove-IRQF_ONESHOT-flag.patch;patchdir=nvidia-oot \
     file://0069-host1x-fence-call-fput-to-avoid-memory-leak.patch;patchdir=nvidia-oot \
+    file://0070-drivers-capture-common-only-create-memory-cache-at-t.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -82,6 +82,7 @@ COMMON_PATCHES = "\
     file://0066-nvdisplay-nvidia-drm-update-legacy-modeset-state-on-.patch;patchdir=nvdisplay \
     file://0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch;patchdir=nvidia-oot \
     file://0068-usb-typec-remove-IRQF_ONESHOT-flag.patch;patchdir=nvidia-oot \
+    file://0069-host1x-fence-call-fput-to-avoid-memory-leak.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -106,6 +106,7 @@ COMMON_PATCHES = "\
     file://0090-media-tegra-capture-vi-fix-use-after-free-on-module-.patch;patchdir=nvidia-oot \
     file://0091-media-tegra-vi-fix-NULL-pointer-dereference-in-chann.patch;patchdir=nvidia-oot \
     file://0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch;patchdir=nvidia-oot \
+    file://0093-media-tegra-vi-fix-memory-leak-in-media-v4l2-cleanup.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -85,6 +85,7 @@ COMMON_PATCHES = "\
     file://0069-host1x-fence-call-fput-to-avoid-memory-leak.patch;patchdir=nvidia-oot \
     file://0070-drivers-capture-common-only-create-memory-cache-at-t.patch;patchdir=nvidia-oot \
     file://0071-usb-typec-release-resource-when-removing-usb-driver-.patch;patchdir=nvidia-oot \
+    file://0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch;patchdir=nvdisplay \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0067-drm-tegra-release-the-count-of-pid-to-avoid-memory-l.patch
@@ -1,0 +1,55 @@
+From aa84b6dbf1fe224889872a834259ba8e6f60ee66 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Fri, 1 Aug 2025 15:29:04 +0800
+Subject: [PATCH] drm/tegra: release the refcount of pid to avoid memory leak
+
+When playing a mp4 file with gstreamer command gst-launch-1.0, there is
+below memory leak reported:
+  backtrace (crc 57282538):
+    kmemleak_alloc+0x3c/0x50
+    kmem_cache_alloc_noprof+0x1b8/0x420
+    alloc_pid+0x68/0x3e0
+    copy_process+0xbb0/0x1440
+    kernel_clone+0x78/0x3f8
+    __do_sys_clone+0x74/0xb0
+    __arm64_sys_clone+0x28/0x40
+    invoke_syscall+0x5c/0x128
+    el0_svc_common.constprop.0+0xc8/0xf8
+    do_el0_svc+0x24/0x40
+    el0_svc+0x30/0xf8
+    el0t_64_sync_handler+0x120/0x138
+    el0t_64_sync+0x190/0x198
+This issue is caused by forgetting to release the refcount of pid, so call
+put_pid() to avoid memory leak.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/gpu/drm/tegra/uapi.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/tegra/uapi.c b/drivers/gpu/drm/tegra/uapi.c
+index 0f9342b..2df0d51 100644
+--- a/drivers/gpu/drm/tegra/uapi.c
++++ b/drivers/gpu/drm/tegra/uapi.c
+@@ -118,9 +118,14 @@ int tegra_drm_ioctl_channel_open(struct drm_device *drm, void *data, struct drm_
+ 		if (err)
+ 			goto put_channel;
+ 
+-		if (supported)
++		if (supported) {
++			struct pid *current_pid;
++
++			current_pid = get_task_pid(current, PIDTYPE_TGID);
+ 			context->memory_context = host1x_memory_context_alloc(
+-				host, client->base.dev, get_task_pid(current, PIDTYPE_TGID));
++				host, client->base.dev, current_pid);
++			put_pid(current_pid);
++		}
+ 
+ 		if (IS_ERR(context->memory_context)) {
+ 			if (PTR_ERR(context->memory_context) != -EOPNOTSUPP) {
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0068-usb-typec-remove-IRQF_ONESHOT-flag.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0068-usb-typec-remove-IRQF_ONESHOT-flag.patch
@@ -1,0 +1,51 @@
+From 04b956afadbab27145f941821a3a3a8facd77f35 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Fri, 24 Oct 2025 09:45:23 +0800
+Subject: [PATCH] usb: typec: remove IRQF_ONESHOT flag
+
+When booting up the rt kernel, there is below warning trace
+Call trace:
+......
+__might_resched+0x15c/0x1e0
+rt_spin_lock+0x5c/0x128
+pm_wakeup_ws_event.part.0+0x34/0x138
+pm_wakeup_ws_event+0x20/0x40
+fusb301_irq_handler+0x48/0x80 [fusb301]
+......
+tegra186_gpio_irq+0x148/0x270
+handle_irq_desc+0x3c/0x68
+generic_handle_domain_irq+0x24/0x40
+gic_handle_irq+0x6c/0xe4
+......
+__primary_switched+0x80/0x90
+If set IRQF_ONESHOT flag when registering interrupt handler,
+the interrupt handler will be executed in atomic status, and report
+warning trace when calling rt lock. Because the IRQF_ONESHOT flag
+is for threaded interrupt, but there is no threaded interrupt handler
+when registering interrupt, it does not need to set this flag. In this
+way, in rt kernel, interrupt handler fusb301_irq_handler() will be
+executed in threaded context, and there will be no warning trace.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/usb/typec/fusb301.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/usb/typec/fusb301.c b/drivers/usb/typec/fusb301.c
+index 717ec17..8a6a6f1 100644
+--- a/drivers/usb/typec/fusb301.c
++++ b/drivers/usb/typec/fusb301.c
+@@ -1452,7 +1452,7 @@ static int fusb301_probe(struct i2c_client *client,
+ 
+ 	ret = devm_request_threaded_irq(cdev, client->irq,
+ 			  fusb301_irq_handler, NULL,
+-			  IRQF_ONESHOT, dev_name(cdev),
++			  0, dev_name(cdev),
+ 			  chip);
+ 	if (ret)
+ 		goto destroy_workqueue;
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0069-host1x-fence-call-fput-to-avoid-memory-leak.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0069-host1x-fence-call-fput-to-avoid-memory-leak.patch
@@ -1,0 +1,43 @@
+From 2244a8c6bd34706c6d2ce952f6584735783c6da6 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Sun, 26 Oct 2025 13:27:09 +0800
+Subject: [PATCH] host1x-fence: call fput() to avoid memory leak
+
+When running deepstream test, there is below memory leak reported
+  backtrace (crc d553f09):
+    kmemleak_alloc+0x3c/0x50
+    kmem_cache_alloc_noprof+0x184/0x3a0
+    alloc_empty_file+0x68/0x138
+    alloc_file_pseudo+0xac/0x120
+    anon_inode_getfile+0x78/0x100
+    dev_file_ioctl+0x24c/0x630 [host1x_fence]
+    __arm64_sys_ioctl+0xb4/0x100
+    invoke_syscall+0x5c/0x128
+    ......
+    el0t_64_sync+0x190/0x198
+This issue is caused by forgetting release file, so call fput () to avoid
+memory leak.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/gpu/host1x-fence/dev.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/host1x-fence/dev.c b/drivers/gpu/host1x-fence/dev.c
+index 2229978..02b8f86 100644
+--- a/drivers/gpu/host1x-fence/dev.c
++++ b/drivers/gpu/host1x-fence/dev.c
+@@ -393,6 +393,8 @@ static int dev_file_ioctl_trigger_pollfd(struct host1x *host1x, void __user *dat
+ 
+ 	mutex_unlock(&pollfd->lock);
+ 
++	fput(file);
++
+ 	return 0;
+ 
+ remove_fence:
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0070-drivers-capture-common-only-create-memory-cache-at-t.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0070-drivers-capture-common-only-create-memory-cache-at-t.patch
@@ -1,0 +1,76 @@
+From fae98a2843915fb3ef8df7f5c774d70d0ab034e7 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Tue, 28 Oct 2025 14:44:47 +0800
+Subject: [PATCH] drivers: capture-common: only create memory cache at the
+ first time
+
+Based on current camera driver design, there are multiple drivers that
+intend to create memory cache with the same name, it is unreasonable.
+So, only create memory cache at the first time, and save it as a global
+variable. If subsequent drivers try to create memory cache, return
+existing the global one directly. In this way, it needs to create a
+variable to count, so that release memory cache if it is equal to 0.
+In addition, use a mutex to protect counter and memory create/destroy
+operation, so that avoid executing code concurrently.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ .../camera/fusa-capture/capture-common.c      | 25 +++++++++++++++++--
+ 1 file changed, 23 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/media/platform/tegra/camera/fusa-capture/capture-common.c b/drivers/media/platform/tegra/camera/fusa-capture/capture-common.c
+index 9a80e53..2312eb5 100644
+--- a/drivers/media/platform/tegra/camera/fusa-capture/capture-common.c
++++ b/drivers/media/platform/tegra/camera/fusa-capture/capture-common.c
+@@ -21,6 +21,17 @@
+ 
+ #include <media/fusa-capture/capture-common.h>
+ 
++/**
++ * There are multiple drivers that intend to create memory cache with
++ * the same name, it is unreasonable. So, only create memory cache at
++ * the first time, and save it as a global variable. If subsequent drivers
++ * try to create memory cache, return existing the global one directly.
++ * In this way, it needs to create a variable to count, so that release
++ * memory cache if it is equal to 0.
++ */
++static int refcount = 0;
++static struct kmem_cache *memory_cache;
++static DEFINE_MUTEX(kmem_lock);
+ 
+ /**
+  * @brief Capture buffer management table.
+@@ -328,7 +339,13 @@ struct capture_buffer_table *create_buffer_table(
+ 	tab = kmalloc(sizeof(*tab), GFP_KERNEL);
+ 
+ 	if (likely(tab != NULL)) {
+-		tab->cache = KMEM_CACHE(capture_mapping, 0U);
++		mutex_lock(&kmem_lock);
++		if (refcount == 0)
++			tab->cache = memory_cache = KMEM_CACHE(capture_mapping, 0U);
++		else
++			tab->cache = memory_cache;
++		refcount++;
++		mutex_unlock(&kmem_lock);
+ 
+ 		if (likely(tab->cache != NULL)) {
+ 			tab->dev = dev;
+@@ -366,8 +383,12 @@ void destroy_buffer_table(
+ 		kmem_cache_free(tab->cache, pin);
+ 	}
+ 
++	mutex_lock(&kmem_lock);
++	refcount--;
++	if (refcount == 0)
++		kmem_cache_destroy(memory_cache);
++	mutex_unlock(&kmem_lock);
+ 
+-	kmem_cache_destroy(tab->cache);
+ 	kfree(tab);
+ }
+ EXPORT_SYMBOL_GPL(destroy_buffer_table);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0071-usb-typec-release-resource-when-removing-usb-driver-.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0071-usb-typec-release-resource-when-removing-usb-driver-.patch
@@ -1,0 +1,35 @@
+From 183e668ee87fe399a092060483c0e090eedd4f1f Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Tue, 28 Oct 2025 16:49:29 +0800
+Subject: [PATCH] usb: typec: release resource when removing usb driver module
+
+When uninstalling and installing usb driver module quickly and
+continuously, there may be a panic triggered because of accessing
+memory that has been released. For example, the struct delayed_work
+instance (twork) is not stopped when removing usb driver module,
+so, it may access unknown memory and cause panic. In order to avoid
+this issue, cancel the 2 work instances in fusb301_remove().
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/usb/typec/fusb301.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/usb/typec/fusb301.c b/drivers/usb/typec/fusb301.c
+index 717ec17..f0141cc 100644
+--- a/drivers/usb/typec/fusb301.c
++++ b/drivers/usb/typec/fusb301.c
+@@ -1492,6 +1492,8 @@ static void fusb301_remove(struct i2c_client *client)
+ 		return;
+ #endif
+ 
++	cancel_work_sync(&chip->dwork);
++	cancel_delayed_work_sync(&chip->twork);
+ 	sysfs_remove_group(&cdev->kobj, &fusb_sysfs_group);
+ 	destroy_workqueue(chip->cc_wq);
+ 	mutex_destroy(&chip->mlock);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0072-nvdisplay-nv-platform-call-platform_device_put-to-de.patch
@@ -1,0 +1,47 @@
+From 7e77f65ef1e10fa8458d79e7a27aa7542bd5459b Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Thu, 30 Oct 2025 11:43:16 +0800
+Subject: [PATCH] nvdisplay: nv-platform: call platform_device_put() to
+ decrease reference of niso device
+
+When uninstalling drivers and then installing again with below command:
+There are some memory leaks, one of examples as below:
+kmemleak_alloc+0x3c/0x50
+__kmalloc_noprof+0x228/0x418
+platform_device_alloc+0x34/0xe0
+of_device_alloc+0x50/0x1a8
+of_platform_device_create_pdata+0x58/0x120
+of_platform_bus_create+0x194/0x390
+of_platform_populate+0x58/0x110
+devm_of_platform_populate+0x60/0xd0
+nv_platform_device_display_probe+0x23c/0xa80 [nvidia]
+nv_platform_device_probe+0x18/0x30 [nvidia]
+......
+bus_for_each_dev+0x84/0x100
+Because reference of niso device is not decreased correctly,
+and then cause memory leak when driver is installed again, call
+platform_device_put() to decrease reference of niso device so
+that avoid memory leak.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ kernel-open/nvidia/nv-platform.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/kernel-open/nvidia/nv-platform.c b/kernel-open/nvidia/nv-platform.c
+index 16c1afb..0eb0447 100644
+--- a/kernel-open/nvidia/nv-platform.c
++++ b/kernel-open/nvidia/nv-platform.c
+@@ -618,6 +618,7 @@ static int nv_platform_register_mapping_devs(struct platform_device *plat_dev,
+ 
+ register_mapping_devs_end:
+     of_node_put(niso_np);
++    platform_device_put(niso_plat_dev);
+     return rc;
+ }
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0073-nvidia-modeset-dp-decrease-reference-if-destroy-func.patch
@@ -1,0 +1,54 @@
+From bd9375cd1e560e429cab177660b068627d2b0e3b Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Wed, 5 Nov 2025 12:03:19 +0800
+Subject: [PATCH] nvidia-modeset: dp: decrease reference if destroy function is
+ invoked before timer callback
+
+When monitor enters black screen status, there is a below memory
+leak reported if stop xserver-nodm service.
+kmemleak_alloc+0x3c/0x50
+__kmalloc_noprof+0x2a4/0x500
+nvkms_alloc+0x78/0x120 [nvidia_modeset]
+nvkms_alloc_ref_ptr+0x28/0x50 [nvidia_modeset]
+nvAllocDevEvo+0x6c/0x2a0 [nvidia_modeset]
+nvidia_frontend_unlocked_ioctl+0x4c/0x70 [nvidia]
+......
+el0t_64_sync+0x190/0x198
+After analyzing code, the root cause as below:
+When monitor is in black status and stop xserver-nodm service,
+there is a 2000ms delay timer created. But because of the stop
+operation, timer is freed in Timer::Callback::~Callback() destroy
+function, and the cancel filed of struct nvkms_timer_t is set as true
+before the delay timer that will be triggered in 2000ms later. In this
+way, the proc() function of struct nvkms_timer_t is not able to be
+invoked, and then causes the reference of struct _NVEvoDevRec
+instance is not decreased, and ref_ptr_free() is not invoked, finally
+the struct nvkms_ref_ptr instance is not released. In order to fix the
+memory, check whether Timer::Callback::~Callback() destroy function
+is called before timer callback, if so, it also needs to decrease the
+reference of of struct _NVEvoDevRec instance.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ src/nvidia-modeset/src/dp/nvdp-timer.cpp | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/nvidia-modeset/src/dp/nvdp-timer.cpp b/src/nvidia-modeset/src/dp/nvdp-timer.cpp
+index bc4d2e2..5e94051 100644
+--- a/src/nvidia-modeset/src/dp/nvdp-timer.cpp
++++ b/src/nvidia-modeset/src/dp/nvdp-timer.cpp
+@@ -47,6 +47,9 @@ namespace nvkmsDisplayPort {
+ 
+     Timer::Callback::~Callback()
+     {
++        if (!isExpired(nvkms_get_usec())) {
++            nvkms_dec_ref(ref_ptr);
++	}
+         nvkms_free_timer(handle);
+     }
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0074-nvdisplay-nv-platform-set-the-dma-segment-size-for-n.patch
@@ -1,0 +1,62 @@
+From 45aa275d465329ec8fd06ffdb928a1834a470f43 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Wed, 8 Apr 2026 19:18:00 +0800
+Subject: [PATCH] nvdisplay: nv-platform: set the dma segment size for nvidia
+ display device
+
+If kernel config CONFIG_DMA_API_DEBUG is enabled, there are below 2
+similar warning trace reported during kernel boots up:
+The 1st one:
+DMA-API: nv_platform 13800000.display: mapping sg segment longer
+than device claims to support [len=8847360] [max=65536]
+WARNING: CPU: 1 PID: 1629 at /usr/src/kernel/kernel/dma/debug.c:1183
+Call trace:
+debug_dma_map_sg+0x29c/0x408 (P)
+__dma_map_sg_attrs+0xb0/0x240
+......
+nvRmApiAlloc+0x4c/0x60 [nvidia_modeset]
+nvidia_frontend_unlocked_ioctl+0x4c/0x70 [nvidia]
+The 2nd one:
+DMA-API: platform 13800000.display:nvdisplay-niso: mapping sg segment
+longer than device claims to support [len=126976] [max=65536]
+WARNING: CPU: 3 PID: 1478 at /usr/src/kernel/kernel/dma/debug.c:1181
+Call trace:
+check_sg_segment+0x1b0/0x228 (P)
+debug_dma_map_sg+0x1a0/0x1f0
+......
+nvRmAllocDeviceEvo+0x640/0x800 [nvidia_modeset]
+nvidia_frontend_unlocked_ioctl+0x4c/0x70 [nvidia]
+Because the kernel default 'max_seg_size' is 64K, and the mapping sg
+segment longer it. In order to avoid this issue, set the dma segment
+size as UINT_MAX.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ kernel-open/nvidia/nv-platform.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/kernel-open/nvidia/nv-platform.c b/kernel-open/nvidia/nv-platform.c
+index 36167ec..29d8a47 100644
+--- a/kernel-open/nvidia/nv-platform.c
++++ b/kernel-open/nvidia/nv-platform.c
+@@ -614,6 +614,7 @@ static int nv_platform_register_mapping_devs(struct platform_device *plat_dev,
+     nvl->niso_dma_dev.addressable_range.start = 0;
+     nvl->niso_dma_dev.addressable_range.limit = NV_U64_MAX;
+     nv->niso_dma_dev = &nvl->niso_dma_dev;
++    dma_set_max_seg_size(&niso_plat_dev->dev, UINT_MAX);
+ 
+ register_mapping_devs_end:
+     of_node_put(niso_np);
+@@ -706,6 +707,7 @@ static int nv_platform_device_display_probe(struct platform_device *plat_dev)
+     nvl->dma_dev.addressable_range.start = 0;
+     nvl->dma_dev.addressable_range.limit = NV_U64_MAX;
+     nv->dma_dev = &nvl->dma_dev;
++    dma_set_max_seg_size(nvl->dev, UINT_MAX);
+ 
+     nvl->tce_bypass_enabled = NV_TRUE;
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0075-drivers-devfreq-call-devfreq_get_freq_range-in-locke.patch
@@ -1,0 +1,41 @@
+From 12b190ad3cccf8f00b1aefef7c47507a5e26d7b4 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 22 Dec 2025 12:12:17 +0800
+Subject: [PATCH] drivers:devfreq: call devfreq_get_freq_range in locked status
+
+When calling function devfreq_get_freq_range, there is below
+warning trace:
+Call trace:
+devfreq_get_freq_range+0x120/0x130
+devfreq_update_wmark_threshold+0x5c/0x1b8 [tegra_wmark]
+devfreq_tegra_wmark_event_handler+0x190/0x1d8 [tegra_wmark]
+......
+el0t_64_sync_handler+0x120/0x130
+el0t_64_sync+0x190/0x198
+Because it needs to execute in locked status. So refer to other
+similar code, add lock to avoid warning trace.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/devfreq/tegra_wmark.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/devfreq/tegra_wmark.c b/drivers/devfreq/tegra_wmark.c
+index 0405f73..7194c01 100644
+--- a/drivers/devfreq/tegra_wmark.c
++++ b/drivers/devfreq/tegra_wmark.c
+@@ -183,7 +183,9 @@ static void devfreq_update_wmark_threshold(struct devfreq *df)
+ #endif
+ 	int err;
+ 
++	mutex_lock(&df->lock);
+ 	devfreq_get_freq_range(df, &min_freq, &max_freq);
++	mutex_unlock(&df->lock);
+ 
+ 	err = devfreq_update_stats(df);
+ 	if (err)
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0076-drivers-devfreq-avoid-deadlock-issue-when-calling-de.patch
@@ -1,0 +1,92 @@
+From 28c7b56e08e415dc2afb829a5dab1b61dd79b169 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Wed, 24 Dec 2025 13:40:20 +0800
+Subject: [PATCH] drivers:devfreq: avoid deadlock issue when calling
+ devfreq_update_wmark_threshold()
+
+After applying last patch ("drivers:devfreq: call devfreq_get_freq_range
+in locked status"), there is a deadlock issue when running multimedia
+cases. Because devfreq_update_wmark_threshold() is called in different
+logical path, sometimes already in locked status, sometimes not, it
+should not add mutex lock in devfreq_update_wmark_threshold() simply.
+In order to avoid deadlock issue, it needs to process it case by case,
+only add mutex lock when devfreq_update_wmark_threshold() is called
+under unlocked status.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/devfreq/tegra_wmark.c | 15 +++++++--------
+ 1 file changed, 7 insertions(+), 8 deletions(-)
+
+diff --git a/drivers/devfreq/tegra_wmark.c b/drivers/devfreq/tegra_wmark.c
+index 7194c01..59a0100 100644
+--- a/drivers/devfreq/tegra_wmark.c
++++ b/drivers/devfreq/tegra_wmark.c
+@@ -183,9 +183,7 @@ static void devfreq_update_wmark_threshold(struct devfreq *df)
+ #endif
+ 	int err;
+ 
+-	mutex_lock(&df->lock);
+ 	devfreq_get_freq_range(df, &min_freq, &max_freq);
+-	mutex_unlock(&df->lock);
+ 
+ 	err = devfreq_update_stats(df);
+ 	if (err)
+@@ -328,9 +326,8 @@ static ssize_t up_wmark_margin_store(struct device *dev,
+ 	mutex_lock(&df->lock);
+ 	govdata = df->governor_data;
+ 	govdata->up_wmark_margin = wmark_margin;
+-	mutex_unlock(&df->lock);
+-
+ 	devfreq_update_wmark_threshold(df);
++	mutex_unlock(&df->lock);
+ 
+ 	return count;
+ }
+@@ -370,9 +367,8 @@ static ssize_t down_wmark_margin_store(struct device *dev,
+ 	mutex_lock(&df->lock);
+ 	govdata = df->governor_data;
+ 	govdata->down_wmark_margin = wmark_margin;
+-	mutex_unlock(&df->lock);
+-
+ 	devfreq_update_wmark_threshold(df);
++	mutex_unlock(&df->lock);
+ 
+ 	return count;
+ }
+@@ -412,9 +408,8 @@ static ssize_t load_target_store(struct device *dev,
+ 	mutex_lock(&df->lock);
+ 	govdata = df->governor_data;
+ 	govdata->load_target = load_target;
+-	mutex_unlock(&df->lock);
+-
+ 	devfreq_update_wmark_threshold(df);
++	mutex_unlock(&df->lock);
+ 
+ 	return count;
+ }
+@@ -538,7 +533,9 @@ static int devfreq_tegra_wmark_event_handler(struct devfreq *df,
+ 		if (err)
+ 			return err;
+ 
++		mutex_lock(&df->lock);
+ 		devfreq_update_wmark_threshold(df);
++		mutex_unlock(&df->lock);
+ 		break;
+ 	case DEVFREQ_GOV_STOP:
+ 		wmark_config.upper_wmark_enabled = 0;
+@@ -552,7 +549,9 @@ static int devfreq_tegra_wmark_event_handler(struct devfreq *df,
+ 		drvdata->update_wmark_threshold(df, &wmark_config);
+ 		break;
+ 	case DEVFREQ_GOV_RESUME:
++		mutex_lock(&df->lock);
+ 		devfreq_update_wmark_threshold(df);
++		mutex_unlock(&df->lock);
+ 		break;
+ 	default:
+ 		break;
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0077-drivers-nvethernet-speed-10-is-not-supported-while-a.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0077-drivers-nvethernet-speed-10-is-not-supported-while-a.patch
@@ -1,0 +1,75 @@
+From c6cac18588ff3515b3c428a2371198c2f8c9944c Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Thu, 8 Jan 2026 17:14:50 +0800
+Subject: [PATCH] drivers:nvethernet: speed 10 is not supported while auto
+ negotiation is disabled
+
+On NVIDIA Orin AGX platform, when running below command, there is a
+warning trace reported.
+ethtool -s <net_name> speed 10 duplex full autoneg off
+phy_start_aneg+0x0/0x58: returned: -22
+WARNING: CPU: 0 PID: 628 at /drivers/net/phy/phy.c:1233 phy_state_machine+0xa0/0x328
+Call trace:
+ phy_state_machine+0xa0/0x328
+ process_one_work+0x16c/0x3f8
+ worker_thread+0x330/0x450
+ kthread+0x124/0x130
+ ret_from_fork+0x10/0x20
+The root cause of this issue is speed 10 is not supported while auto
+negotiation is disabled. After setting speed 10, the PHY machine state
+is triggered, detailed code logical as below:
+phy_state_machine()
+->phy_start_aneg()
+    -> phy_sanitize_settings()
+In phy_sanitize_settings(), because speed 10 is not supported, and
+100/HALF selected as link mode finally. When calling aqr_config_aneg()
+of phy driver to set the link mode, genphy_c45_pma_setup_forced() is
+called if auto negotiation is disabled. But based on clause 45, half
+duplex is not supported, so return -EINVAL, and then above warning
+trace is reported in phy_state_machine()->phy_error_precise(). In order
+to avoid this issue, create a specific callback for the set_link_ksettings
+field of struct ethtool_ops, check the speed parameter, like function
+phy_ethtool_ksettings_set() return -EINVAL when encountering unreasonable
+parameters.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/net/ethernet/nvidia/nvethernet/ethtool.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/net/ethernet/nvidia/nvethernet/ethtool.c b/drivers/net/ethernet/nvidia/nvethernet/ethtool.c
+index 235d5bf..d552632 100644
+--- a/drivers/net/ethernet/nvidia/nvethernet/ethtool.c
++++ b/drivers/net/ethernet/nvidia/nvethernet/ethtool.c
+@@ -1669,13 +1669,25 @@ static void ether_set_msglevel(struct net_device *ndev, u32 level)
+ }
+ #endif /* OSI_STRIPPED_LIB */
+ 
++static int ether_set_link_ksettings(struct net_device *ndev,
++				   const struct ethtool_link_ksettings *cmd)
++{
++	u8 autoneg = cmd->base.autoneg;
++	u32 speed = cmd->base.speed;
++
++	if (autoneg == AUTONEG_DISABLE && speed == SPEED_10)
++		return -EINVAL;
++
++	return phy_ethtool_set_link_ksettings(ndev, cmd);
++}
++
+ /**
+  * @brief Set of ethtool operations
+  */
+ static const struct ethtool_ops ether_ethtool_ops = {
+ 	.get_link = ethtool_op_get_link,
+ 	.get_link_ksettings = phy_ethtool_get_link_ksettings,
+-	.set_link_ksettings = phy_ethtool_set_link_ksettings,
++	.set_link_ksettings = ether_set_link_ksettings,
+ 	.get_ts_info = ether_get_ts_info,
+ 	.get_strings = ether_get_strings,
+ 	.get_ethtool_stats = ether_get_ethtool_stats,
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0078-nvdisplay-replace-lock-sync-with-wait-event-mechanis.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0078-nvdisplay-replace-lock-sync-with-wait-event-mechanis.patch
@@ -1,0 +1,533 @@
+From 0c89599e4f2d032eb566a187598fff7f0f280a95 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 12 Jan 2026 19:46:12 +0800
+Subject: [PATCH] nvdisplay: replace lock sync with wait event mechanism
+
+When kernel boots up, there is below warning trace:
+WARNING: lock held when returning to user space!
+Xorg/1509 is leaving the kernel with locks still held!
+1 lock held by Xorg/1509:
+ #0: ffffffe3f958f028 (&nv_system_pm_lock){....}-{3:3}, at:
+nv_procfs_open_params+0x60/0xb8 [nvidia]
+This issue is introduced by using semaphore unreasonable, it should
+not hold semaphore after system call has returned. In order to avoid
+this issue, replace lock sync with wait event, create wait queue head
+and implement sync solution with wait event mechanism.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ kernel-open/common/inc/nv-linux.h             |  2 +
+ kernel-open/common/inc/nv-procfs-utils.h      | 18 ++++----
+ .../nvidia-modeset/nvidia-modeset-linux.c     | 23 ++++++----
+ kernel-open/nvidia/nv-caps.c                  | 12 ++---
+ kernel-open/nvidia/nv-mmap.c                  | 16 ++++---
+ kernel-open/nvidia/nv-procfs.c                | 32 ++++++++-----
+ kernel-open/nvidia/nv.c                       | 45 +++++++++++++------
+ 7 files changed, 95 insertions(+), 53 deletions(-)
+
+diff --git a/kernel-open/common/inc/nv-linux.h b/kernel-open/common/inc/nv-linux.h
+index e2254aa..177ff05 100644
+--- a/kernel-open/common/inc/nv-linux.h
++++ b/kernel-open/common/inc/nv-linux.h
+@@ -1664,6 +1664,8 @@ extern struct semaphore nv_linux_devices_lock;
+  * device state must acquire the lock in read mode.
+  */
+ extern struct rw_semaphore nv_system_pm_lock;
++extern wait_queue_head_t nv_system_pm_wq;
++extern atomic_t nv_wait_flag;
+ 
+ extern NvBool nv_ats_supported;
+ 
+diff --git a/kernel-open/common/inc/nv-procfs-utils.h b/kernel-open/common/inc/nv-procfs-utils.h
+index c4035ec..5d4a232 100644
+--- a/kernel-open/common/inc/nv-procfs-utils.h
++++ b/kernel-open/common/inc/nv-procfs-utils.h
+@@ -91,7 +91,7 @@ typedef struct file_operations nv_proc_ops_t;
+ #define NV_PDE_DATA(inode) PDE_DATA(inode)
+ #endif
+ 
+-#define NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, lock)                     \
++#define NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, wq, flag)               \
+     static int nv_procfs_open_##name(                                       \
+         struct inode *inode,                                                \
+         struct file *filep                                                  \
+@@ -104,11 +104,12 @@ typedef struct file_operations nv_proc_ops_t;
+         {                                                                   \
+             return ret;                                                     \
+         }                                                                   \
+-        ret = nv_down_read_interruptible(&lock);                            \
++        ret = wait_event_interruptible(wq, !atomic_cmpxchg(&flag, 0, 1));   \
+         if (ret < 0)                                                        \
+         {                                                                   \
+             single_release(inode, filep);                                   \
+         }                                                                   \
++                                                                            \
+         return ret;                                                         \
+     }                                                                       \
+                                                                             \
+@@ -117,12 +118,13 @@ typedef struct file_operations nv_proc_ops_t;
+         struct file *filep                                                  \
+     )                                                                       \
+     {                                                                       \
+-        up_read(&lock);                                                     \
++        atomic_set(&flag, 0);                                               \
++        wake_up_all(&wq);                                                   \
+         return single_release(inode, filep);                                \
+     }
+ 
+-#define NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, lock)                  \
+-    NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, lock)                         \
++#define NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, wq, flag)            \
++    NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, wq, flag)                   \
+                                                                             \
+     static const nv_proc_ops_t nv_procfs_##name##_fops = {                  \
+         NV_PROC_OPS_SET_OWNER()                                             \
+@@ -133,9 +135,9 @@ typedef struct file_operations nv_proc_ops_t;
+     };
+ 
+ 
+-#define NV_DEFINE_SINGLE_PROCFS_FILE_READ_WRITE(name, lock,                 \
+-write_callback)                                                             \
+-    NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, lock)                         \
++#define NV_DEFINE_SINGLE_PROCFS_FILE_READ_WRITE(name, wq,                 \
++write_callback, flag)                                                       \
++    NV_DEFINE_SINGLE_PROCFS_FILE_HELPER(name, wq, flag)                   \
+                                                                             \
+     static ssize_t nv_procfs_write_##name(                                  \
+         struct file *file,                                                  \
+diff --git a/kernel-open/nvidia-modeset/nvidia-modeset-linux.c b/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+index c2ae900..7aad962 100644
+--- a/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
++++ b/kernel-open/nvidia-modeset/nvidia-modeset-linux.c
+@@ -381,6 +381,8 @@ static struct semaphore nvkms_lock;
+  *************************************************************************/
+ 
+ static struct rw_semaphore nvkms_pm_lock;
++static wait_queue_head_t nvkms_pm_wq;
++static atomic_t nvkms_wait_flag = ATOMIC_INIT(0);
+ 
+ /*************************************************************************
+  * NVKMS executes almost all of its queued work items on a single
+@@ -428,12 +430,12 @@ struct nvkms_per_open {
+ 
+ static inline int nvkms_read_trylock_pm_lock(void)
+ {
+-    return !down_read_trylock(&nvkms_pm_lock);
++    return atomic_cmpxchg(&nvkms_wait_flag, 0, 1);
+ }
+ 
+ static inline void nvkms_read_lock_pm_lock(void)
+ {
+-    while (!down_read_trylock(&nvkms_pm_lock)) {
++    while (atomic_cmpxchg(&nvkms_wait_flag, 0, 1) == 1) {
+         try_to_freeze();
+         cond_resched();
+     }
+@@ -441,17 +443,19 @@ static inline void nvkms_read_lock_pm_lock(void)
+ 
+ static inline void nvkms_read_unlock_pm_lock(void)
+ {
+-    up_read(&nvkms_pm_lock);
++    atomic_set(&nvkms_wait_flag, 0);
++    wake_up_all(&nvkms_pm_wq);
+ }
+ 
+ static inline void nvkms_write_lock_pm_lock(void)
+ {
+-    down_write(&nvkms_pm_lock);
++    wait_event(nvkms_pm_wq, !atomic_cmpxchg(&nvkms_wait_flag, 0, 1));
+ }
+ 
+ static inline void nvkms_write_unlock_pm_lock(void)
+ {
+-    up_write(&nvkms_pm_lock);
++    atomic_set(&nvkms_wait_flag, 0);
++    wake_up_all(&nvkms_pm_wq);
+ }
+ 
+ /*************************************************************************
+@@ -1534,7 +1538,7 @@ void nvkms_sema_up(nvkms_sema_handle_t *sema)
+ #if defined(CONFIG_PROC_FS)
+ 
+ #define NV_DEFINE_SINGLE_NVKMS_PROCFS_FILE(name) \
+-    NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, nvkms_pm_lock)
++    NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, nvkms_pm_wq, nvkms_wait_flag)
+ 
+ #define NVKMS_PROCFS_FOLDER "driver/nvidia-modeset"
+ 
+@@ -1768,7 +1772,8 @@ static int nvkms_open(struct inode *inode, struct file *filp)
+ {
+     int status;
+ 
+-    status = nv_down_read_interruptible(&nvkms_pm_lock);
++    status = wait_event_interruptible(nvkms_pm_wq,
++                               !atomic_cmpxchg(&nvkms_wait_flag, 0, 1));
+     if (status != 0) {
+         return status;
+     }
+@@ -1825,7 +1830,8 @@ static int nvkms_ioctl(struct inode *inode, struct file *filp,
+         return -EFAULT;
+     }
+ 
+-    status = nv_down_read_interruptible(&nvkms_pm_lock);
++    status = wait_event_interruptible(nvkms_pm_wq,
++                              !atomic_cmpxchg(&nvkms_wait_flag, 0, 1));
+     if (status != 0) {
+         return status;
+     }
+@@ -1892,6 +1898,7 @@ static int __init nvkms_init(void)
+ 
+     sema_init(&nvkms_lock, 1);
+     init_rwsem(&nvkms_pm_lock);
++    init_waitqueue_head(&nvkms_pm_wq);
+ 
+     ret = nv_kthread_q_init(&nvkms_kthread_q,
+                             "nvidia-modeset/kthread_q");
+diff --git a/kernel-open/nvidia/nv-caps.c b/kernel-open/nvidia/nv-caps.c
+index 7840414..46cada2 100644
+--- a/kernel-open/nvidia/nv-caps.c
++++ b/kernel-open/nvidia/nv-caps.c
+@@ -247,11 +247,11 @@ static int nv_procfs_read_mig_minors(struct seq_file *s, void *v)
+     return 0;
+ }
+ 
+-NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(nvlink_minors, nv_system_pm_lock);
++NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(nvlink_minors, nv_system_pm_wq, nv_wait_flag);
+ 
+-NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(mig_minors, nv_system_pm_lock);
++NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(mig_minors, nv_system_pm_wq, nv_wait_flag);
+ 
+-NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(sys_minors, nv_system_pm_lock);
++NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(sys_minors, nv_system_pm_wq, nv_wait_flag);
+ 
+ static void nv_cap_procfs_exit(void)
+ {
+@@ -425,7 +425,8 @@ static int nv_cap_procfs_open(struct inode *inode, struct file *file)
+         return rc;
+     }
+ 
+-    rc = nv_down_read_interruptible(&nv_system_pm_lock);
++    rc = wait_event_interruptible(nv_system_pm_wq,
++                          !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (rc < 0)
+     {
+         single_release(inode, file);
+@@ -448,7 +449,8 @@ static int nv_cap_procfs_release(struct inode *inode, struct file *file)
+         private = s->private;
+     }
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+diff --git a/kernel-open/nvidia/nv-mmap.c b/kernel-open/nvidia/nv-mmap.c
+index 1549652..587d8fc 100644
+--- a/kernel-open/nvidia/nv-mmap.c
++++ b/kernel-open/nvidia/nv-mmap.c
+@@ -229,10 +229,8 @@ static vm_fault_t nvidia_fault(
+     }
+ 
+     // Wake up GPU and reinstate mappings only if we are not in S3/S4 entry
+-    if (!down_read_trylock(&nv_system_pm_lock))
+-    {
++    if (atomic_cmpxchg(&nv_wait_flag, 0, 1) == 1)
+         return VM_FAULT_NOPAGE;
+-    }
+ 
+     down(&nvl->mmap_lock);
+ 
+@@ -245,7 +243,8 @@ static vm_fault_t nvidia_fault(
+         {
+             // GPU wakeup callback already scheduled.
+             up(&nvl->mmap_lock);
+-            up_read(&nv_system_pm_lock);
++            atomic_set(&nv_wait_flag, 0);
++            wake_up_all(&nv_system_pm_wq);
+             return VM_FAULT_NOPAGE;
+         }
+ 
+@@ -259,14 +258,16 @@ static vm_fault_t nvidia_fault(
+             nv_printf(NV_DBG_ERRORS,
+                       "NVRM: VM: rm_schedule_gpu_wakeup failed: %x\n", status);
+             up(&nvl->mmap_lock);
+-            up_read(&nv_system_pm_lock);
++            atomic_set(&nv_wait_flag, 0);
++            wake_up_all(&nv_system_pm_wq);
+             return VM_FAULT_SIGBUS;
+         }
+         // Ensure that we do not schedule duplicate GPU wakeup callbacks.
+         nvl->gpu_wakeup_callback_needed = NV_FALSE;
+ 
+         up(&nvl->mmap_lock);
+-        up_read(&nv_system_pm_lock);
++        atomic_set(&nv_wait_flag, 0);
++        wake_up_all(&nv_system_pm_wq);
+         return VM_FAULT_NOPAGE;
+     }
+ 
+@@ -288,7 +289,8 @@ static vm_fault_t nvidia_fault(
+         nvl->all_mappings_revoked = NV_FALSE;
+     }
+     up(&nvl->mmap_lock);
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     return ret;
+ }
+diff --git a/kernel-open/nvidia/nv-procfs.c b/kernel-open/nvidia/nv-procfs.c
+index d4d2007..c7c3305 100644
+--- a/kernel-open/nvidia/nv-procfs.c
++++ b/kernel-open/nvidia/nv-procfs.c
+@@ -35,7 +35,7 @@
+ #include "nv-ibmnpu.h"
+ 
+ #define NV_DEFINE_SINGLE_NVRM_PROCFS_FILE(name) \
+-    NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, nv_system_pm_lock)
++    NV_DEFINE_SINGLE_PROCFS_FILE_READ_ONLY(name, nv_system_pm_wq, nv_wait_flag)
+ 
+ static const char *__README_warning = \
+     "The NVIDIA graphics driver tries to detect potential problems\n"
+@@ -337,7 +337,8 @@ nv_procfs_open_registry(
+         return retval;
+     }
+ 
+-    retval = nv_down_read_interruptible(&nv_system_pm_lock);
++    retval = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (retval < 0)
+     {
+         single_release(inode, file);
+@@ -411,7 +412,8 @@ nv_procfs_close_registry(
+     }
+ 
+ done:
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+@@ -740,7 +742,8 @@ nv_procfs_open_exercise_error_forwarding(
+         return retval;
+     }
+ 
+-    retval = nv_down_read_interruptible(&nv_system_pm_lock);
++    retval = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (retval < 0)
+     {
+         single_release(inode, file);
+@@ -783,7 +786,8 @@ nv_procfs_close_exercise_error_forwarding(
+         status = -EINVAL;
+ 
+ done:
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+@@ -845,7 +849,8 @@ nv_procfs_open_unbind_lock(
+         return retval;
+     }
+ 
+-    retval = nv_down_read_interruptible(&nv_system_pm_lock);
++    retval = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (retval < 0)
+     {
+         single_release(inode, file);
+@@ -910,7 +915,8 @@ nv_procfs_close_unbind_lock(
+     }
+ 
+ done:
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+@@ -1095,7 +1101,8 @@ nv_procfs_open_offline_pages(
+         return retval;
+     }
+ 
+-    retval = nv_down_read_interruptible(&nv_system_pm_lock);
++    retval = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (retval < 0)
+     {
+         single_release(inode, file);
+@@ -1114,7 +1121,8 @@ nv_procfs_close_offline_pages(
+     struct seq_file *s = file->private_data;
+     nv_procfs_private_t *nvpp = s->private;
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+@@ -1181,7 +1189,8 @@ nv_procfs_open_numa_status(
+         return retval;
+     }
+ 
+-    retval = nv_down_read_interruptible(&nv_system_pm_lock);
++    retval = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (retval < 0)
+     {
+         single_release(inode, file);
+@@ -1264,7 +1273,8 @@ nv_procfs_close_numa_status(
+ done:
+     up(&nvl->ldata_lock);
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     single_release(inode, file);
+ 
+diff --git a/kernel-open/nvidia/nv.c b/kernel-open/nvidia/nv.c
+index 1910355..3cf3be6 100644
+--- a/kernel-open/nvidia/nv.c
++++ b/kernel-open/nvidia/nv.c
+@@ -122,6 +122,8 @@ nv_kthread_q_t nv_kthread_q;
+ nv_kthread_q_t nv_deferred_close_kthread_q;
+ 
+ struct rw_semaphore nv_system_pm_lock;
++wait_queue_head_t nv_system_pm_wq;
++atomic_t nv_wait_flag = ATOMIC_INIT(0);
+ 
+ #if defined(CONFIG_PM)
+ static nv_power_state_t nv_system_power_state;
+@@ -443,6 +445,7 @@ nv_module_state_init(nv_stack_t *sp)
+     nv_linux_devices = NULL;
+     NV_INIT_MUTEX(&nv_linux_devices_lock);
+     init_rwsem(&nv_system_pm_lock);
++    init_waitqueue_head(&nv_system_pm_wq);
+ 
+ #if defined(CONFIG_PM)
+     NV_INIT_MUTEX(&nv_system_power_state_lock);
+@@ -1474,16 +1477,20 @@ nvidia_open(
+         return rc;
+     }
+ 
+-    rc = nv_down_read_interruptible(&nv_system_pm_lock);
++    rc = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (rc < 0)
+-        goto failed;
++    {
++	    goto failed;
++    }
+ 
+     /* Takes nvl->ldata_lock */
+     nvl = find_minor(NV_DEVICE_MINOR_NUMBER(inode));
+     if (!nvl)
+     {
+         rc = -ENODEV;
+-        up_read(&nv_system_pm_lock);
++        atomic_set(&nv_wait_flag, 0);
++        wake_up_all(&nv_system_pm_wq);
+         goto failed;
+     }
+ 
+@@ -1510,7 +1517,8 @@ nvidia_open(
+ failed1:
+     up(&nvl->ldata_lock);
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ failed:
+     if (rc != 0)
+     {
+@@ -1763,11 +1771,12 @@ static void nvidia_close_deferred(void *data)
+ {
+     nv_linux_file_private_t *nvlfp = data;
+ 
+-    down_read(&nv_system_pm_lock);
++    wait_event(nv_system_pm_wq, !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+ 
+     nvidia_close_callback(nvlfp);
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ }
+ 
+ int
+@@ -1790,11 +1799,13 @@ nvidia_close(
+ 
+     NV_SET_FILE_PRIVATE(file, NULL);
+ 
+-    rc = nv_down_read_interruptible(&nv_system_pm_lock);
++    rc = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
+     if (rc == 0)
+     {
+         nvidia_close_callback(nvlfp);
+-        up_read(&nv_system_pm_lock);
++        atomic_set(&nv_wait_flag, 0);
++        wake_up_all(&nv_system_pm_wq);
+     }
+     else
+     {
+@@ -1939,9 +1950,11 @@ nvidia_ioctl(
+     nv_printf(NV_DBG_INFO, "NVRM: ioctl(0x%x, 0x%x, 0x%x)\n",
+         _IOC_NR(cmd), (unsigned int) i_arg, _IOC_SIZE(cmd));
+ 
+-    status = nv_down_read_interruptible(&nv_system_pm_lock);
+-    if (status < 0)
++    status = wait_event_interruptible(nv_system_pm_wq,
++                              !atomic_cmpxchg(&nv_wait_flag, 0, 1));
++    if (status < 0) {
+         return status;
++    }
+ 
+     status = nv_kmem_cache_alloc_stack(&sp);
+     if (status != 0)
+@@ -2259,7 +2272,8 @@ unlock:
+ done:
+     nv_kmem_cache_free_stack(sp);
+ 
+-    up_read(&nv_system_pm_lock);
++    atomic_set(&nv_wait_flag, 0);
++    wake_up_all(&nv_system_pm_wq);
+ 
+     if (arg_copy != NULL)
+     {
+@@ -4175,7 +4189,8 @@ nv_set_system_power_state(
+     if (power_state == NV_POWER_STATE_RUNNING)
+     {
+         status = nv_resume_devices(pm_action, nv_system_pm_action_depth);
+-        up_write(&nv_system_pm_lock);
++        atomic_set(&nv_wait_flag, 0);
++        wake_up_all(&nv_system_pm_wq);
+     }
+     else
+     {
+@@ -4187,11 +4202,13 @@ nv_set_system_power_state(
+ 
+         nv_system_pm_action_depth = pm_action_depth;
+ 
+-        down_write(&nv_system_pm_lock);
++        wait_event(nv_system_pm_wq, !atomic_cmpxchg(&nv_wait_flag, 0, 1));
++
+         status = nv_suspend_devices(pm_action, nv_system_pm_action_depth);
+         if (status != NV_OK)
+         {
+-            up_write(&nv_system_pm_lock);
++            atomic_set(&nv_wait_flag, 0);
++            wake_up_all(&nv_system_pm_wq);
+             goto done;
+         }
+     }
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0079-nvgpu-dma-use-unlocked-variant-function-to-process-d.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0079-nvgpu-dma-use-unlocked-variant-function-to-process-d.patch
@@ -1,0 +1,68 @@
+From 7220c4e4015c0a52e1b966daa0a96889f0254a4b Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Tue, 13 Jan 2026 12:37:22 +0800
+Subject: [PATCH] nvgpu: dma: use unlocked variant function to process dma
+ buffer
+
+When kernel boots up, there is below warning trace:
+WARNING: CPU: 1 PID: 1519 at /drivers/dma-buf/dma-buf.c:
+1109 dma_buf_map_attachment+0xb0/0x160
+Call trace:
+dma_buf_map_attachment+0xb0/0x160
+......
+el0t_64_sync+0x19c/0x1a0
+Trace reporting is caused by missing lock before calling
+dma buffer operation fucntion. In order to keep code logical with
+original code that doesn't use lock and avoid the warning trace,
+it prefers to use unlocked variant function to replace them.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/gpu/nvgpu/os/linux/dmabuf_priv.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/gpu/nvgpu/os/linux/dmabuf_priv.c b/drivers/gpu/nvgpu/os/linux/dmabuf_priv.c
+index cbfc1cb..2344c6a 100644
+--- a/drivers/gpu/nvgpu/os/linux/dmabuf_priv.c
++++ b/drivers/gpu/nvgpu/os/linux/dmabuf_priv.c
+@@ -184,7 +184,7 @@ struct sg_table *nvgpu_mm_pin(struct device *dev,
+ 		return ERR_CAST(attach);
+ 	}
+ 
+-	sgt = dma_buf_map_attachment(attach, direction);
++	sgt = dma_buf_map_attachment_unlocked(attach, direction);
+ 	if (IS_ERR(sgt)) {
+ 		dma_buf_detach(dmabuf, attach);
+ 		nvgpu_err(g, "Failed to map attachment (err = %ld)!",
+@@ -202,7 +202,7 @@ void nvgpu_mm_unpin(struct device *dev,
+ 			struct dma_buf_attachment *attachment,
+ 			struct sg_table *sgt)
+ {
+-	dma_buf_unmap_attachment(attachment, sgt, DMA_BIDIRECTIONAL);
++	dma_buf_unmap_attachment_unlocked(attachment, sgt, DMA_BIDIRECTIONAL);
+ 	dma_buf_detach(dmabuf, attachment);
+ }
+ 
+@@ -368,7 +368,7 @@ static void *__gk20a_dmabuf_vmap(struct dma_buf *dmabuf)
+ 	struct dma_buf_map map = {0};
+ #endif
+ 	/* Linux v5.11 and later kernels */
+-	if (dma_buf_vmap(dmabuf, &map))
++	if (dma_buf_vmap_unlocked(dmabuf, &map))
+ 		return NULL;
+ 
+ 	return map.vaddr;
+@@ -396,7 +396,7 @@ void gk20a_dmabuf_vunmap(struct dma_buf *dmabuf, void *addr)
+ 	struct dma_buf_map map = DMA_BUF_MAP_INIT_VADDR(addr);
+ #endif
+ 	/* Linux v5.11 and later kernels */
+-	dma_buf_vunmap(dmabuf, &map);
++	dma_buf_vunmap_unlocked(dmabuf, &map);
+ #else
+ 	/* Linux v5.10 and earlier kernels */
+ 	dma_buf_vunmap(dmabuf, addr);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0080-nvdisplay-dma-use-unlocked-variant-function-when-map.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0080-nvdisplay-dma-use-unlocked-variant-function-when-map.patch
@@ -1,0 +1,50 @@
+From 97ebb408f97359f5f3b4d4bcd122f0118ac5dea7 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Tue, 13 Jan 2026 12:58:28 +0800
+Subject: [PATCH] nvdisplay: dma: use unlocked variant function when
+ mapping/unmapping dma buffer
+
+When kernel boots up, there is below warning trace:
+WARNING: CPU: 1 PID: 1519 at /drivers/dma-buf/dma-buf.c:
+1109 dma_buf_map_attachment+0xb0/0x160
+Call trace:
+dma_buf_map_attachment+0xb0/0x160
+......
+el0t_64_sync+0x19c/0x1a0
+Trace reporting is caused by missing lock before calling
+dma_buf_map_attachment(). In order to keep code logical with original
+code that doesn't use lock and avoid the warning trace, it prefers to
+use unlocked variant of dma_buf_map_attachment() to replace it.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ kernel-open/nvidia/nv-dma.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/kernel-open/nvidia/nv-dma.c b/kernel-open/nvidia/nv-dma.c
+index c07f7c8..91ea4a9 100644
+--- a/kernel-open/nvidia/nv-dma.c
++++ b/kernel-open/nvidia/nv-dma.c
+@@ -1139,7 +1139,7 @@ NV_STATUS NV_API_CALL nv_dma_import_dma_buf
+         goto dma_buf_attach_fail;
+     }
+ 
+-    map_sgt = dma_buf_map_attachment(dma_attach, DMA_BIDIRECTIONAL);
++    map_sgt = dma_buf_map_attachment_unlocked(dma_attach, DMA_BIDIRECTIONAL);
+     if (IS_ERR_OR_NULL(map_sgt))
+     {
+         NV_DMA_DEV_PRINTF(NV_DBG_ERRORS, dma_dev,
+@@ -1207,7 +1207,7 @@ void NV_API_CALL nv_dma_release_dma_buf
+     }
+ 
+     nv_dma_buf = (nv_dma_buf_t *)import_priv;
+-    dma_buf_unmap_attachment(nv_dma_buf->dma_attach, nv_dma_buf->sgt,
++    dma_buf_unmap_attachment_unlocked(nv_dma_buf->dma_attach, nv_dma_buf->sgt,
+                                 DMA_BIDIRECTIONAL);
+     dma_buf_detach(nv_dma_buf->dma_buf, nv_dma_buf->dma_attach);
+     dma_buf_put(nv_dma_buf->dma_buf);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0081-gpu-nvgpu-probe-clock-availability-during-acquisitio.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0081-gpu-nvgpu-probe-clock-availability-during-acquisitio.patch
@@ -1,0 +1,62 @@
+From 78262b43f4ad8edcc4aa3fcba2f2183f9d129e52 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Tue, 21 Apr 2026 14:37:37 +0800
+Subject: [PATCH] gpu: nvgpu: probe clock availability during acquisition
+
+On Jetson AGX Orin Platform, it supports multiple power modes. In the
+lower power mode(e.g.MODE_30W), nvpmodel configures BPMP (Boot and Power
+Management Processor) to power-gate GPC1(Graphics Processing Cluster)
+and writes tpc_pg_mask via sysfs, which sets g->gpc_pg_mask so that
+ga10b_tegra_is_clock_available() skips gpc1clk. When module is reloaded
+(modprobe -r followed by modprobe), g->gpc_pg_mask is reset to 0 because
+nvpmodel only runs once at boot (oneshot service) and does not re-apply
+the mask. However, BPMP retains the GPC1 power-gate state from the
+previous session. This causes ga10b_tegra_is_clock_available() to report
+gpc1clk as available, but clk_prepare_enable(gpc1clk) fails with -EINVAL
+because BPMP rejects enabling a clock for a power-gated GPC.
+There is no API from BPMP to get current GPC count automatically, so
+only make a workaround to probing each clock with clk_prepare_enable/
+clk_disable_unprepare during acquisition. If BPMP rejects the enable,
+the clock belongs to a power-gated GPC and is skipped. This ensures
+platform->num_clks only includes clocks that are actually usable in the
+current power mode.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ .../gpu/nvgpu/os/linux/platform_ga10b_tegra.c  | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/drivers/gpu/nvgpu/os/linux/platform_ga10b_tegra.c b/drivers/gpu/nvgpu/os/linux/platform_ga10b_tegra.c
+index 8f1d235..dd70cad 100644
+--- a/drivers/gpu/nvgpu/os/linux/platform_ga10b_tegra.c
++++ b/drivers/gpu/nvgpu/os/linux/platform_ga10b_tegra.c
+@@ -179,6 +179,24 @@ static int ga10b_tegra_acquire_platform_clocks(struct device *dev,
+ 			err = PTR_ERR(c);
+ 			goto err_get_clock;
+ 		} else {
++			/*
++			 * Verify the clock can be enabled in the current
++			 * power mode. BPMP retains GPC power-gate state
++			 * across module reload, but g->gpc_pg_mask may
++			 * not yet reflect it (set later via sysfs by
++			 * nvpmodel). Probe the clock to detect if BPMP
++			 * allows enabling it.
++			 */
++			err = clk_prepare_enable(c);
++			if (err) {
++				nvgpu_info(g, "clock %s unavailable in "
++					   "current power mode, skipping",
++					   clk_entries[i].name);
++				clk_put(c);
++				continue;
++			}
++			clk_disable_unprepare(c);
++
+ 			rate = clk_entries[i].default_rate;
+ 			clk_set_rate(c, rate);
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0082-gpu-host1x-Do-not-setup-DMA-for-virtual-devices.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0082-gpu-host1x-Do-not-setup-DMA-for-virtual-devices.patch
@@ -1,0 +1,59 @@
+From de26cde29c91d0b244175ca98a407022b23d54cc Mon Sep 17 00:00:00 2001
+From: Thierry Reding <treding@nvidia.com>
+Date: Thu, 14 Mar 2024 16:49:43 +0100
+Subject: [PATCH 1/4] gpu: host1x: Do not setup DMA for virtual devices
+
+The host1x devices are virtual compound devices and do not perform DMA
+accesses themselves, so they do not need to be set up for DMA.
+
+Ideally we would also not need to set up DMA masks for the virtual
+devices, but we currently still need those for legacy support on old
+hardware.
+
+Upstream-Status: Backport [8ab58f6841b19423231c5db3378691ec80c778f8]
+
+Tested-by: Jon Hunter <jonathanh@nvidia.com>
+Acked-by: Jon Hunter <jonathanh@nvidia.com>
+Signed-off-by: Thierry Reding <treding@nvidia.com>
+Link: https://patchwork.freedesktop.org/patch/msgid/20240314154943.2487549-1-thierry.reding@gmail.com
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/gpu/host1x/bus.c | 8 --------
+ 1 file changed, 8 deletions(-)
+
+diff --git a/drivers/gpu/host1x/bus.c b/drivers/gpu/host1x/bus.c
+index e8879e5..1a06d75 100644
+--- a/drivers/gpu/host1x/bus.c
++++ b/drivers/gpu/host1x/bus.c
+@@ -378,11 +378,6 @@ static int host1x_device_uevent(struct device *dev,
+ 	return 0;
+ }
+ 
+-static int host1x_dma_configure(struct device *dev)
+-{
+-	return of_dma_configure(dev, dev->of_node, true);
+-}
+-
+ static const struct dev_pm_ops host1x_device_pm_ops = {
+ 	.suspend = pm_generic_suspend,
+ 	.resume = pm_generic_resume,
+@@ -396,7 +391,6 @@ struct bus_type host1x_bus_type = {
+ 	.name = "host1x",
+ 	.match = host1x_device_match,
+ 	.uevent = host1x_device_uevent,
+-	.dma_configure = host1x_dma_configure,
+ 	.pm = &host1x_device_pm_ops,
+ };
+ 
+@@ -485,8 +479,6 @@ static int host1x_device_add(struct host1x *host1x,
+ 	device->dev.bus = &host1x_bus_type;
+ 	device->dev.parent = host1x->dev;
+ 
+-	of_dma_configure(&device->dev, host1x->dev->of_node, true);
+-
+ 	device->dev.dma_parms = &device->dma_parms;
+ 	dma_set_max_seg_size(&device->dev, UINT_MAX);
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0083-video-tegra-pva-use-dma_map_phys-for-RAM-backed-carv.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0083-video-tegra-pva-use-dma_map_phys-for-RAM-backed-carv.patch
@@ -1,0 +1,122 @@
+From bce95a8aea7f884bfcb17234053ece1d65e1952e Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Fri, 24 Apr 2026 00:09:31 +0800
+Subject: [PATCH 2/4] video: tegra: pva: use dma_map_phys for RAM-backed
+ carveout mapping
+
+pva_read_ucode_co() maps the PVA firmware carveout region using
+nvpva_map_region() which calls dma_map_resource(). The carveout is
+reserved RAM where pfn_valid() returns true, triggering a warning
+in dma_map_resource() which is intended for MMIO regions only:
+WARNING at dma_map_resource: WARN_ON_ONCE(pfn_valid(PHYS_PFN(phys_addr)))
+Fix by introducing nvpva_map_mem/nvpva_unmap_mem that wrap
+dma_map_phys/dma_unmap_phys for RAM-backed memory regions. Unlike
+dma_map_resource, dma_map_phys handles both RAM and MMIO addresses
+correctly without the pfn_valid warning.
+The existing nvpva_map_region/nvpva_unmap_region helpers remain
+unchanged for MMIO syncpt region mappings where dma_map_resource
+is appropriate.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/pva/nvpva_syncpt.c | 26 +++++++++++++++++++++
+ drivers/video/tegra/host/pva/nvpva_syncpt.h |  9 +++++++
+ drivers/video/tegra/host/pva/pva.c          | 18 +++++++-------
+ 3 files changed, 44 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/video/tegra/host/pva/nvpva_syncpt.c b/drivers/video/tegra/host/pva/nvpva_syncpt.c
+index bf3d8c3..306dac2 100644
+--- a/drivers/video/tegra/host/pva/nvpva_syncpt.c
++++ b/drivers/video/tegra/host/pva/nvpva_syncpt.c
+@@ -43,6 +43,32 @@ int nvpva_unmap_region(struct device *dev,
+ 	return 0;
+ }
+ 
++int nvpva_map_mem(struct device *dev,
++		  phys_addr_t start,
++		  size_t size,
++		  dma_addr_t *dma_addr,
++		  enum dma_data_direction dir)
++{
++	if (iommu_get_domain_for_dev(dev)) {
++		*dma_addr = dma_map_phys(dev, start, size, dir, 0);
++		if (dma_mapping_error(dev, *dma_addr))
++			return -ENOMEM;
++	} else {
++		*dma_addr = start;
++	}
++
++	return 0;
++}
++
++void nvpva_unmap_mem(struct device *dev,
++		     dma_addr_t dma_addr,
++		     size_t size,
++		     enum dma_data_direction dir)
++{
++	if (iommu_get_domain_for_dev(dev))
++		dma_unmap_phys(dev, dma_addr, size, dir, 0);
++}
++
+ void nvpva_syncpt_put_ref_ext(struct platform_device *pdev,
+ 			       u32 id)
+ {
+diff --git a/drivers/video/tegra/host/pva/nvpva_syncpt.h b/drivers/video/tegra/host/pva/nvpva_syncpt.h
+index 7fcf56d..eeed3a8 100644
+--- a/drivers/video/tegra/host/pva/nvpva_syncpt.h
++++ b/drivers/video/tegra/host/pva/nvpva_syncpt.h
+@@ -25,4 +25,13 @@ int nvpva_unmap_region(struct device *dev,
+ 		       dma_addr_t addr,
+ 		       size_t size,
+ 		       u32 attr);
++int nvpva_map_mem(struct device *dev,
++		  phys_addr_t start,
++		  size_t size,
++		  dma_addr_t *dma_addr,
++		  enum dma_data_direction dir);
++void nvpva_unmap_mem(struct device *dev,
++		     dma_addr_t dma_addr,
++		     size_t size,
++		     enum dma_data_direction dir);
+ #endif
+diff --git a/drivers/video/tegra/host/pva/pva.c b/drivers/video/tegra/host/pva/pva.c
+index 67b4faa..ce487d0 100644
+--- a/drivers/video/tegra/host/pva/pva.c
++++ b/drivers/video/tegra/host/pva/pva.c
+@@ -486,10 +486,10 @@ static int pva_free_fw(struct platform_device *pdev, struct pva *pva)
+ 					  pva->priv1_dma.va, pva->priv1_dma.pa);
+ 	} else {
+ 		if (pva->map_co_needed && (pva->priv1_dma.pa != 0)) {
+-			nvpva_unmap_region(&pdev->dev,
+-					   pva->priv1_dma.pa,
+-					   pva->co->size,
+-					   DMA_BIDIRECTIONAL);
++			nvpva_unmap_mem(&pdev->dev,
++					pva->priv1_dma.pa,
++					pva->co->size,
++					DMA_BIDIRECTIONAL);
+ 		}
+ 
+ 		pva->co->base_pa = 0;
+@@ -579,11 +579,11 @@ static int pva_read_ucode_co(struct platform_device *pdev,
+ 	}
+ 
+ 	if (pva->map_co_needed) {
+-		err = nvpva_map_region(&pdev->dev,
+-				       pva->co->base,
+-				       pva->co->size,
+-				       &pva->priv1_dma.pa,
+-				       DMA_BIDIRECTIONAL);
++		err = nvpva_map_mem(&pdev->dev,
++				    pva->co->base,
++				    pva->co->size,
++				    &pva->priv1_dma.pa,
++				    DMA_BIDIRECTIONAL);
+ 		if (err) {
+ 			err = -ENOMEM;
+ 			goto out;
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0084-video-tegra-pva-use-DMA-IOVA-API-for-contiguous-sync.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0084-video-tegra-pva-use-DMA-IOVA-API-for-contiguous-sync.patch
@@ -1,0 +1,250 @@
+From b9f7752c2ce7bb74eb800377283f037c87975582 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Fri, 24 Apr 2026 21:25:24 +0800
+Subject: [PATCH 3/4] video: tegra: pva: use DMA IOVA API for contiguous syncpt
+ mapping
+
+The PVA R5 firmware accesses RW syncpts as base + queue_id * page_size,
+requiring the syncpt IOVAs to be contiguous and 512K-aligned. The
+original code maps each syncpt individually via dma_map_resource(),
+then checks if the resulting IOVAs happen to be contiguous and aligned.
+This fails on module reload because the IOMMU IOVA allocator may
+return non-contiguous addresses after IOVA space fragmentation from
+the previous alloc/free cycle:
+pva 16000000.pva0: RW sync pts base not aligned to 512k
+pva 16000000.pva0: probe with driver pva failed with error -12
+The original code also assumes the IOVA allocator returns addresses
+in decreasing order (top-down), which is not guaranteed on all
+platforms or allocator states.
+Fix by using the DMA IOVA API (dma_iova_try_alloc/dma_iova_link):
+1. dma_iova_try_alloc() allocates a contiguous IOVA block of
+     2 * 512K to allow for 512K alignment
+2. ALIGN() finds the 512K-aligned base within the allocation
+3. dma_iova_link() maps each syncpt's physical page at the
+     aligned offset within the IOVA range
+4. dma_iova_sync() flushes the IOTLB
+For cleanup, dma_iova_unlink() removes each linked page individually,
+then dma_iova_free() releases the IOVA allocation. This avoids using
+dma_iova_destroy() which would attempt to unmap the entire allocated
+range including the unlinked alignment padding, triggering IOMMU page
+table warnings.
+This guarantees contiguous and 512K-aligned IOVAs by construction,
+regardless of syncpt ID order, gaps, or IOVA allocator fragmentation.
+The alignment and contiguity checks are no longer needed.
+For the non-IOMMU case, physical addresses are used directly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/pva/nvpva_syncpt.c | 152 ++++++++++++++------
+ drivers/video/tegra/host/pva/pva.h          |   3 +
+ 2 files changed, 115 insertions(+), 40 deletions(-)
+
+diff --git a/drivers/video/tegra/host/pva/nvpva_syncpt.c b/drivers/video/tegra/host/pva/nvpva_syncpt.c
+index 306dac2..7ddb82b 100644
+--- a/drivers/video/tegra/host/pva/nvpva_syncpt.c
++++ b/drivers/video/tegra/host/pva/nvpva_syncpt.c
+@@ -172,13 +172,30 @@ void nvpva_syncpt_unit_interface_deinit(struct platform_device *pdev,
+ 	pva->syncpts.syncpt_start_iova_r = 0;
+ 	pva->syncpts.syncpt_range_r = 0;
+ 
++	/* Unmap RW syncpt IOVA region */
++	if (pva->syncpts.syncpt_start_iova_rw) {
++		size_t offset = pva->syncpts.iova_align_offset;
++
++		/* Unlink only the mapped portion within the aligned range */
++		for (i = 0; i < MAX_PVA_QUEUE_COUNT; i++) {
++			dma_iova_unlink(&paux_dev->dev,
++					&pva->syncpts.iova_state,
++					offset + i * pva->syncpts.page_size,
++					pva->syncpts.page_size,
++					DMA_BIDIRECTIONAL, 0);
++		}
++
++		/* Free the entire IOVA allocation */
++		dma_iova_free(&paux_dev->dev, &pva->syncpts.iova_state);
++
++		pva->syncpts.syncpt_start_iova_rw = 0;
++		pva->syncpts.syncpt_range_rw = 0;
++	}
++
+ 	for (i = 0; i < MAX_PVA_QUEUE_COUNT; i++) {
+ 		if (pva->syncpts.syncpts_rw[i].id == 0)
+ 			continue;
+ 
+-		nvpva_unmap_region(&paux_dev->dev, pva->syncpts.syncpts_rw[i].addr,
+-			       pva->syncpts.syncpts_rw[i].size,
+-			       DMA_BIDIRECTIONAL);
+ 		pva->syncpts.syncpts_rw[i].addr = 0;
+ 		pva->syncpts.syncpts_rw[i].size = 0;
+ 		pva->syncpts.syncpts_rw[i].assigned = 0;
+@@ -258,52 +275,107 @@ int nvpva_syncpt_unit_interface_init(struct platform_device *pdev,
+ 			goto err_alloc_syncpt;
+ 		}
+ 
+-		syncpt_offset =
+-			nvhost_syncpt_unit_interface_get_byte_offset_ext(pva->syncpts.host_pdev,
+-									 id);
+-		err = nvpva_map_region(&paux_dev->dev,
+-				       (base + syncpt_offset),
+-				       pva->syncpts.page_size,
+-				       &syncpt_addr_rw,
+-				       DMA_BIDIRECTIONAL);
+-		if (err) {
+-			dev_err(&pdev->dev, "failed to map syncpt %d\n", id);
+-			goto err_map_sp;
+-		}
+-
+-		pva->syncpts.syncpts_rw[i].addr = syncpt_addr_rw;
+ 		pva->syncpts.syncpts_rw[i].id = id;
+ 		pva->syncpts.syncpts_rw[i].assigned = 0;
+-		nvpva_dbg_info(pva,
+-			"syncpt_addr:  id: %d   addr: %llx offset: %llx\n",
+-			id,
+-			syncpt_addr_rw,
+-			0LLU);
+ 	}
+ 
+-	pva->syncpts.syncpts_mapped_rw = true;
+-	syncpt_addr_rw = pva->syncpts.syncpts_rw[MAX_PVA_QUEUE_COUNT - 1].addr;
+-	pva->syncpts.syncpt_start_iova_rw = syncpt_addr_rw;
+-	pva->syncpts.syncpt_range_rw = MAX_PVA_QUEUE_COUNT *
+-				       (pva->syncpts.syncpts_rw[0].addr -
+-					pva->syncpts.syncpts_rw[1].addr);
++	/*
++	 * Map all RW syncpts into a contiguous, aligned IOVA range.
++	 * The PVA R5 firmware accesses syncpts as base + queue_id * page_size,
++	 * requiring contiguous and 512K-aligned IOVAs. Individual
++	 * dma_map_resource() calls cannot guarantee this after IOVA space
++	 * fragmentation from module reload cycles.
++	 *
++	 * Use dma_iova_try_alloc() to reserve a contiguous IOVA block, then
++	 * dma_iova_link() to map each syncpt's physical page into the range.
++	 */
++	if (iommu_get_domain_for_dev(&paux_dev->dev)) {
++		u32 total_size = MAX_PVA_QUEUE_COUNT * pva->syncpts.page_size;
++		u32 alloc_size = total_size + total_size; /* over-allocate for alignment */
++		struct dma_iova_state *state = &pva->syncpts.iova_state;
++		dma_addr_t aligned_base;
++		size_t align_offset;
++
++		if (!dma_iova_try_alloc(&paux_dev->dev, state,
++					base, alloc_size)) {
++			dev_err(&pdev->dev, "failed to alloc syncpt IOVA\n");
++			err = -ENOMEM;
++			goto err_map_sp;
++		}
+ 
+-	if (pva->version == PVA_HW_GEN1)
+-		goto out;
++		/* Align the base within the over-allocated range */
++		aligned_base = ALIGN(state->addr, total_size);
++		align_offset = aligned_base - state->addr;
++		pva->syncpts.iova_align_offset = align_offset;
++
++		for (i = 0; i < MAX_PVA_QUEUE_COUNT; i++) {
++			syncpt_offset =
++				nvhost_syncpt_unit_interface_get_byte_offset_ext(
++					pva->syncpts.host_pdev,
++					pva->syncpts.syncpts_rw[i].id);
++
++			err = dma_iova_link(&paux_dev->dev, state,
++					    base + syncpt_offset,
++					    align_offset + i * pva->syncpts.page_size,
++					    pva->syncpts.page_size,
++					    DMA_BIDIRECTIONAL, 0);
++			if (err) {
++				int j;
++
++				dev_err(&pdev->dev,
++					"dma_iova_link syncpt %d failed: %d\n",
++					pva->syncpts.syncpts_rw[i].id, err);
++				for (j = 0; j < i; j++)
++					dma_iova_unlink(&paux_dev->dev, state,
++							align_offset + j * pva->syncpts.page_size,
++							pva->syncpts.page_size,
++							DMA_BIDIRECTIONAL, 0);
++				dma_iova_free(&paux_dev->dev, state);
++				goto err_map_sp;
++			}
++
++			pva->syncpts.syncpts_rw[i].addr =
++				aligned_base + i * pva->syncpts.page_size;
++			pva->syncpts.syncpts_rw[i].size = 0;
++			nvpva_dbg_info(pva,
++				"syncpt_addr:  id: %d   addr: %llx\n",
++				pva->syncpts.syncpts_rw[i].id,
++				pva->syncpts.syncpts_rw[i].addr);
++		}
+ 
+-	if (syncpt_addr_rw % (pva->syncpts.syncpt_range_rw) != 0) {
+-		dev_err(&pdev->dev, "RW sync pts base not aligned to 512k");
+-		err = -ENOMEM;
+-		goto err_map_sp;
+-	}
++		err = dma_iova_sync(&paux_dev->dev, state,
++				    align_offset, total_size);
++		if (err) {
++			dev_err(&pdev->dev, "dma_iova_sync failed: %d\n", err);
++			for (i = 0; i < MAX_PVA_QUEUE_COUNT; i++)
++				dma_iova_unlink(&paux_dev->dev, state,
++						align_offset + i * pva->syncpts.page_size,
++						pva->syncpts.page_size,
++						DMA_BIDIRECTIONAL, 0);
++			dma_iova_free(&paux_dev->dev, state);
++			goto err_map_sp;
++		}
+ 
+-	syncpt_addr_rw += (MAX_PVA_QUEUE_COUNT - 1) * pva->syncpts.page_size;
+-	if (syncpt_addr_rw != pva->syncpts.syncpts_rw[0].addr) {
+-		dev_err(&pdev->dev, "RW sync pts not contiguous");
+-		err = -ENOMEM;
+-		goto err_map_sp;
++		pva->syncpts.syncpt_start_iova_rw = aligned_base;
++		pva->syncpts.syncpt_range_rw = total_size;
++	} else {
++		/* No IOMMU — use physical addresses directly */
++		for (i = 0; i < MAX_PVA_QUEUE_COUNT; i++) {
++			syncpt_offset =
++				nvhost_syncpt_unit_interface_get_byte_offset_ext(
++					pva->syncpts.host_pdev,
++					pva->syncpts.syncpts_rw[i].id);
++			pva->syncpts.syncpts_rw[i].addr = base + syncpt_offset;
++			pva->syncpts.syncpts_rw[i].size = 0;
++		}
++		pva->syncpts.syncpt_start_iova_rw =
++			pva->syncpts.syncpts_rw[0].addr;
++		pva->syncpts.syncpt_range_rw =
++			MAX_PVA_QUEUE_COUNT * pva->syncpts.page_size;
+ 	}
+ 
++	pva->syncpts.syncpts_mapped_rw = true;
++
+ 	goto out;
+ 
+ err_map_sp:
+diff --git a/drivers/video/tegra/host/pva/pva.h b/drivers/video/tegra/host/pva/pva.h
+index cb04fec..2bb30eb 100644
+--- a/drivers/video/tegra/host/pva/pva.h
++++ b/drivers/video/tegra/host/pva/pva.h
+@@ -9,6 +9,7 @@
+ #define __NVHOST_PVA_H__
+ 
+ #include <linux/firmware.h>
++#include <linux/dma-mapping.h>
+ #include <linux/mutex.h>
+ #include <linux/version.h>
+ #include <linux/workqueue.h>
+@@ -324,6 +325,8 @@ struct nvpva_syncpt_desc {
+ struct nvpva_syncpts_desc {
+ 	struct platform_device *host_pdev;
+ 	struct nvpva_syncpt_desc syncpts_rw[MAX_PVA_QUEUE_COUNT];
++	struct dma_iova_state iova_state;
++	size_t iova_align_offset;
+ 	dma_addr_t syncpt_start_iova_r;
+ 	dma_addr_t syncpt_range_r;
+ 	dma_addr_t syncpt_start_iova_rw;
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0085-video-tegra-pva-add-missing-nvhost-syncpt-interface-.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0085-video-tegra-pva-add-missing-nvhost-syncpt-interface-.patch
@@ -1,0 +1,36 @@
+From 10598665a245e78226fbf05effc397e90348807c Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Sat, 25 Apr 2026 09:21:14 +0800
+Subject: [PATCH 4/4] video: tegra: pva: add missing nvhost syncpt interface
+ cleanup on remove
+
+pva_probe() calls nvhost_syncpt_unit_interface_init() which maps the
+syncpt aperture via dma_map_resource(). However, pva_remove() never
+calls the matching nvhost_syncpt_unit_interface_deinit() to unmap it.
+On each module reload cycle, a new DMA mapping is created for the
+same physical syncpt aperture without freeing the previous one. After
+7 cycles, the DMA debug layer warns:
+DMA-API: exceeded 7 overlapping mappings of cacheline 0x0000000001800000
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/pva/pva.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/video/tegra/host/pva/pva.c b/drivers/video/tegra/host/pva/pva.c
+index ce487d0..f844b2e 100644
+--- a/drivers/video/tegra/host/pva/pva.c
++++ b/drivers/video/tegra/host/pva/pva.c
+@@ -1518,6 +1518,7 @@ static int __exit pva_remove(struct platform_device *pdev)
+ 	pva_auth_allow_list_destroy(&pva->pva_auth);
+ 	pva_free_task_status_buffer(pva);
+ 	nvpva_syncpt_unit_interface_deinit(pdev, pva->aux_pdev);
++	nvhost_syncpt_unit_interface_deinit(pdev);
+ 	nvpva_client_context_deinit(pva);
+ 	nvpva_queue_deinit(pva->pool);
+ 	nvhost_client_device_release(pdev);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0086-video-tegra-nvcsi-fix-resource-leak-on-module-unload.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0086-video-tegra-nvcsi-fix-resource-leak-on-module-unload.patch
@@ -1,0 +1,45 @@
+From b1f97c82b9e525a83fd08ec3772e30eb0905e36b Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 10:21:57 +0800
+Subject: [PATCH] video: tegra: nvcsi: fix resource leak on module unload
+
+t194_nvcsi_probe() calls nvhost_module_init() and
+nvhost_client_device_init() to set up runtime PM, debugfs, and
+the nvcsi device class. However, t194_nvcsi_remove() does not call
+the corresponding cleanup functions, leaking these resources on
+module unload.
+On module reload, this causes:
+- "Unbalanced pm_runtime_enable!", because pm_runtime_enable called
+  again without prior pm_runtime_disable
+- "debugfs: 'nvcsi' already exists", because debugfs directory not
+  removed
+- "sysfs: cannot create duplicate filename '/class/nvcsi'", because
+  device class not destroyed
+- Probe fails with -EEXIST
+Fix by adding nvhost_client_device_release() and nvhost_module_deinit()
+in t194_nvcsi_remove() to properly clean up the device class, debugfs,
+and runtime PM state.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/nvcsi/nvcsi-t194.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/video/tegra/host/nvcsi/nvcsi-t194.c b/drivers/video/tegra/host/nvcsi/nvcsi-t194.c
+index ea11afa..abbb852 100644
+--- a/drivers/video/tegra/host/nvcsi/nvcsi-t194.c
++++ b/drivers/video/tegra/host/nvcsi/nvcsi-t194.c
+@@ -242,6 +242,8 @@ static int __exit t194_nvcsi_remove(struct platform_device *dev)
+ 	tegra_camera_device_unregister(nvcsi);
+ 	mc_csi = NULL;
+ 	tegra_csi_media_controller_remove(&nvcsi->csi);
++	nvhost_client_device_release(dev);
++	nvhost_module_deinit(dev);
+ 
+ 	return 0;
+ }
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0087-video-tegra-isp5-fix-use-after-free-on-module-unload.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0087-video-tegra-isp5-fix-use-after-free-on-module-unload.patch
@@ -1,0 +1,42 @@
+From 65ce64cc5377b34860a04876d7c54c3b12f5f99b Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 12:21:56 +0800
+Subject: [PATCH 1/2] video: tegra: isp5: fix use-after-free on module unload
+
+capture_isp_exit() calls isp_channel_drv_exit() before
+platform_driver_unregister(). isp_channel_drv_exit() destroys
+isp_channel_class, then platform_driver_unregister() triggers
+isp5_remove() which calls isp_channel_drv_unregister() that uses
+the already-freed class in device_destroy(), causing a kernel panic:
+Unable to handle kernel paging request at virtual address
+006b6b6b6b6b6b6b
+Fix by reversing the teardown order: unregister the platform driver
+first so isp5_remove() runs while isp_channel_class is still valid,
+then call isp_channel_drv_exit() to destroy the class. This mirrors
+the init order where isp_channel_drv_init() is called before
+platform_driver_register().
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/isp/isp5.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/video/tegra/host/isp/isp5.c b/drivers/video/tegra/host/isp/isp5.c
+index 0efa515..dd48afa 100644
+--- a/drivers/video/tegra/host/isp/isp5.c
++++ b/drivers/video/tegra/host/isp/isp5.c
+@@ -391,8 +391,8 @@ static int __init capture_isp_init(void)
+ }
+ static void __exit capture_isp_exit(void)
+ {
+-	isp_channel_drv_exit();
+ 	platform_driver_unregister(&isp5_driver);
++	isp_channel_drv_exit();
+ }
+ 
+ module_init(capture_isp_init);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0088-video-tegra-isp5-fix-resource-leak-on-module-unload.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0088-video-tegra-isp5-fix-resource-leak-on-module-unload.patch
@@ -1,0 +1,45 @@
+From 98de2fe18fce8a0b068c0aa0ca2103be1761dfa7 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 13:49:53 +0800
+Subject: [PATCH 2/2] video: tegra: isp5: fix resource leak on module unload
+
+isp5_probe() calls nvhost_module_init() and nvhost_client_device_init()
+to set up runtime PM, debugfs, and the isp device class. However,
+isp5_remove() does not call the corresponding cleanup functions,
+leaking these resources on module unload.
+On module reload, this causes:
+- "Unbalanced pm_runtime_enable!", because pm_runtime_enable called
+  again without prior pm_runtime_disable
+- "debugfs: 'isp' already exists", because debugfs directory not
+  removed
+- "sysfs: cannot create duplicate filename '/class/isp'", because
+  device class not destroyed
+- Probe fails with -EEXIST
+Fix by adding nvhost_client_device_release() and nvhost_module_deinit()
+in isp5_remove() to properly clean up the device class, debugfs, and
+runtime PM state.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/isp/isp5.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/video/tegra/host/isp/isp5.c b/drivers/video/tegra/host/isp/isp5.c
+index dd48afa..f04e876 100644
+--- a/drivers/video/tegra/host/isp/isp5.c
++++ b/drivers/video/tegra/host/isp/isp5.c
+@@ -320,6 +320,9 @@ static int isp5_remove(struct platform_device *pdev)
+ 
+ 	platform_device_put(isp5->isp_thi);
+ 
++	nvhost_client_device_release(pdev);
++	nvhost_module_deinit(pdev);
++
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0089-video-tegra-vi5-fix-resource-leak-on-module-unload.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0089-video-tegra-vi5-fix-resource-leak-on-module-unload.patch
@@ -1,0 +1,43 @@
+From b1430d72157a9713ac6279d5ae8dbfb55fb2b23f Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 15:09:08 +0800
+Subject: [PATCH] video: tegra: vi5: fix resource leak on module unload
+
+vi5_probe() calls nvhost_module_init() and nvhost_client_device_init()
+to set up runtime PM, debugfs, and the vi device class. However,
+vi5_remove() does not call the corresponding cleanup functions,
+leaking these resources on module unload.
+On module reload, this causes:
+- "Unbalanced pm_runtime_enable!", because pm_runtime_enable called
+  again without prior pm_runtime_disable
+- "debugfs: 'vi0' already exists", because debugfs directory not removed
+- "sysfs: cannot create duplicate filename '/class/vi0'", because device
+  class not destroyed
+- Probe fails with -EEXIST
+Fix by adding nvhost_client_device_release() and nvhost_module_deinit()
+in vi5_remove() to properly clean up the device class, debugfs, and
+runtime PM state.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/vi/vi5.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/video/tegra/host/vi/vi5.c b/drivers/video/tegra/host/vi/vi5.c
+index 2a3387a..9a79da2 100644
+--- a/drivers/video/tegra/host/vi/vi5.c
++++ b/drivers/video/tegra/host/vi/vi5.c
+@@ -316,6 +316,8 @@ static int vi5_remove(struct platform_device *pdev)
+ 
+ 	vi5_remove_debugfs(vi5);
+ 	platform_device_put(vi5->vi_thi);
++	nvhost_client_device_release(pdev);
++	nvhost_module_deinit(pdev);
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0090-media-tegra-capture-vi-fix-use-after-free-on-module-.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0090-media-tegra-capture-vi-fix-use-after-free-on-module-.patch
@@ -1,0 +1,43 @@
+From 243eb04b7235b16b4187bed11a0c5c731ee3c8e5 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 17:36:43 +0800
+Subject: [PATCH 1/3] media: tegra: capture-vi: fix use-after-free on module
+ unload
+
+capture_vi_exit() calls vi_channel_drv_exit() before
+platform_driver_unregister(). vi_channel_drv_exit() destroys
+vi_channel_class, then platform_driver_unregister() triggers
+capture_vi_remove() which calls vi_channel_drv_unregister() that
+uses the already-freed class in device_destroy(), causing a kernel
+panic:
+Unable to handle kernel paging request at virtual address
+0050ac07552f63f8
+Fix by reversing the teardown order: unregister the platform driver
+first so capture_vi_remove() runs while vi_channel_class is still
+valid, then call vi_channel_drv_exit() to destroy the class. This
+mirrors the init order.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/media/platform/tegra/camera/fusa-capture/capture-vi.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/fusa-capture/capture-vi.c b/drivers/media/platform/tegra/camera/fusa-capture/capture-vi.c
+index 2289f47..62c16c0 100644
+--- a/drivers/media/platform/tegra/camera/fusa-capture/capture-vi.c
++++ b/drivers/media/platform/tegra/camera/fusa-capture/capture-vi.c
+@@ -1755,8 +1755,8 @@ static int __init capture_vi_init(void)
+ }
+ static void __exit capture_vi_exit(void)
+ {
+-	vi_channel_drv_exit();
+ 	platform_driver_unregister(&capture_vi_driver);
++	vi_channel_drv_exit();
+ }
+ 
+ module_init(capture_vi_init);
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0091-media-tegra-vi-fix-NULL-pointer-dereference-in-chann.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0091-media-tegra-vi-fix-NULL-pointer-dereference-in-chann.patch
@@ -1,0 +1,38 @@
+From 71c2bc5e207bb59af3ccbd6cb240682f3f079f95 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 17:41:23 +0800
+Subject: [PATCH 2/3] media: tegra: vi: fix NULL pointer dereference in channel
+ unregister
+
+tegra_vi_channels_unregister() dereferences it->video without a NULL
+check. When nvhost_vi5 is unloaded before tegra_camera, the VI
+channel video devices are already cleaned up and it->video is NULL,
+causing a kernel panic during tegra_vi_media_controller_cleanup():
+Unable to handle kernel NULL pointer dereference at virtual address
+00000000000005b8
+Fix by adding a NULL check for it->video before accessing
+it->video->cdev.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/media/platform/tegra/camera/vi/channel.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 37c5383..96092e9 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -2762,7 +2762,7 @@ void tegra_vi_channels_unregister(struct tegra_mc_vi *vi)
+ 	struct tegra_channel *it;
+ 
+ 	list_for_each_entry(it, &vi->vi_chans, list) {
+-		if (it->video->cdev != NULL)
++		if (it->video && it->video->cdev != NULL)
+ 			video_unregister_device(it->video);
+ 	}
+ }
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0092-video-tegra-camera_platform-fix-debugfs-leak-on-modu.patch
@@ -1,0 +1,54 @@
+From f0183f7f4fdc0f563292240b96937e3a46e31d03 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 19:13:23 +0800
+Subject: [PATCH 3/3] video: tegra: camera_platform: fix debugfs leak on module
+ unload
+
+dbgfs_tegra_camera_init() creates a debugfs directory
+"tegra_camera_platform" but the dentry is stored in a local variable
+and never removed. On module reload, debugfs_create_dir() warns:
+debugfs: 'tegra_camera_platform' already exists in '/'
+Fix by saving the debugfs dentry in a static variable and calling
+debugfs_remove_recursive() in tegra_camera_remove().
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/camera/tegra_camera_platform.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/drivers/video/tegra/camera/tegra_camera_platform.c b/drivers/video/tegra/camera/tegra_camera_platform.c
+index b2b5510..51b40b6 100644
+--- a/drivers/video/tegra/camera/tegra_camera_platform.c
++++ b/drivers/video/tegra/camera/tegra_camera_platform.c
+@@ -153,6 +153,7 @@ static int tegra_camera_release(struct inode *inode, struct file *file)
+ #ifdef CONFIG_DEBUG_FS
+ static u64 vi_mode_d;
+ static u64 bypass_mode_d;
++static struct dentry *tegra_camera_debugfs_dir;
+ 
+ static int dbgfs_tegra_camera_init(void)
+ {
+@@ -162,6 +163,7 @@ static int dbgfs_tegra_camera_init(void)
+ 	if (!dir)
+ 		return -ENOMEM;
+ 
++	tegra_camera_debugfs_dir = dir;
+ 	debugfs_create_u64("vi", S_IRUGO, dir, &vi_mode_d);
+ 	debugfs_create_u64("scf", S_IRUGO, dir, &bypass_mode_d);
+ 
+@@ -789,6 +791,10 @@ static int tegra_camera_remove(struct platform_device *pdev)
+ 
+ 	tegra_camera_isomgr_unregister(info);
+ 	misc_deregister(&tegra_camera_misc);
++#ifdef CONFIG_DEBUG_FS
++	debugfs_remove_recursive(tegra_camera_debugfs_dir);
++	tegra_camera_debugfs_dir = NULL;
++#endif
+ 
+ 	return 0;
+ }
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0093-media-tegra-vi-fix-memory-leak-in-media-v4l2-cleanup.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0093-media-tegra-vi-fix-memory-leak-in-media-v4l2-cleanup.patch
@@ -1,0 +1,65 @@
+From a0a44adb2c4b7500e9cdc54dd84cf086f6998365 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 27 Apr 2026 19:46:32 +0800
+Subject: [PATCH] media: tegra: vi: fix memory leak in media/v4l2 cleanup
+
+Two missing cleanup calls cause memory leaks on module unload:
+1. tegra_vi_graph_cleanup() calls v4l2_async_nf_unregister() but not
+   v4l2_async_nf_cleanup(). The kernel's v4l2 async framework requires
+   both: unregister unbinds subdevices, cleanup frees the notifier's
+   internal resources.
+2. tegra_vi_v4l2_cleanup() calls media_device_unregister() but not
+   media_device_cleanup(). The media graph walk bitmap allocated by
+   media_graph_walk_init() during entity registration is only freed
+   by media_device_cleanup().
+   kmemleak reports:
+     unreferenced object (size 8):
+       backtrace:
+         bitmap_zalloc
+         media_graph_walk_init
+         media_device_register_entity
+Fix by adding the missing v4l2_async_nf_cleanup() /
+v4l2_async_notifier_cleanup() and media_device_cleanup() calls.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/media/platform/tegra/camera/vi/graph.c     | 2 ++
+ drivers/media/platform/tegra/camera/vi/mc_common.c | 4 +++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/graph.c b/drivers/media/platform/tegra/camera/vi/graph.c
+index 7c2d05e..731ed87 100644
+--- a/drivers/media/platform/tegra/camera/vi/graph.c
++++ b/drivers/media/platform/tegra/camera/vi/graph.c
+@@ -427,8 +427,10 @@ void tegra_vi_graph_cleanup(struct tegra_mc_vi *vi)
+ #if defined(CONFIG_V4L2_ASYNC)
+ #if defined(NV_V4L2_ASYNC_NOTIFIER_INIT_PRESENT)
+ 		v4l2_async_notifier_unregister(&chan->notifier);
++		v4l2_async_notifier_cleanup(&chan->notifier);
+ #else
+ 		v4l2_async_nf_unregister(&chan->notifier);
++		v4l2_async_nf_cleanup(&chan->notifier);
+ #endif
+ #endif
+ 		list_for_each_entry_safe(entity, entityp,
+diff --git a/drivers/media/platform/tegra/camera/vi/mc_common.c b/drivers/media/platform/tegra/camera/vi/mc_common.c
+index ae6b492..aa14e31 100644
+--- a/drivers/media/platform/tegra/camera/vi/mc_common.c
++++ b/drivers/media/platform/tegra/camera/vi/mc_common.c
+@@ -85,8 +85,10 @@ void tegra_vi_v4l2_cleanup(struct tegra_mc_vi *vi)
+ {
+ 	v4l2_ctrl_handler_free(&vi->ctrl_handler);
+ 	v4l2_device_unregister(&vi->v4l2_dev);
+-	if (!vi->pg_mode)
++	if (!vi->pg_mode) {
+ 		media_device_unregister(&vi->media_dev);
++		media_device_cleanup(&vi->media_dev);
++	}
+ }
+ EXPORT_SYMBOL(tegra_vi_v4l2_cleanup);
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0094-video-tegra-capture-support-fix-resource-leak-on-mod.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0094-video-tegra-capture-support-fix-resource-leak-on-mod.patch
@@ -1,0 +1,45 @@
+From c662be9243bf1321bb09165a96df5613afd9a527 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Fri, 8 May 2026 14:09:46 +0800
+Subject: [PATCH] video: tegra: capture-support: fix resource leak on module
+ unload
+
+capture_support_probe() calls nvhost_module_init(),
+nvhost_client_device_init(), and nvhost_syncpt_unit_interface_init()
+but capture_support_remove() is empty, it doesn't release all resources
+on module unload and causes issues as below when module is loaded again.
+- "Unbalanced pm_runtime_enable!", because pm_runtime_enable called
+  again without prior pm_runtime_disable
+- "debugfs: 'vi0-thi' already exists", because debugfs directory is not
+  removed
+- "sysfs: cannot create duplicate filename '/class/vi0-thi'", because
+  device class is not destroyed
+Fix this issue by adding nvhost_syncpt_unit_interface_deinit(),
+nvhost_client_device_release(), and nvhost_module_deinit() in
+capture_support_remove() to properly clean up the syncpt mapping,
+device class, debugfs, and runtime PM state.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/video/tegra/host/capture/capture-support.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/video/tegra/host/capture/capture-support.c b/drivers/video/tegra/host/capture/capture-support.c
+index e8d8514..a065506 100644
+--- a/drivers/video/tegra/host/capture/capture-support.c
++++ b/drivers/video/tegra/host/capture/capture-support.c
+@@ -143,6 +143,9 @@ error:
+ 
+ static int capture_support_remove(struct platform_device *pdev)
+ {
++	nvhost_syncpt_unit_interface_deinit(pdev);
++	nvhost_client_device_release(pdev);
++	nvhost_module_deinit(pdev);
+ 	return 0;
+ }
+ 
+-- 
+2.34.1
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0095-net-can-mttcan-fix-use-after-free-issue-of-skb.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0095-net-can-mttcan-fix-use-after-free-issue-of-skb.patch
@@ -1,0 +1,59 @@
+From 2fc7986608cc61f98848a0ff475b3643e0fe09e7 Mon Sep 17 00:00:00 2001
+From: Meng Li <Meng.Li@windriver.com>
+Date: Mon, 18 May 2026 18:44:29 +0800
+Subject: [PATCH] net: can: mttcan: fix use-after-free issue of skb
+
+mttcan_handle_bus_err() and mttcan_state_change() access cf->can_dlc
+after calling netif_receive_skb(skb). netif_receive_skb() consumes the skb
+and free it immediately via can_receive() -> consume_skb(), making
+the subsequent access to cause a use-after-free:
+BUG: KFENCE: use-after-free read in mttcan_handle_bus_err+0x158/0x248
+allocated by task 0:
+    alloc_can_err_skb
+    mttcan_handle_bus_err
+freed by task 0:
+    consume_skb
+    can_receive
+    can_rcv
+    __netif_receive_skb_one_core
+    netif_receive_skb
+    mttcan_handle_bus_err
+Fix by updating stats->rx_packets and stats->rx_bytes before calling
+netif_receive_skb(), while the skb data is still valid.
+
+Upstream-Status: Pending
+
+Signed-off-by: Meng Li <Meng.Li@windriver.com>
+---
+ drivers/net/can/mttcan/native/m_ttcan_linux.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/can/mttcan/native/m_ttcan_linux.c b/drivers/net/can/mttcan/native/m_ttcan_linux.c
+index d881f78..582e599 100644
+--- a/drivers/net/can/mttcan/native/m_ttcan_linux.c
++++ b/drivers/net/can/mttcan/native/m_ttcan_linux.c
+@@ -515,9 +515,9 @@ static int mttcan_state_change(struct net_device *dev,
+ 	default:
+ 		break;
+ 	}
+-	netif_receive_skb(skb);
+ 	stats->rx_packets++;
+ 	stats->rx_bytes += cf->can_dlc;
++	netif_receive_skb(skb);
+ 
+ 	return 1;
+ }
+@@ -575,9 +575,9 @@ static int mttcan_handle_bus_err(struct net_device *dev,
+ 		break;
+ 	}
+ 
+-	netif_receive_skb(skb);
+ 	stats->rx_packets++;
+ 	stats->rx_bytes += cf->can_dlc;
++	netif_receive_skb(skb);
+ 	return 1;
+ }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
Hi @ichergui 

All the 22 patches are used to fix issue of nvidia-kernel-oot. 
Could you please have a look, and check whether they are able to be contributed to NVIDIA community?

thanks,
Limeng 