### PR TITLE
L4T R39.2.0: CUDA 13.2 build fixes (nvcc -Xcompiler handling, cub proclaims specializations)

### DIFF
--- a/classes-recipe/cuda.bbclass
+++ b/classes-recipe/cuda.bbclass
@@ -16,7 +16,7 @@ LDFLAGS:prepend:cuda = "${TOOLCHAIN_OPTIONS} "
 LDFLAGS:append:cuda = " ${CUDA_LDFLAGS}"
 DEBUG_PREFIX_MAP:remove:cuda = "-fcanon-prefix-map"
 
-def cuda_extract_compiler(compiler, d, prefix='-Xcompiler '):
+def cuda_extract_compiler(compiler, d, prefix='-Xcompiler='):
     args = d.getVar(compiler).split()
     if args[0] == "ccache":
         return args[1], ' '.join([prefix + arg for arg in args[2:]])

--- a/recipes-devtools/cuda/cuda-cccl/0001-Fix-invalid-C-syntax-in-proclaims_copyable_arguments.patch
+++ b/recipes-devtools/cuda/cuda-cccl/0001-Fix-invalid-C-syntax-in-proclaims_copyable_arguments.patch
@@ -1,0 +1,50 @@
+Fix invalid C++ syntax in proclaims_copyable_arguments specializations
+
+cccl/CUB declares its two cuda::proclaims_copyable_arguments specializations in
+cub/device/device_transform.cuh and tuning_transform.cuh with a leading global
+qualifier (struct ::cuda::...<...> : base). gcc rejects this in some translation
+units (e.g. onnxruntime CUDA kernels pulling in cub::DeviceTransform via cutlass
++ libcu++) with:
+
+  error: global qualification of class name is invalid before ':' token
+  error: expected '{' before ':' token
+
+Upstream re-declares the specializations inside "namespace cuda { ... }", which
+is valid C++ and behaviour-preserving.
+
+Upstream-Status: Backport [https://github.com/NVIDIA/cccl/pull/8771]
+Signed-off-by: Johannes Schrimpf <johannes.schrimpf@blueye.no>
+
+--- a/usr/local/cuda-13.2/include/cccl/cub/device/device_transform.cuh	2026-06-05 18:36:49.372858231 +0200
++++ b/usr/local/cuda-13.2/include/cccl/cub/device/device_transform.cuh	2026-06-05 18:37:08.896962291 +0200
+@@ -40,9 +40,12 @@
+ } // namespace detail
+ CUB_NAMESPACE_END
+ 
++namespace cuda
++{
+ template <typename T>
+-struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
++struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
+ {};
++} // namespace cuda
+ 
+ CUB_NAMESPACE_BEGIN
+ //! DeviceTransform provides device-wide, parallel operations for transforming elements tuple-wise from multiple input
+--- a/usr/local/cuda-13.2/include/cccl/cub/device/dispatch/tuning/tuning_transform.cuh	2026-06-05 18:36:49.376858252 +0200
++++ b/usr/local/cuda-13.2/include/cccl/cub/device/dispatch/tuning/tuning_transform.cuh	2026-06-05 18:37:08.900962313 +0200
+@@ -48,10 +48,12 @@
+ } // namespace detail::transform
+ CUB_NAMESPACE_END
+ 
++namespace cuda
++{
+ template <>
+-struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
+-    : ::cuda::std::true_type
++struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate> : ::cuda::std::true_type
+ {};
++} // namespace cuda
+ 
+ CUB_NAMESPACE_BEGIN
+ namespace detail::transform

--- a/recipes-devtools/cuda/cuda-cccl_13.2.75-1.bb
+++ b/recipes-devtools/cuda/cuda-cccl_13.2.75-1.bb
@@ -5,6 +5,7 @@ CUDA_INSTALL_ARCH:class-native = "${HOST_ARCH}"
 require cuda-shared-binaries.inc
 
 SRC_URI:append = " file://0001-Avoid-compile-issues-with-libc-math-functions.patch"
+SRC_URI:append = " file://0001-Fix-invalid-C-syntax-in-proclaims_copyable_arguments.patch"
 
 MAINSUM = "949fde97f8b10c7ee0306c02cf7bfbeed2faef8acfccc10ad54af69bb90cb181"
 MAINSUM:x86-64 = "0c8259dc86abaffcb588b7f98a662d7b5c9064d16049ee591c1f07949640444d"


### PR DESCRIPTION
When compiling onnxruntime with the wip-l4t-r39.2.0 branch, I got two different compilation errors regarding cuda. Both patches were drafted with AI assistance, reviewed and tested by me.

The cuda-cccl patch, I can easily also add in my own meta layer as a bbappend, so if you'd rather not take that one, feel free to drop it. As far as I understand, the cuda.bbclass change is not as easy to fix downstream.

**1) Error message due to dangling -Xcompiler (cuda.bbclass)**

```
aarch64-poky-linux-g++: error: unrecognized command-line option '-Xcompiler'
```

The problem seems to be that the OE-core distro defaults inject `-Werror=format-security`, which is then forwarded by cuda.bbclass as `-Xcompiler -Werror=format-security`. When cmake probes the CUDA compiler it strips `-Werror` parameters, leaving `-Xcompiler` without an argument, which then fails.

Apparently `-Xcompiler` with a space and with `=` are treated the same, so adding the `=` prevents the parameter from being stripped and builds cleanly.

**2) namespace-scope problems (cuda-cccl)**

```
| .../work/aarch64_tegra234-poky-linux/onnxruntime/1.26.0/recipe-sysroot/usr/local/cuda-13.2/include/cccl/cub/device/device_transform.cuh:44:111: error: global qualification of class name is invalid before ':' token
|    44 | struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
|       |                                                                                                               ^
| .../work/aarch64_tegra234-poky-linux/onnxruntime/1.26.0/recipe-sysroot/usr/local/cuda-13.2/include/cccl/cub/device/device_transform.cuh:44:111: error: expected '{' before ':' token
```

The problem seems to be that cub/device/device_transform.cuh and dispatch/tuning/tuning_transform.cuh declare two
cuda::proclaims_copyable_arguments specializations with a leading global qualifier (struct ::cuda::...<...> : base), which gcc does not accept here.

Re-declaring them inside namespace cuda { ... } builds cleanly. As far as I can tell it is behaviour-preserving: same
specialization of the same template for the same types, just declared from namespace cuda instead of with a leading global qualifier.