### PR TITLE
Updates for JetPack 7.2 / L4T R39.2.0

### DIFF
--- a/conf/machine/include/tegra234.inc
+++ b/conf/machine/include/tegra234.inc
@@ -57,4 +57,4 @@ TEGRA_BOOT_FIRMWARE_FILES = "\
 
 TEGRA_EDK2_PLATFORM = "t23x"
 IMAGE_TEGRAFLASH_FS_TYPE = "ext4"
-MACHINE_EXTRA_RDEPENDS += "nvidia-kernel-oot-compute"
+MACHINE_EXTRA_RDEPENDS += "nvidia-kernel-oot-compute-nvgpu"

--- a/conf/machine/include/tegra264.inc
+++ b/conf/machine/include/tegra264.inc
@@ -75,4 +75,4 @@ PREFERRED_PROVIDER_hafnium ?= "hafnium"
 PREFERRED_VERSION_hafnium ?= "2.11-l4t%"
 
 TEGRA_EDK2_PLATFORM = "t26x"
-MACHINE_EXTRA_RDEPENDS += "nv-kernel-module-nvpmodel-clk-cap"
+MACHINE_EXTRA_RDEPENDS += "nvidia-kernel-oot-compute nv-kernel-module-nvpmodel-clk-cap"

--- a/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/gstreamer1.0-plugins-tegra-binaryonly_39.2.0.bb
@@ -45,6 +45,7 @@ do_install() {
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvunixfd*
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvvidconv*
     rm -f ${D}${libdir}/gstreamer-1.0/libgstnvcompositor*
+    rm -f ${D}${libdir}/gstreamer-1.0/libgstnvsiplsrc*
 }
 
 FILES_SOLIBSDEV = ""

--- a/recipes-devtools/nsight-systems/nsight-systems_2026.3.1.157-263138048394v0.bb
+++ b/recipes-devtools/nsight-systems/nsight-systems_2026.3.1.157-263138048394v0.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://opt/nvidia/nsight-systems/${BASE_VERSION}/EULA.txt;md
 inherit l4t_deb_pkgfeed
 
 SRC_COMMON_DEBS = "nsight-systems-${BASE_VERSION}_${PV}_arm64.deb;subdir=${BPN}"
-SRC_URI[sha256sum] = "0e4bc67a481a376c4a7315ee1344f055b15efe34d5950b600fddca5e294317ab"
+SRC_URI[sha256sum] = "72640c2c40c2f7f45aa79b06de4c51615ba008b8c4f32fb9807dae7d8f7ab2fb"
 
 S = "${UNPACKDIR}/${BPN}"
 B = "${S}"
