### PR TITLE
Factor AGX Thor SOM config into includes

### DIFF
--- a/conf/machine/include/agx-thor-t4000.inc
+++ b/conf/machine/include/agx-thor-t4000.inc
@@ -1,0 +1,61 @@
+# Common settings for AGX Thor T4000 (p3834-0000) modules
+
+TEGRA_BOARDID ?= "3834"
+TEGRA_FAB ?= "000"
+TEGRA_BOARDSKU ?= "0000"
+TEGRA_BOARDREV ?= "B.1"
+TEGRA_CHIPREV ?= "1"
+NVPMODEL ?= "nvpmodel_p3834_0000"
+NVFANCONTROL ?= "nvfancontrol_p3834_0000_p4071_0000"
+
+TNSPEC_BOOTDEV ?= "nvme0n1p1"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_l4t_t264_qspi.xml"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
+PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
+TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
+
+TEGRA_BUPGEN_SPECS ?= " \
+    fab=000;boardsku=0000;boardrev=;chiprev=;chipsku=00:00:00:E2;bup_type=bl \
+"
+
+EMMC_SIZE ?= ""
+BOOTPART_SIZE ?= ""
+
+TEGRA_PLUGIN_MANAGER_OVERLAYS ?= "tegra264-p4071-0000+p3834-xxxx-dynamic.dtbo"
+TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra264-bpmp-3834-0000-4071-xxxx.dtb"
+TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t264-TE1070M-A1_prod.bin"
+TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:E2"
+TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra264-mb1-bct-cprod-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra264-mb1-bct-device-p3834-xxxx.dts"
+TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra264-br-bct-common-l4t.dts"
+TEGRA_FLASHVAR_DEV_PARAMS_B ?= ""
+TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra264-br-bct-diag-boot.dts"
+TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra264-mb1-bct-gpioint-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra264-mb2-bct-misc-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "--minratchet_config tegra264-mb1-bct-ratchet-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra264-mb1-bct-misc-p3834-0000-p4071-0000.dts"
+TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra264-mb1-bct-padvoltage-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra264-mb1-bct-pmic-p3834-0000-p4071-0000.dts"
+TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra264-mb1-bct-prod-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_RAMCODE ?= "0"
+TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra264-mb2-bct-firewall-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_UPHY_CONFIG ?= "tegra264-mb1-bct-uphy-lanes-p4071-0000.dts"
+TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra264-p3834-0000-sdram-bct-warmboot-l4t.dts"
+TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0000-sdram-dfs.dts"
+
+require conf/machine/include/tegra264.inc
+
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
+MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
+
+KERNEL_DEVICETREE ?= "tegra264-p4071-0000+p3834-0000-nv.dtb"
+# 50GiB default rootfs size
+ROOTFSPART_SIZE_DEFAULT ?= "53687091200"
+TEGRA_FLASHVAR_ODMDATA ?= ""
+EMC_BCT ?= "tegra264-p3834-0000-sdram-bct-l4t.dts"
+TEGRA_AUDIO_DEVICE ?= "tegra-hda-p3767-p3509"
+
+OTABOOTDEV ?= "/dev/mtdblock0"
+OTAGPTDEV ?= "/dev/mtdblock0"

