### PR TITLE
conf/layer.conf: update LAYERSERIESCOMPAT with wrynose

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,7 +12,7 @@ LAYERVERSION_tegra = "1"
 
 LAYERDEPENDS_tegra = "core"
 
-LAYERSERIES_COMPAT_tegra = "blacksail"
+LAYERSERIES_COMPAT_tegra = "wrynose blacksail"
 
 # Recipe modifications for other layers that may be included in the build
 BBFILES += "${@' '.join('${LAYERDIR}/external/%s/recipes*/*/*.bb' % layer \


### PR DESCRIPTION
When Nvidia is releasing Jetpack 39.2.0 with Yocto support quite
close in time with the release of Yocto 6.0, that is a LTS release,
I think it will be quite common to use them together. Let us aim for
compatibility of the two until we need to branch them out.