@@ -26,7 +26,7 @@ do_compile() {
 
 do_install() {
     install -d ${D}/opt/nvidia/nsight-systems/${BASE_VERSION}/
-    cp -R --preserve=mode,timestamps,links --no-dereference ${B}/opt/nvidia/nsight-systems/${BASE_VERSION}/target-linux-sbsa-armv8// ${D}/opt/nvidia/nsight-systems/${BASE_VERSION}/
+    cp -R --preserve=mode,timestamps,links --no-dereference ${B}/opt/nvidia/nsight-systems/${BASE_VERSION}/target-linux-sbsa-armv8/ ${D}/opt/nvidia/nsight-systems/${BASE_VERSION}/
     cp -R --preserve=mode,timestamps,links --no-dereference ${B}/opt/nvidia/nsight-systems/${BASE_VERSION}/host-linux-armv8/ ${D}/opt/nvidia/nsight-systems/${BASE_VERSION}/
     cp -R --preserve=mode,timestamps,links --no-dereference ${B}/opt/nvidia/nsight-systems/${BASE_VERSION}/bin/ ${D}/opt/nvidia/nsight-systems/${BASE_VERSION}/
 }
@@ -36,7 +36,11 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_SYSROOT_STRIP = "1"
 EXCLUDE_FROM_SHLIBS = "1"
 
+PACKAGES =+ "${PN}-collectx"
 PACKAGES += "${PN}-qdstrmimporter"
+FILES:${PN}-collectx = " \
+    /opt/nvidia/nsight-systems/${BASE_VERSION}/target-linux-sbsa-armv8/CollectX \
+"
 FILES:${PN} = " \
     /opt/nvidia/nsight-systems/${BASE_VERSION}/target-linux-sbsa-armv8 \
 "
@@ -44,6 +48,11 @@ FILES:${PN}-qdstrmimporter = " \
     /opt/nvidia/nsight-systems/${BASE_VERSION}/host-linux-armv8 \
     /opt/nvidia/nsight-systems/${BASE_VERSION}/bin \
 "
+PACKAGECONFIG ??= ""
+PACKAGECONFIG[rdma] = ",,rdma-core,rdma-core"
+
+RDEPENDS:${PN}-collectx = "${@bb.utils.contains('PACKAGECONFIG', 'rdma', 'rdma-core', '', d)}"
 INSANE_SKIP:${PN} = "ldflags file-rdeps dev-so"
+INSANE_SKIP:${PN}-collectx = "ldflags file-rdeps dev-so"
 INSANE_SKIP:${PN}-qdstrmimporter = "ldflags file-rdeps dev-so"
 PACKAGE_ARCH = "${TEGRA_PKGARCH}"

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -111,8 +111,8 @@ do_install() {
 SYSROOT_DIRS += "/boot/devicetree"
 SYSROOT_DIRS += "/usr/src/device-tree"
 
-PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}-wifi ${PN}-canbus ${PN}-virtualization ${PN}-alsa ${PN}-test ${PN}-base ${PN}-extra"
-PACKAGES:append:tegra234 = " ${PN}-compute"
+PACKAGES =+ "${PN}-devicetrees ${PN}-display ${PN}-cameras ${PN}-bluetooth ${PN}-wifi ${PN}-canbus ${PN}-virtualization ${PN}-alsa ${PN}-test ${PN}-base ${PN}-extra ${PN}-compute"
+PACKAGES:append:tegra234 = " ${PN}-compute-nvgpu"
 
 PROVIDES += "kernel-module-${BPN}"
 FILES:${PN}-devicetrees = "/boot/devicetree"
@@ -132,6 +132,7 @@ ALLOW_EMPTY:${PN}-test = "1"
 ALLOW_EMPTY:${PN}-base = "1"
 ALLOW_EMPTY:${PN}-extra = "1"
 ALLOW_EMPTY:${PN}-compute = "1"
+ALLOW_EMPTY:${PN}-compute-nvgpu = "1"
 
 RDEPENDS:${PN}-display = "${TEGRA_OOT_DISPLAY_DRIVERS}"
 RDEPENDS:${PN}-cameras = "${TEGRA_OOT_CAMERA_DRIVERS}"
@@ -143,6 +144,7 @@ RDEPENDS:${PN}-alsa = "${TEGRA_OOT_ALSA_DRIVERS}"
 RDEPENDS:${PN}-test = "${TEGRA_OOT_TEST_DRIVERS}"
 RDEPENDS:${PN}-base = "${TEGRA_OOT_BASE_DRIVERS}"
 RDEPENDS:${PN}-compute = "${TEGRA_OOT_COMPUTE_DRIVERS}"
+RDEPENDS:${PN}-compute-nvgpu = "${TEGRA_OOT_NVGPU_COMPUTE_DRIVERS}"
 RRECOMMENDS:${PN}-extra = "${TEGRA_OOT_EXTRA_DRIVERS}"
 
 TEGRA_OOT_ALL_DRIVER_PACKAGES = ""
@@ -153,7 +155,6 @@ TEGRA_OOT_DISPLAY_DRIVERS ?= "\
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-nvidia-modeset \
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-tegra-dce \
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-tegra-drm \
-    ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-nvidia-uvm \
     ${TEGRA_OOT_EXTRA_DISPLAY_DRIVERS} \
 "
 TEGRA_OOT_ALL_DRIVER_PACKAGES += "${TEGRA_OOT_DISPLAY_DRIVERS}"
@@ -227,7 +228,7 @@ TEGRA_OOT_CANBUS_DRIVERS ?= "\
     ${TEGRA_OOT_EXTRA_CANBUS_DRIVERS} \
 "
 TEGRA_OOT_ALL_DRIVER_PACKAGES += "${TEGRA_OOT_CANBUS_DRIVERS}"
-TEGRA_OOT_EXTRA_VIRUTALIZATION_DRIVERS ??= ""
+TEGRA_OOT_EXTRA_VIRTUALIZATION_DRIVERS ??= ""
 TEGRA_OOT_VIRTUALIZATION_DRIVERS ?= "\
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-hvc-sysfs \
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-nv-virtio-console-poc \
@@ -243,7 +244,7 @@ TEGRA_OOT_VIRTUALIZATION_DRIVERS ?= "\
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-tegra-vblk \
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-tegra-vnet \
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-userspace-ivc-mempool \
-    ${TEGRA_OOT_EXTRA_VIRUTALIZATION_DRIVERS} \
+    ${TEGRA_OOT_EXTRA_VIRTUALIZATION_DRIVERS} \
 "
 TEGRA_OOT_ALL_DRIVER_PACKAGES += "${TEGRA_OOT_VIRTUALIZATION_DRIVERS}"
 TEGRA_OOT_EXTRA_ALSA_DRIVERS ??= ""
@@ -316,9 +317,15 @@ TEGRA_OOT_BASE_DRIVERS ?= "\
 "
 TEGRA_OOT_ALL_DRIVER_PACKAGES += "${TEGRA_OOT_BASE_DRIVERS}"
 TEGRA_OOT_COMPUTE_DRIVERS = "\
+    ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-nvidia-uvm \
+"
+TEGRA_OOT_NVGPU_COMPUTE_DRIVERS = "\
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-nvgpu \
 "
-TEGRA_OOT_ALL_DRIVER_PACKAGES += "${TEGRA_OOT_COMPUTE_DRIVERS}"
+TEGRA_OOT_ALL_DRIVER_PACKAGES += "\
+    ${TEGRA_OOT_COMPUTE_DRIVERS} \
+    ${TEGRA_OOT_NVGPU_COMPUTE_DRIVERS} \
+"
 TEGRA_OOT_EXTRA_OTHER_DRIVERS ??= ""
 TEGRA_OOT_OTHER_DRIVERS ?= "\
     ${KERNEL_MODULE_PACKAGE_PREFIX}kernel-module-f75308 \

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot_git.bb
@@ -3,6 +3,7 @@ SRC_REPO_NV_ETHERNETRM = "gitlab.com/nvidia/nv-tegra/kernel/nvethernetrm.git;pro
 SRC_REPO_UNIFIED_GPU_DISP = "gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-unified-gpu-display-driver.git;protocol=https"
 SRC_REPO_NV_KERNEL_DISPLAY = "gitlab.com/nvidia/nv-tegra/tegra/kernel-src/nv-kernel-display-driver.git;protocol=https"
 SRC_REPO_HWPM = "gitlab.com/nvidia/nv-tegra/linux-hwpm.git;protocol=https"
+SRC_REPO_NVGPU = "gitlab.com/nvidia/nv-tegra/tegra/kernel-src/linux-nvgpu.git;protocol=https"
 SRC_REPO_T264_DTS = "gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t264-public-dts.git;protocol=https"
 SRC_REPO_T23X_DTS = "gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/t23x-public-dts.git;protocol=https"
 SRC_REPO_TEGRA_DTS = "gitlab.com/nvidia/nv-tegra/device/hardware/nvidia/tegra-public-dts.git;protocol=https"
@@ -13,6 +14,7 @@ SRC_URI = " \
     git://${SRC_REPO_UNIFIED_GPU_DISP};branch=${SRCBRANCH};name=unifiedgpudisp;destsuffix=${BPN}-${PV}/unifiedgpudisp \
     git://${SRC_REPO_NV_KERNEL_DISPLAY};branch=${SRCBRANCH};name=nvdisplay;destsuffix=${BPN}-${PV}/nvdisplay \
     git://${SRC_REPO_HWPM};branch=${SRCBRANCH};name=hwpm;destsuffix=${BPN}-${PV}/hwpm \
+    git://${SRC_REPO_NVGPU};branch=${SRCBRANCH};name=nvgpu;destsuffix=${BPN}-${PV}/nvgpu \
     git://${SRC_REPO_T264_DTS};branch=${SRCBRANCH};name=t264-dts;destsuffix=${BPN}-${PV}/hardware/nvidia/t264/nv-public \
     git://${SRC_REPO_T23X_DTS};branch=${SRCBRANCH};name=t23x-dts;destsuffix=${BPN}-${PV}/hardware/nvidia/t23x/nv-public \
     git://${SRC_REPO_TEGRA_DTS};branch=${SRCBRANCH};name=tegra-dts;destsuffix=${BPN}-${PV}/hardware/nvidia/tegra/nv-public \
@@ -25,11 +27,12 @@ SRCREV_nvethernetrm = "cf2ae53fdf4ee85333f3b3907d1337d6546db64f"
 SRCREV_unifiedgpudisp = "a662a636f19939ce9d11ac25a873fab8b2dedb36"
 SRCREV_nvdisplay = "c66bad7cc07f605a59a46cf7e6585433c88ad161"
 SRCREV_hwpm = "80b966b1bdc20f896cc9625a84708cbbe4638e38"
+SRCREV_nvgpu = "fb2c5dedeb1843eab91e8fd7e976fdc277d58aa3"
 SRCREV_t264-dts = "664a726551f62958a5a57b6538be01b9a62cd178"
 SRCREV_t23x-dts = "3897df11a86397704db8685071de46559cfb3c6e"
 SRCREV_tegra-dts = "d76c3a7751ea75592413b42c984eac7084a99592"
 
-SRCREV_FORMAT = "nvidia-oot_nvethernetrm_unifiedgpudisp_nvdisplay_hwpm_t264-dts_t23x-dts_tegra-dts_kernel-devicetree"
+SRCREV_FORMAT = "nvidia-oot_nvethernetrm_unifiedgpudisp_nvdisplay_hwpm_nvgpu_t264-dts_t23x-dts_tegra-dts_kernel-devicetree"
 
 inherit l4t_bsp
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc/0001-Build-fixups.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc/0001-Build-fixups.patch
@@ -1,0 +1,177 @@
+From 31355469f74d02a155a48161aadadea047131e9d Mon Sep 17 00:00:00 2001
+From: Ilies CHERGUI <ichergui@nvidia.com>
+Date: Wed, 18 Feb 2026 12:29:15 -0800
+Subject: [PATCH] Build fixups
+
+Upstream-Status: Inappropriate [OE-specific]
+Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
+---
+ Makefile | 84 ++++++++++++--------------------------------------------
+ 1 file changed, 18 insertions(+), 66 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 5fb433e..047a71a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -35,10 +35,11 @@
+ SO_NAME := libgstnvsiplsrc.so
+ 
+ CC := g++
++exec_prefix ?= /usr
++libdir ?= $(exec_prefix)/lib
++includedir ?= $(exec_prefix)/include
+ 
+-# Installation directories
+-GST_INSTALL_DIR ?= /usr/lib/aarch64-linux-gnu/gstreamer-1.0/
+-LIB_INSTALL_DIR ?= /usr/lib/aarch64-linux-gnu/tegra/
++GST_INSTALL_DIR ?= $(libdir)/gstreamer-1.0
+ 
+ # Source files for the SIPL GStreamer plugin
+ SRCS := \
+@@ -50,30 +51,6 @@ SRCS := \
+ 
+ OBJS := $(SRCS:.cpp=.o)
+ 
+-# SIPL installation path detection
+-# NOTE: jetson_sipl_api.tbz2 installation is a prerequisite for compiling this plugin.
+-# The jetson_sipl_api.tbz2 package should be extracted to provide the SIPL headers and libraries.
+-# SIPL_ROOT can be overridden via command line: make SIPL_ROOT=/path/to/sipl
+-ifeq ($(SIPL_ROOT),)
+-    SIPL_ROOT := $(shell if [ -d "/usr/src/jetson_sipl_api" ]; then echo "/usr/src/jetson_sipl_api"; else find /usr -name "jetson_sipl_api" -type d 2>/dev/null | head -1; fi)
+-    ifeq ($(SIPL_ROOT),)
+-        SIPL_ROOT := /usr/src/jetson_sipl_api/
+-    endif
+-endif
+-
+-# Include paths
+-INCLUDES += -I./
+-INCLUDES += -I../
+-
+-# SIPL-specific include paths
+-INCLUDES += \
+-	-I"$(SIPL_ROOT)/sipl/include" \
+-	-I"$(SIPL_ROOT)/sipl/include/query/include" \
+-	-I"$(SIPL_ROOT)/sipl/include/nvsci"
+-
+-# Jetson Multimedia API includes
+-INCLUDES += -I/usr/src/jetson_multimedia_api/include/
+-
+ # GStreamer and system includes
+ PKGS := gstreamer-1.0 \
+ 	gstreamer-base-1.0 \
+@@ -82,26 +59,26 @@ PKGS := gstreamer-1.0 \
+ 	glib-2.0
+ 
+ # Compilation flags
+-CFLAGS := -fPIC
++CXXFLAGS := -fPIC
+ 
+ # Use C++17 with exceptions and RTTI (required for SIPL)
+-CFLAGS += -std=c++17 -fexceptions -frtti
++CXXFLAGS += -std=c++17 -fexceptions -frtti
+ 
+ # Add GStreamer flags
+-CFLAGS += `pkg-config --cflags $(PKGS)`
++CXXFLAGS += `pkg-config --cflags $(PKGS)`
+ 
+ # Warning flags
+-CFLAGS += -Wall -Wextra
++CXXFLAGS += -Wall -Wextra
+ 
+ # Optimization and debug flags
+ ifdef DEBUG
+-    CFLAGS += -g -O0 -DDEBUG
++    CXXFLAGS += -g -O0 -DDEBUG
+ else
+-    CFLAGS += -O2 -DNDEBUG
++    CXXFLAGS += -O2 -DNDEBUG
+ endif
+ 
+ # Linker flags
+-LDFLAGS = -Wl,--no-undefined -L$(LIB_INSTALL_DIR) -Wl,-rpath,$(LIB_INSTALL_DIR)
++LDFLAGS += -Wl,--no-undefined
+ 
+ # SIPL and NvSci libraries
+ LIBS := \
+@@ -114,9 +91,6 @@ LIBS := \
+ 	-lnvbufsurftransform \
+ 	-lpthread
+ 
+-# Add library path for SIPL UDDF libraries
+-LDFLAGS += -L/usr/lib/nvsipl_uddf
+-
+ # GStreamer libraries
+ LIBS += `pkg-config --libs $(PKGS)`
+ 
+@@ -130,57 +104,35 @@ config:
+ 	@echo "SO_NAME: $(SO_NAME)"
+ 	@echo "GST_INSTALL_DIR: $(GST_INSTALL_DIR)"
+ 	@echo "LIB_INSTALL_DIR: $(LIB_INSTALL_DIR)"
+-	@echo "CC: $(CC)"
++	@echo "CXX: $(CXX)"
+ 	@echo "SRCS: $(SRCS)"
+ 	@echo "CFLAGS: $(CFLAGS)"
+ 	@echo "LDFLAGS: $(LDFLAGS)"
+ 	@echo "LIBS: $(LIBS)"
+ 	@echo "==============================================="
+ 
+-# Check if SIPL is installed
+-check-sipl:
+-	@echo "Checking SIPL installation..."
+-	@if [ ! -d "$(SIPL_ROOT)" ]; then \
+-		echo "ERROR: SIPL not found at $(SIPL_ROOT)"; \
+-		echo "Please install jetson_sipl_api.tbz2 or set SIPL_ROOT=/path/to/sipl"; \
+-		exit 1; \
+-	fi
+-	@if [ ! -f "$(SIPL_ROOT)/sipl/include/NvSIPLCamera.hpp" ]; then \
+-		echo "ERROR: SIPL headers not found in $(SIPL_ROOT)"; \
+-		echo "Please check SIPL installation"; \
+-		exit 1; \
+-	fi
+-	@echo "SIPL found at: $(SIPL_ROOT)"
+-
+ # Compilation rule for object files
+ %.o: %.cpp
+ 	@echo "Compiling: $<"
+-	$(CC) -c $< $(CFLAGS) $(INCLUDES) -o $@
++	$(CXX) $(CXXFLAGS) -c $< -o $@
+ 
+ # Link the shared library
+-$(SO_NAME): check-sipl $(OBJS)
++$(SO_NAME): $(OBJS)
+ 	@echo "Linking: $@"
+-	$(CC) -shared -o $(SO_NAME) $(OBJS) $(LIBS) $(LDFLAGS)
++	$(CXX) -shared -o $(SO_NAME) $(OBJS) $(LIBS) $(LDFLAGS)
+ 	@echo "Successfully built: $(SO_NAME)"
+ 
+ # Install the plugin
+ .PHONY: install
+ install: $(SO_NAME)
+ 	@echo "Installing $(SO_NAME) to $(GST_INSTALL_DIR)"
+-	sudo mkdir -p $(GST_INSTALL_DIR)
+-	sudo cp -vp $(SO_NAME) $(GST_INSTALL_DIR)
++	install -d $(DESTDIR)$(GST_INSTALL_DIR)
++	install -m 0644 $(SO_NAME) $(DESTDIR)$(GST_INSTALL_DIR)/
+ 	@echo "Installation complete. Plugin installed at: $(GST_INSTALL_DIR)$(SO_NAME)"
+ 	@echo ""
+ 	@echo "To verify installation, run:"
+ 	@echo "  gst-inspect-1.0 nvsiplsrc"
+ 
+-# Uninstall the plugin
+-.PHONY: uninstall
+-uninstall:
+-	@echo "Uninstalling $(SO_NAME) from $(GST_INSTALL_DIR)"
+-	sudo rm -f $(GST_INSTALL_DIR)$(SO_NAME)
+-	@echo "Uninstallation complete."
+-
+ # Clean build artifacts
+ .PHONY: clean
+ clean:
+@@ -232,4 +184,4 @@ help:
+ 	@echo "  make debug install         - Build debug version and install"
+ 	@echo "  make clean rebuild         - Clean rebuild"
+ 
+-.PHONY: all config check-sipl install uninstall clean rebuild debug test help
++.PHONY: all config install uninstall clean rebuild debug test help
+-- 
+2.43.0

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc_1.0.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc_1.0.0-r39.2.0.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "NVIDIA nvsiplcamera GStreamer plugin"
+SECTION = "multimedia"
+LICENSE = "BSD-3-Clause & Proprietary"
+LIC_FILES_CHKSUM = "file://gstnvsipl.h;endline=29;md5=a94fb30f9bc256e10bfed0615bba9756 \
+                    file://README.txt;endline=32;md5=06e37147d5873f2584371719d9887f89 \
+"
+
+TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/gst-nvsiplcamera_src.tbz2"
+TEGRA_SRC_SUBARCHIVE_OPTS = "--exclude=3rdpartyheaders.tbz2"
+
+require recipes-bsp/tegra-sources/tegra-sources-39.2.0.inc
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+SRC_URI += "\
+    file://0001-Build-fixups.patch \
+"
+
+DEPENDS = "gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base virtual/egl tegra-libraries-camera tegra-libraries-multimedia-ds tegra-libraries-multimedia-utils tegra-mmapi jetson-sipl-api"
+
+S = "${UNPACKDIR}/gst-nvsiplcamera"
+
+inherit pkgconfig features_check
+
+REQUIRED_DISTRO_FEATURES = "opengl"
+
+do_install() {
+	oe_runmake install DESTDIR="${D}"
+}
+FILES:${PN} = "${libdir}/gstreamer-1.0"


### PR DESCRIPTION
- Fix nvidia-uvm package. 
  - nvidia-uvm is required for `CUDA` compute
- Restore NVGPU repo in the `nvidia-kernel-oot` recipe
- Fix typo in `nvidia-kernel-oot` recipe
- Add SIPL GST plugin recipe
- Update nsight-systems to `2026.3.1.157-263138048394v0`