--- a/conf/machine/include/agx-thor-t5000.inc
+++ b/conf/machine/include/agx-thor-t5000.inc
@@ -1,0 +1,62 @@
+# Common settings for AGX Thor T5000 (p3834-0008) modules
+
+TEGRA_BOARDID ?= "3834"
+TEGRA_FAB ?= "400"
+TEGRA_BOARDSKU ?= "0008"
+TEGRA_BOARDREV ?= "G.5"
+TEGRA_CHIPREV ?= "1"
+NVPMODEL ?= "nvpmodel_p3834_0008"
+NVFANCONTROL ?= "nvfancontrol_p3834_0008_p4071_0000"
+
+TNSPEC_BOOTDEV ?= "nvme0n1p1"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_l4t_t264_qspi.xml"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
+PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
+TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
+
+TEGRA_BUPGEN_SPECS ?= " \
+    fab=000;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
+    fab=401;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
+"
+
+EMMC_SIZE ?= ""
+BOOTPART_SIZE ?= ""
+
+TEGRA_PLUGIN_MANAGER_OVERLAYS ?= "tegra264-p4071-0000+p3834-xxxx-dynamic.dtbo"
+TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra264-bpmp-3834-0008-4071-xxxx.dtb"
+TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t264-TA1090SA-A1_prod.bin"
+TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:A0"
+TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra264-mb1-bct-cprod-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra264-mb1-bct-device-p3834-xxxx.dts"
+TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra264-br-bct-common-l4t.dts"
+TEGRA_FLASHVAR_DEV_PARAMS_B ?= ""
+TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra264-br-bct-diag-boot.dts"
+TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra264-mb1-bct-gpioint-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra264-mb2-bct-misc-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "--minratchet_config tegra264-mb1-bct-ratchet-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra264-mb1-bct-misc-p3834-0008-p4071-0000.dts"
+TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra264-mb1-bct-padvoltage-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra264-mb1-bct-pmic-p3834-0008-p4071-0000.dts"
+TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra264-mb1-bct-prod-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_RAMCODE ?= "12"
+TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra264-mb2-bct-firewall-p3834-xxxx-p4071-0000.dts"
+TEGRA_FLASHVAR_UPHY_CONFIG ?= "tegra264-mb1-bct-uphy-lanes-p4071-0000.dts"
+TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra264-p3834-0008-sdram-bct-warmboot-l4t.dts"
+TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0008-sdram-dfs.dts"
+
+require conf/machine/include/tegra264.inc
+
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
+MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
+
+KERNEL_DEVICETREE ?= "tegra264-p4071-0000+p3834-0008-nv.dtb"
+# 50GiB default rootfs size
+ROOTFSPART_SIZE_DEFAULT ?= "53687091200"
+TEGRA_FLASHVAR_ODMDATA ?= ""
+EMC_BCT ?= "tegra264-p3834-0008-sdram-bct-l4t.dts"
+TEGRA_AUDIO_DEVICE ?= "tegra-hda-p3767-p3509"
+
+OTABOOTDEV ?= "/dev/mtdblock0"
+OTAGPTDEV ?= "/dev/mtdblock0"

--- a/conf/machine/jetson-agx-thor-devkit.conf
+++ b/conf/machine/jetson-agx-thor-devkit.conf
@@ -2,66 +2,7 @@
 #@NAME: Nvidia AGX Thor dev kit
 #@DESCRIPTION: Nvidia AGX Thor dev kit (P3834-0008 module in P4071-0000 carrier with NVMe)
 
-TEGRA_BOARDID ?= "3834"
-TEGRA_FAB ?= "400"
-TEGRA_BOARDSKU ?= "0008"
-TEGRA_BOARDREV ?= "G.5"
-TEGRA_CHIPREV ?= "1"
-NVPMODEL ?= "nvpmodel_p3834_0008"
-NVFANCONTROL ?= "nvfancontrol_p3834_0008_p4071_0000"
-
-TNSPEC_BOOTDEV ?= "nvme0n1p1"
-PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_l4t_t264_qspi.xml"
-PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
-PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
-TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
-
-TEGRA_BUPGEN_SPECS ?= " \
-    fab=000;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
-    fab=401;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
-"
-
-EMMC_SIZE ?= ""
-BOOTPART_SIZE ?= ""
-
-TEGRA_PLUGIN_MANAGER_OVERLAYS ?= "tegra264-p4071-0000+p3834-xxxx-dynamic.dtbo"
-TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra264-bpmp-3834-0008-4071-xxxx.dtb"
-TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t264-TA1090SA-A1_prod.bin"
-TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:A0"
-TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra264-mb1-bct-cprod-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra264-mb1-bct-device-p3834-xxxx.dts"
-TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra264-br-bct-common-l4t.dts"
-TEGRA_FLASHVAR_DEV_PARAMS_B ?= ""
-TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra264-br-bct-diag-boot.dts"
-TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra264-mb1-bct-gpioint-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra264-mb2-bct-misc-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "--minratchet_config tegra264-mb1-bct-ratchet-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra264-mb1-bct-misc-p3834-0008-p4071-0000.dts"
-TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra264-mb1-bct-padvoltage-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra264-mb1-bct-pmic-p3834-0008-p4071-0000.dts"
-TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra264-mb1-bct-prod-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_RAMCODE ?= "12"
-TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra264-mb2-bct-firewall-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_UPHY_CONFIG ?= "tegra264-mb1-bct-uphy-lanes-p4071-0000.dts"
-TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra264-p3834-0008-sdram-bct-warmboot-l4t.dts"
-TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0008-sdram-dfs.dts"
-
-require conf/machine/include/tegra264.inc
-
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
-MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
-
-KERNEL_DEVICETREE ?= "tegra264-p4071-0000+p3834-0008-nv.dtb"
-# 50GiB default rootfs size
-ROOTFSPART_SIZE_DEFAULT ?= "53687091200"
-TEGRA_FLASHVAR_ODMDATA ?= ""
-EMC_BCT ?= "tegra264-p3834-0008-sdram-bct-l4t.dts"
-TEGRA_AUDIO_DEVICE ?= "tegra-hda-p3767-p3509"
-
-OTABOOTDEV ?= "/dev/mtdblock0"
-OTAGPTDEV ?= "/dev/mtdblock0"
+require conf/machine/include/agx-thor-t5000.inc
 
 NVIDIA_WIFI ?= "kernel-module-rtk-btusb kernel-module-rtl8852ce"
 require conf/machine/include/devkit-wifi.inc

