### PR TITLE
39.2.0: gstreamer1.0-plugins-nvvideo4linux2: add runtime dep on nvdsseimeta

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r39.2.0.bb
@@ -44,3 +44,5 @@ do_install() {
 }
 FILES:${PN} = "${libdir}/gstreamer-1.0"
 RDEPENDS:${PN} += "libgstnvcustomhelper"
+# dlopen'd by the encoders at runtime, not seen by shlib dependency tracking
+RDEPENDS:${PN} += "tegra-libraries-nvdsseimeta"


### PR DESCRIPTION
Since L4T r39, NVIDIA's gst-v4l2 Makefile no longer links the plugin against libgstnvdsseimeta.so (-lgstnvdsseimeta was replaced with -ldl; gst_video_sei_meta_api_get_type is now resolved at runtime). With no NEEDED entry, OE's automatic shared-library dependency tracking no longer pulls tegra-libraries-nvdsseimeta into the image, so the library is missing from the rootfs. The SEI meta GType lookup in nvv4l2h264enc/nvv4l2h265enc then yields 0 and GStreamer emits a CRITICAL for every input buffer:

  GStreamer-CRITICAL **: gst_buffer_get_meta: assertion 'api != 0' failed

Reproduce on target (one CRITICAL per encoded frame):

  gst-launch-1.0 -q videotestsrc num-buffers=10 \
    ! 'video/x-raw,format=I420,width=320,height=240,framerate=30/1' \
    ! nvvidconv ! 'video/x-raw(memory:NVMM),format=NV12' \
    ! nvv4l2h264enc ! fakesink

Add an explicit RDEPENDS on tegra-libraries-nvdsseimeta so the library is shipped again, restoring the implicit dependency that existed up through r36 where the plugin was linked against it directly.