### PR TITLE
39.2.0: tensorrt-core: split per-architecture resources into separate packages

### DIFF
--- a/recipes-devtools/gie/tensorrt-core_10.16.2.10-1.bb
+++ b/recipes-devtools/gie/tensorrt-core_10.16.2.10-1.bb
@@ -85,4 +85,26 @@ FILES:${PN}-lean = "${libdir}/libnvinfer_lean${SOLIBS}"
 FILES:${PN}-lean-dev = "${libdir}/libnvinfer_lean${SOLIBSDEV}"
 RDEPENDS:${PN}-lean-dev = "${PN}-lean"
 RDEPENDS:${PN}-dev += "${PN}-dispatch-dev ${PN}-lean-dev"
-PACKAGE_ARCH = "${TEGRA_PKGARCH}"
+
+# NVIDIA's 10.16 deb bundles one builder resource per GPU arch (sm75..sm120 +
+# PTX, ~2GB). Split each into its own package and pull in only the target SoC's
+# arch via RDEPENDS, instead of installing all of them.
+PACKAGES_DYNAMIC += "^${PN}-builder-resource-.*"
+
+python split_builder_resources() {
+    do_split_packages(d, d.expand('${libdir}'),
+                      r'^libnvinfer_builder_resource_(.*)\.so\..*$',
+                      d.expand('${PN}-builder-resource-%s'),
+                      'TensorRT builder resource for %s',
+                      allow_dirs=False, prepend=True)
+}
+PACKAGESPLITFUNCS =+ "split_builder_resources"
+
+# The resource the builder loads is not simply sm<compute-capability>: the SBSA
+# deb ships no sm_87, and on orin, tensorrt apparently loads sm_86.
+# Select per SoC.
+TENSORRT_BUILDER_RESOURCE_ARCH ?= "${TEGRA_CUDA_ARCHITECTURE}"
+TENSORRT_BUILDER_RESOURCE_ARCH:tegra234 = "86"
+RDEPENDS:${PN} += "${PN}-builder-resource-sm${TENSORRT_BUILDER_RESOURCE_ARCH}"
+
+PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"


### PR DESCRIPTION
The tensorrt-core 10.16 deb ships the builder resource as one shared library per GPU architecture (sm75..sm120 plus a PTX variant) and bundles all of them (~2GB total). The recipe installed all variants unconditionally via a wildcard glob, so every image carried ~2GB of builder kernels for GPU architectures it does not use.

Split each variant into its own package and pull in only the one the target SoC's builder loads, via RDEPENDS.

Additionally, the SBSA deb ships no sm_87, and on Orin the builder appears to load sm_86 (observed with trtexec on hardware). Therefore, the resource is selected per SoC via TENSORRT_BUILDER_RESOURCE_ARCH (defaulting to the SoC's compute capability) to keep the mapping easy to revisit.

Output from testing with `trtexec` on Orin NX before installing the sm_86 resources

```
[06/10/2026-10:46:01] [E] [TRT] createInferBuilder: Error Code 6: API Usage Error (Unable to load library: libnvinfer_builder_resource_sm86.so.10.16.2: libnvinfer_builder_resource_sm86.so.10.16.2: cannot open shared object file: No such file or directory In Impl at /_src/runtime/dispatch/libLoader.cpp:305)
[06/10/2026-10:46:01] [E] Builder creation failed
[06/10/2026-10:46:01] [E] Failed to create engine from model or file.
[06/10/2026-10:46:01] [E] Engine set up failed
```

With installed sm_86 model it succeeds. I don't have a Thor for testing, but there it should default to the available sm_110 resources.

Closes https://github.com/OE4T/meta-tegra/issues/2240

From the initial draft in the issue, I excluded the ptx resources, and changed from RRECOMMENDS to RDEPENDS. The meta layer supports TEGRA_CUDA_ARCHITECTURE 87 via tegra234 and 110 via tegra264, so both cases should be addressed, the tegra234 specifically and the tegra264 generally.

CC @ichergui 