--- a/conf/machine/jetson-agx-thor-t4000.conf
+++ b/conf/machine/jetson-agx-thor-t4000.conf
@@ -2,65 +2,7 @@
 #@NAME: Nvidia AGX Thor T4000 module
 #@DESCRIPTION: Nvidia AGX Thor dev kit (P3834-0000 module in P4071-0000 carrier with NVMe)
 
-TEGRA_BOARDID ?= "3834"
-TEGRA_FAB ?= "000"
-TEGRA_BOARDSKU ?= "0000"
-TEGRA_BOARDREV ?= "B.1"
-TEGRA_CHIPREV ?= "1"
-NVPMODEL ?= "nvpmodel_p3834_0000"
-NVFANCONTROL ?= "nvfancontrol_p3834_0000_p4071_0000"
-
-TNSPEC_BOOTDEV ?= "nvme0n1p1"
-PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_l4t_t264_qspi.xml"
-PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
-PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
-TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
-
-TEGRA_BUPGEN_SPECS ?= " \
-    fab=000;boardsku=0000;boardrev=;chiprev=;chipsku=00:00:00:E2;bup_type=bl \
-"
-
-EMMC_SIZE ?= ""
-BOOTPART_SIZE ?= ""
-
-TEGRA_PLUGIN_MANAGER_OVERLAYS ?= "tegra264-p4071-0000+p3834-xxxx-dynamic.dtbo"
-TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra264-bpmp-3834-0000-4071-xxxx.dtb"
-TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t264-TE1070M-A1_prod.bin"
-TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:E2"
-TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra264-mb1-bct-cprod-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra264-mb1-bct-device-p3834-xxxx.dts"
-TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra264-br-bct-common-l4t.dts"
-TEGRA_FLASHVAR_DEV_PARAMS_B ?= ""
-TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra264-br-bct-diag-boot.dts"
-TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra264-mb1-bct-gpioint-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra264-mb2-bct-misc-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "--minratchet_config tegra264-mb1-bct-ratchet-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra264-mb1-bct-misc-p3834-0000-p4071-0000.dts"
-TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra264-mb1-bct-padvoltage-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra264-mb1-bct-pmic-p3834-0000-p4071-0000.dts"
-TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra264-mb1-bct-prod-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_RAMCODE ?= "0"
-TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra264-mb2-bct-firewall-p3834-xxxx-p4071-0000.dts"
-TEGRA_FLASHVAR_UPHY_CONFIG ?= "tegra264-mb1-bct-uphy-lanes-p4071-0000.dts"
-TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra264-p3834-0000-sdram-bct-warmboot-l4t.dts"
-TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0000-sdram-dfs.dts"
-
-require conf/machine/include/tegra264.inc
-
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
-MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
-
-KERNEL_DEVICETREE ?= "tegra264-p4071-0000+p3834-0000-nv.dtb"
-# 50GiB default rootfs size
-ROOTFSPART_SIZE_DEFAULT ?= "53687091200"
-TEGRA_FLASHVAR_ODMDATA ?= ""
-EMC_BCT ?= "tegra264-p3834-0000-sdram-bct-l4t.dts"
-TEGRA_AUDIO_DEVICE ?= "tegra-hda-p3767-p3509"
-
-OTABOOTDEV ?= "/dev/mtdblock0"
-OTAGPTDEV ?= "/dev/mtdblock0"
+require conf/machine/include/agx-thor-t4000.inc
 
 NVIDIA_WIFI ?= "kernel-module-rtk-btusb kernel-module-rtl8852ce"
 require conf/machine/include/devkit-wifi.inc


### PR DESCRIPTION
`jetson-agx-thor-devkit.conf` (p3834-0008) and `jetson-agx-thor-t4000.conf` (p3834-0000) duplicated the full SOM and carrier configuration. This moves the shared settings into `conf/machine/include/agx-thor-t5000.inc` and `agx-thor-t4000.inc`, following the existing `agx-orin.inc`/`orin-nx.inc` pattern, and requires them from the devkit confs.
