### PR TITLE
nvidia-kernel-oot-dtb: fix build for tegra264

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_39.2.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_39.2.0.bb
@@ -26,7 +26,7 @@ DT_FILES_PATH:tegra264 = "${DT_NV_BASE}/t264/nv-public/nv-platform"
 # Prepend the NVIDIA extended kernel headers to DTC_PPFLAGS so those flags
 # are emitted before DT_INCLUDE paths.
 DTC_PPFLAGS:prepend:tegra234 = "-I${DT_NV_BASE}/tegra/nv-public/include/kernel "
-DTC_PPFLAGS:prepend:tegra264 = "-I${DT_NV_BASE}/tegra/nv-public/include/kernel "
+DTC_PPFLAGS:prepend:tegra264 = "-I${DT_NV_BASE}/t264/nv-public/include/kernel-t264 -I${DT_NV_BASE}/tegra/nv-public/include/kernel "
 
 DT_INCLUDE:tegra234 = " \
     ${DT_NV_BASE}/t23x/nv-public/nv-platform \
@@ -39,8 +39,7 @@ DT_INCLUDE:tegra234 = " \
 DT_INCLUDE:tegra264 = " \
     ${DT_NV_BASE}/t264/nv-public/nv-platform \
     ${DT_NV_BASE}/t264/nv-public \
-    ${DT_NV_BASE}/t264/nv-public/include/nvidia-oot \
-    ${DT_NV_BASE}/t264/nv-public/include/platforms \
+    ${DT_NV_BASE}/tegra/nv-public/include/nvidia-oot \
     ${DT_NV_BASE}/tegra/nv-public \
     ${KERNEL_INCLUDE} \
 "


### PR DESCRIPTION
The recipe updates to use devicetree.bbclass missed required includes for tegra264, <dt-bindings/clock/tegra264-clock.h> and <dt-bindings/mailbox/tegra186-hsp-oot.h>.

This change adds the missing include paths as required.