### PR TITLE
tegra-uefi-prebuilt: fix build issue

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-uefi-prebuilt_39.2.0.bb
@@ -42,8 +42,7 @@ do_install() {
 
 do_deploy() {
     install -d ${DEPLOYDIR}
-    install -m 0644 ${B}/uefi_jetson.bin ${DEPLOYDIR}/${TEGRA_FLASHVAR_UEFI_IMAGE}.bin
-    install -m 0644 ${B}/uefi_jetson_minimal.bin ${DEPLOYDIR}/${TEGRA_FLASHVAR_RCM_UEFI_IMAGE}.bin
+    install -m 0644 ${B}/uefi*.bin ${DEPLOYDIR}/
     for dtbo in ${TEGRA_BOOTCONTROL_OVERLAYS}; do
 	[ -e ${S}/kernel/dtb/$dtbo ] || continue
 	install -m 0644 ${S}/kernel/dtb/$dtbo ${DEPLOYDIR}/


### PR DESCRIPTION
Mismatch in compile and deploy tasks about filenames. With this commit all files staged to build directory is also deployed.