### PR TITLE
Updates to oe4t docs for r39

### DIFF
--- a/docs/Creating-a-custom-MACHINE.md
+++ b/docs/Creating-a-custom-MACHINE.md
@@ -103,6 +103,83 @@ Include this new file in Yocto the same way as explained in [Add pinmux dtsi fil
 ## Use a custom device tree
 See [Custom Device Tree](#custom-device-tree) and apply the described changes to your `${machine}.conf`.
 
+# Jetson AGX Thor
+
+Thor (Tegra264) custom machine definitions follow a similar pattern to Orin (Tegra234). Replace
+occurrences of `${machine}` below with your machine name.
+
+## Create a new machine config
+
+Create `conf/machine/${machine}.conf` in your layer. Use one of the existing Thor machine
+configurations in `meta-tegra` (e.g., `jetson-agx-thor-t4000.conf`) as a starting point. Your
+config should `require` the appropriate `agx-thor-*.inc` or `tegra264.inc` include.
+
+Key Thor-specific variables to be aware of:
+
+* **`PARTITION_LAYOUT_RCMBOOT` / `PARTITION_LAYOUT_RCMBOOT_DEFAULT`** — partition layout XML used
+  for the RCMBoot flashing stage. Thor uses a separate UEFI image for this stage. The default is
+  `flash_l4t_t264_rcmboot.xml`.
+
+* **`TEGRA_RCM_EDK2_CONFIGURATION`** — controls which EDK2 firmware build is used for RCMBoot.
+  Defaults to `"minimal"`. If you set this to the same value as `TEGRA_EDK2_CONFIGURATION`, the
+  main UEFI build is reused and no separate RCMBoot UEFI build is required.
+
+* **`EMC_BCTS`** — a comma-separated list of EMC BCT files for the flash process. This extends
+  `EMC_BCT` to support multiple entries when needed for different memory configurations.
+
+## RCMBoot UEFI
+
+Unlike Orin, Thor requires a UEFI firmware image specifically for the RCMBoot stage. The
+`edk2-firmware-tegra-rcmboot` recipe builds this from EDK2 sources. If you cannot or do not wish
+to build from source, the `edk2-firmware-tegra-rcmboot-prebuilt` recipe provides a prebuilt
+binary. To use the prebuilt binary, add the following to your machine configuration or
+`local.conf`:
+
+```
+PREFERRED_PROVIDER_edk2-firmware-tegra-rcmboot = "edk2-firmware-tegra-rcmboot-prebuilt"
+```
+
+See `bootloader/uefi_bins/README_uefi.txt` in the L4T BSP kit for information on the UEFI
+sources.
+
+## Add pinmux and BCT files
+
+Unlike Orin, which uses `.dtsi` kernel device tree fragments for pinmux configuration, Thor uses
+MB1 BCT DTS files (`.dts`) for all boot-time hardware configuration. These are generated from the
+NVIDIA pinmux spreadsheet for Thor and have a `tegra264-mb1-bct-` naming convention in the
+reference BSP.
+
+In your machine configuration, set the relevant `TEGRA_FLASHVAR_*` variables to the filenames of
+your custom BCT DTS files. The two most commonly customized are:
+
+```
+TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-${MACHINE}.dts"
+TEGRA_FLASHVAR_PMC_CONFIG    ?= "tegra264-mb1-bct-padvoltage-${MACHINE}.dts"
+```
+
+Then provide those files via a `tegra-bootfiles_39.2.0.bbappend` in your layer:
+
+```bitbake
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
+SRC_URI:append:${machine} = "\
+    file://tegra264-mb1-bct-pinmux-${MACHINE}.dts \
+    file://tegra264-mb1-bct-padvoltage-${MACHINE}.dts \
+"
+
+CUSTOM_BCT_DIR := "${THISDIR}/${BPN}"
+do_install:append:${machine}() {
+    install -m 0644 ${CUSTOM_BCT_DIR}/tegra264-mb1-bct-pinmux-${MACHINE}.dts ${D}${datadir}/tegraflash/
+    install -m 0644 ${CUSTOM_BCT_DIR}/tegra264-mb1-bct-padvoltage-${MACHINE}.dts ${D}${datadir}/tegraflash/
+}
+```
+
+Other `TEGRA_FLASHVAR_*` variables (e.g. `GPIOINT_CONFIG`, `MB2BCT_CFG`, `PMIC_CONFIG`) may also
+require custom files depending on your carrier board design. Consult the Platform Adaptation and
+Bring-Up Guide for Thor for the full list of configuration files and their purpose.
+
+## Use a custom device tree
+See [Custom Device Tree](#custom-device-tree) and apply the described changes to your `${machine}.conf`.
+
 # Customizing the kernel
 For custom hardware, you'll probably need to modify the kernel in at least one of the following ways:
 * Custom kernel configuration

--- a/docs/NVIDIA-Container-Runtime-support.md
+++ b/docs/NVIDIA-Container-Runtime-support.md
@@ -1,16 +1,35 @@
-Notes on integration of the Jetson-customized NVIDIA container runtime (beta version 0.9.0) with Docker support.
-See [this page](https://github.com/NVIDIA/nvidia-docker/wiki/NVIDIA-Container-Runtime-on-Jetson) for information on how this is integrated with the JetPack SDK.
+Notes on integrating the NVIDIA container runtime with Docker support on Jetson platforms.
 
 # Supported branches
-Support for the container runtime is available on the `zeus-l4t-r32.3.1` and later branches.
+
+Container runtime support is available on the `zeus-l4t-r32.3.1` and later branches.
 
 # Layers required
-In addition to the OE-Core and meta-tegra layers, you will need the  [meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/) layer and the `meta-oe`, `meta-networking`, and `meta-python` layers from the [meta-openembedded](https://git.openembedded.org/meta-openembedded/) repository.
+
+In addition to the OE-Core and meta-tegra layers, you will need the
+[meta-virtualization](https://git.yoctoproject.org/cgit/cgit.cgi/meta-virtualization/) layer and
+the `meta-oe`, `meta-networking`, and `meta-python` layers from the
+[meta-openembedded](https://git.openembedded.org/meta-openembedded/) repository.
 
 # Configuration
-Add `virtualization` to your DISTRO_FEATURES setting.
+
+Add `virtualization` to your `DISTRO_FEATURES` setting.
 
 # Building
-1. To run any containers, add `nvidia-docker` to your image.
-2. The [Docker containers that NVIDIA supplies](https://ngc.nvidia.com/catalog/containers?orderBy=modifiedDESC&pageNumber=0&query=jetson&quickFilter=containers&filters=) do not bundle in most of the hardware-specific libraries needed to run them, but expect them to be provided by the underlying host OS, so be sure to include TensorRT ([note](L4T-R32.3.1-Notes.md#tensorrt-packaging-change)), CuDNN, and/or VisionWorks, if you expect to be running containers needing those packages.
-3. For containers that use GStreamer, be sure to include the Jetson-specific GStreamer plugins you may need.
+
+1. Add `nvidia-container-toolkit` to your image to enable GPU-accelerated containers.
+
+   **Note:** The `nvidia-docker` recipe was removed in L4T R39.2.0/JetPack 7.2.
+   `nvidia-container-toolkit` is the current replacement and provides the same functionality.
+
+2. See the [NVIDIA Container Toolkit documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
+   for details on runtime configuration and usage.
+
+3. The [Docker containers that NVIDIA supplies](https://ngc.nvidia.com/catalog/containers?orderBy=modifiedDESC&pageNumber=0&query=jetson&quickFilter=containers&filters=)
+   do not bundle most hardware-specific libraries, but expect them to be provided by the host OS.
+   Be sure to include TensorRT, cuDNN, and/or other JetPack components in your image if you expect
+   to run containers that need them.
+
+4. For containers that use GStreamer, include the Jetson-specific GStreamer plugins you may need.
+   See [Tegra-specific GStreamer plugins](Tegra-specific-gstreamer-plugins.md) for the available
+   plugin recipes.

--- a/docs/Release-Notes.md
+++ b/docs/Release-Notes.md
@@ -5,7 +5,10 @@ NVIDIA L4T/meta-tegra.  If you are viewing this page in the
 mdbook please ensure you use the "master" branch version of
 documentation to ensure you are referencing the most recent source
 
-# Jetpack 7 / R38.x
+# JetPack 7.2 / R39.x
+- [JetPack-7.2-L4T-R39.2.0-Notes](release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md)
+
+# JetPack 7.0–7.1 / R38.x
 - [JetPack-7.1-L4T-R38.4.x-Notes](release-notes/JetPack-7.1-L4T-R38.4.x-Notes.md)
 - [JetPack-7.0-L4T-R38.2.x-Notes](release-notes/JetPack-7.0-L4T-R38.2.x-Notes.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -41,6 +41,7 @@
 
 # Release Notes
 - [Release Notes](Release-Notes.md)
+  - [JetPack-7.2-L4T-R39.2.0-Notes](release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md)
   - [JetPack-7.1-L4T-R38.4.x-Notes](release-notes/JetPack-7.1-L4T-R38.4.x-Notes.md)
   - [JetPack-7.0-L4T-R38.2.x-Notes](release-notes/JetPack-7.0-L4T-R38.2.x-Notes.md)
   - [JetPack-6.2.2-L4T-R36.5.0-Notes](release-notes/JetPack-6.2.2-L4T-R36.5.0-Notes.md)

--- a/docs/Secure-Boot-Support-in-L4T-R35.2.1-and-later.md
+++ b/docs/Secure-Boot-Support-in-L4T-R35.2.1-and-later.md
@@ -83,12 +83,53 @@ EXTRA_OEMAKE += "TA_SIGN_KEY=${WORKDIR}/optee-signing-key.pem"
 Post-build signing of TAs is more difficult, since external TAs are generally packaged and installed into the root filesystem as part of the build. For that approach, though, you would include the public key file in the `optee-os` bbappend, and set `TA_PUBLIC_KEY` instead of `TA_SIGN_KEY`.  The OP-TEE makefiles will sign TAs with the a dummy private key, but the public key you specify will be compiled into the secure OS.  You will have to figure out how to re-sign the TAs with your actual private key before they get used.
 
 # Using the NVIDIA built-in sample TAs
-To make use of the encryption/decryption functions NVIDIA provides by default with their OP-TEE implementation, you will need to supply an "Encrypted Keyblob" (EKB) that corresponds to the KEK/K2 fuses you have burned on your Jetson device.  Instructions for generating an EKB are in [this section](https://docs.nvidia.com/jetson/archives/r36.4.3/DeveloperGuide/SD/Security/OpTee.html#tool-for-ekb-generation) of the Jetson Linux documentation.  See the note at the top of this page for information about changes in L4T R35.5.0 that require the re-generation of the EKB.
+To make use of the encryption/decryption functions NVIDIA provides by default with their OP-TEE implementation, you will need to supply an "Encrypted Keyblob" (EKB) that corresponds to the fuses you have burned on your Jetson device.  See the [EKB documentation](https://docs.nvidia.com/jetson/archives/r39.2/DeveloperGuide/SD/Security/OpTee/Ekb.html) in the Jetson Linux Developer's Guide for full details.  See the note at the top of this page for information about changes in L4T R35.5.0 that require the re-generation of the EKB.
 
-The `tegra-bootfiles` recipe installs the default EKB from the L4T kit.  Add a bbappend for that recipe to replace the default with the custom EKB for your device.
+The `tegra-bootfiles` recipe installs the default EKB from the L4T kit.  If you have burned secure boot fuses on your device, you must replace this with a custom EKB that matches your fuse keys, for example by configuring the build-time EKB generation, or adding a bbappend to include keys generated outside the build.
 
-## Generating a Custom EKB
-Before replacing the default EKB in your Yocto build, you must generate a custom one that matches OemK1 fuse burned on your Jetson device. To do this, you need the `gen_ekb.py` script from the NVIDIA OP-TEE samples code base (for the `hwkey-agent` sample). You can find that script either in the L4T public sources tarball, or on [NVIDIA's git server](https://nv-tegra.nvidia.com/r/plugins/gitiles/tegra/optee-src/nv-optee) (making sure you choose the branch for the L4T version you are targeting).
+## Build-time EKB generation
+
+The `tegra-eks-image` recipe can generate your custom EKB automatically during the build. Set the
+following variables in your `local.conf` (or machine configuration) to enable this:
+
+| Variable | Platform | Description |
+|---|---|---|
+| `TEGRA_EKB_OEM_K1` | Orin (Tegra234) | Path to the `OEM_K1` fuse key file |
+| `TEGRA_EKB_OEM_KDK1` | Thor (Tegra264) | Path to the `PSC_OEM_KDK1` fuse key file |
+| `TEGRA_EKB_SYM2` | Both | Path to the disk encryption key file (optional but recommended) |
+| `TEGRA_EKB_AUTH` | Both | Path to the UEFI variable authentication key file |
+
+The recipe automatically selects `-chip t234` or `-chip t264` based on the target `SOC_FAMILY`.
+When the platform-appropriate fuse key variable is set and points to an existing file, `gen_ekb.py`
+is invoked during the build and the resulting `eks.img` is used instead of the default from the
+L4T kit.
+
+Example `local.conf` entries for Orin:
+```
+TEGRA_EKB_OEM_K1 = "/path/to/oem_k1.key"
+TEGRA_EKB_SYM2   = "/path/to/sym2.key"
+TEGRA_EKB_AUTH   = "/path/to/auth.key"
+```
+
+Example `local.conf` entries for Thor:
+```
+TEGRA_EKB_OEM_KDK1 = "/path/to/oem_kdk1.key"
+TEGRA_EKB_SYM2     = "/path/to/sym2.key"
+TEGRA_EKB_AUTH     = "/path/to/auth.key"
+```
+
+If the fuse key variable is not set or the file does not exist, the default EKB from the L4T kit
+is used — this is suitable for development only and must not be used on a production device with
+fuses burned.
+
+## Generating a Custom EKB manually
+
+If you need to generate the EKB outside of the build, you can run `gen_ekb.py` directly. The
+script is available in the L4T public sources tarball or on
+[NVIDIA's git server](https://nv-tegra.nvidia.com/r/plugins/gitiles/tegra/optee-src/nv-optee)
+(choose the branch matching your L4T version).
+
+### Jetson Orin (Tegra234)
 
 Example:
 ```
@@ -105,4 +146,26 @@ where
 * `eks_t234.img` is the generated EKB image to be flashed to the EKS partition of the device
 
 Kernel encryption is not currently supported in meta-tegra, so do *not* provide the UEFI payload encryption key (using `-in_sym_key`).
+
+### Jetson AGX Thor (Tegra264)
+
+Thor uses a different fuse key (`PSC_OEM_KDK1` instead of `OEM_K1`/`OEM_K2`) and a different key
+derivation function (NIST-SP-800-108 with HMAC-SHA256). The generated EKB image is `eks_t264.img`
+(EKB version 2.1), which is not backward-compatible with the Orin format.
+
+Example:
+```
+python3 gen_ekb.py -chip t264 \
+    -oem_kdk1_key oem_kdk1.key \
+    -in_sym_key2 sym2_t264.key \
+    -in_auth_key auth_t264.key \
+    -out eks_t264.img
+```
+where
+* `oem_kdk1.key` is the `PSC_OEM_KDK1` key burned into the Thor device fuses.
+* `sym2_t264.key` is the disk encryption key.
+* `auth_t264.key` is the UEFI variable authentication key.
+* `eks_t264.img` is the generated EKB image to be flashed to the EKS partition of the device.
+
+See the [EKB documentation](https://docs.nvidia.com/jetson/archives/r39.2/DeveloperGuide/SD/Security/OpTee/Ekb.html) for the full key derivation details and additional generation parameters.
 

--- a/docs/Tegra-specific-gstreamer-plugins.md
+++ b/docs/Tegra-specific-gstreamer-plugins.md
@@ -1,10 +1,45 @@
-Originally, the machine configurations set MACHINE_GSTREAMER_1_0_PLUGIN to include the `gstreamer1.0-plugins-tegra` package, which is the base set of binary-only gstreamer plugins that is provided with L4T.  In more recent releases, this has been changed to point to `gstreamer1.0-omx-tegra` instead (and using the now-current MACHINE_HWCODECS variable) to make it easier to build multimedia-ready images.
+# Tegra-specific GStreamer plugins
 
-Note that since the OpenMAX plugins package is flagged as commercially licensed, it is also whitelisted in the machine configuration with:
-```
-LICENSE_FLAGS_WHITELIST_append = " commercial_gstreamer1.0-omx-tegra"
-```
+Starting with L4T R35.x (JetPack 5), the NVIDIA-specific GStreamer plugins are built individually
+from source as separate recipes, rather than being delivered as a single binary blob package.
+Each recipe below corresponds to a Yocto package that can be added to your image.
 
-## Update 2020-09-17
-Starting with the branches using L4T R32.4.3 (`dunfell-l4t-r32.4.3` and later), the commercially-licensed flag was removed from the OpenMAX plugin recipe, as the sources are available and do not appear to contain any encumbered code.
+## Plugin recipes
 
+| Recipe | GStreamer element(s) | Description |
+|---|---|---|
+| `gstreamer1.0-plugins-nvarguscamerasrc` | `nvarguscamerasrc` | LibArgus-based CSI camera capture source |
+| `gstreamer1.0-plugins-nvcompositor` | `nvcompositor` | GPU-accelerated multi-input compositor |
+| `gstreamer1.0-plugins-nvdrmvideosink` | `nvdrmvideosink` | DRM/KMS video sink |
+| `gstreamer1.0-plugins-nveglgles` | `nvvideosink`, `nvoverlaysink` | EGL/GLES-based render sinks |
+| `gstreamer1.0-plugins-nvipcpipeline` | `nvipcsrc`, `nvipcsink` | Inter-process GStreamer pipeline elements |
+| `gstreamer1.0-plugins-nvjpeg` | `nvjpegdec`, `nvjpegenc` | Hardware-accelerated JPEG decode/encode |
+| `gstreamer1.0-plugins-nvsiplcamerasrc` | `nvsiplcamerasrc` | SIPL-based camera source (R39.2.0+, requires `jetson-sipl-api`) |
+| `gstreamer1.0-plugins-nvtee` | `nvtee` | Tegra-specific tee element |
+| `gstreamer1.0-plugins-nvunixfd` | `nvunixfdsrc`, `nvunixfdsink` | Unix file-descriptor buffer sharing elements |
+| `gstreamer1.0-plugins-nvv4l2camerasrc` | `nvv4l2camerasrc` | V4L2-based camera capture source |
+| `gstreamer1.0-plugins-nvvidconv` | `nvvidconv` | Hardware video format and color-space conversion |
+| `gstreamer1.0-plugins-nvvideo4linux2` | `nvv4l2dec`, `nvv4l2h264enc`, `nvv4l2h265enc`, etc. | V4L2-based hardware video decode and encode |
+| `gstreamer1.0-plugins-nvvideosinks` | `nvvideosink` | NvBuf-backed video sink |
+
+### Supporting packages
+
+* **`libgstnvcustomhelper`** — shared helper library used internally by several of the plugins above; pulled in automatically as a dependency
+* **`nvgstapps`** — sample GStreamer applications from NVIDIA demonstrating use of these plugins
+
+## Machine configuration
+
+The `MACHINE_HWCODECS` variable in each machine configuration selects the hardware codec packages
+for that target. The GStreamer plugins above can be included individually in your image recipe, or
+grouped through appropriate `IMAGE_INSTALL` or `MACHINE_EXTRA_RRECOMMENDS` settings in your
+layer.
+
+## Camera source plugin notes
+
+**nvarguscamerasrc** is the standard CSI camera source for most Jetson platforms, using the
+LibArgus camera API.
+
+**nvsiplcamerasrc** (available from R39.2.0/JetPack 7.2 onwards) is an alternative source for
+cameras attached via the SIPL framework. It is built from source and depends on the
+`jetson-sipl-api` package. SIPL is typically used with more complex camera module configurations
+that require an ISP tuning database.

--- a/docs/release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md
+++ b/docs/release-notes/JetPack-7.2-L4T-R39.2.0-Notes.md
@@ -1,0 +1,97 @@
+As of June 2026, the `master` branch supports JetPack 7.2/L4T R39.2.0.
+
+# Changes from L4T R36.5.0/JetPack 6.2.2 and R38.4.x/JetPack 7.1
+
+This release is the first JetPack 7 release to support **both** the Orin family (AGX Orin, Orin NX, Orin Nano) **and** AGX Thor (T4000, T5000) simultaneously. Previous JetPack 7.x releases (R38.x) were Thor-only on their respective branches.
+
+See the release notes in the NVIDIA documentation for this release for information on new and updated features:
+* [Jetson Linux R39.2 release notes](https://docs.nvidia.com/jetson/archives/r39.2/ReleaseNotes/)
+* [JetPack 7.2 download page](https://developer.nvidia.com/embedded/jetpack/downloads/archive-7.2)
+
+## BSP changes
+
+### New machine configurations
+
+Support for the AGX Thor platform is incorporated alongside Orin. New machine configurations added versus r36.x:
+* `jetson-agx-thor-devkit` — AGX Thor development kit (T4000 module, p4071 carrier)
+* `jetson-agx-thor-t4000` — AGX Thor T4000 module
+
+### Flashing process changes
+
+The `tegra-flash-helper.sh` script has been renamed to `tegra234-flash-helper.sh`, and a new
+`tegra264-flash-helper.sh` has been added for Thor targets. Both Tegra234 (Orin) and Tegra264 (Thor)
+use the `initrd-flash` flow, but each invokes its own SoC-specific flash helper internally.
+
+For both Orin and Thor targets, use `initrd-flash`. Options such as `--external-only`, `-k NAME`, `--qspi-only`, and `--debug` are available on both platforms.
+
+## Kernel changes
+
+### Orin (Tegra234)
+
+The kernel for Orin has been upgraded from `linux-jammy-nvidia-tegra` (5.15-based) to
+`linux-noble-nvidia-tegra` (6.8.12-based). This is a significant kernel version upgrade.
+
+A notable consequence of moving to the 6.8 kernel is that many Tegra ASoC audio drivers that were
+previously delivered as out-of-tree modules (in the `nvidia-kernel-oot-alsa` package) are now
+included in the mainline kernel. The following drivers have moved in-tree and are no longer
+provided by the OOT package:
+
+* `snd-soc-tegra186-asrc`
+* `snd-soc-tegra186-dspk`
+* `snd-soc-tegra210-admaif`
+* `snd-soc-tegra210-adx`
+* `snd-soc-tegra210-ahub`
+* `snd-soc-tegra210-amx`
+* `snd-soc-tegra210-dmic`
+* `snd-soc-tegra210-i2s`
+* `snd-soc-tegra210-mixer`
+* `snd-soc-tegra210-mvc`
+* `snd-soc-tegra210-ope`
+* `snd-soc-tegra210-sfc`
+* `snd-soc-tegra-machine-driver`
+
+A smaller set of audio drivers (ADSP and virtualization-related) remains out-of-tree.
+
+### Thor (Tegra264)
+
+Thor targets already used `linux-noble-nvidia-tegra` (6.8.12) in the R38.x branches. The kernel
+base version is unchanged, but has been updated to the R39.2.0 L4T patch series.
+
+### nvidia-kernel-oot
+
+The out-of-tree kernel module package has been updated to R39.2.0, with compatibility updates for
+the 6.8 kernel across both Tegra234 and Tegra264 platforms.
+
+## JetPack changes
+
+JetPack 7.2 includes significant component upgrades from JetPack 6.2.2:
+
+| Component | JetPack 6.2.2 | JetPack 7.1 | JetPack 7.2 |
+|---|---|---|---|
+| CUDA | 12.6 | 13.0 | 13.2 |
+| cuDNN | 9.3.0 | 9.12.0 | 9.20.0 |
+| TensorRT | 10.3.0 | 10.13.3 | 10.16.2 |
+| Hafnium | — | 2.9 | 2.11 |
+| OPTEE | 4.2 | 4.4 | 4.6 |
+
+PVA SDK and Nsight Systems have also been updated; see the NVIDIA release notes for version details.
+
+## New recipes
+
+* **`gstreamer1.0-plugins-nvsiplcamerasrc`** — GStreamer source plugin for SIPL-based cameras,
+  built from source. Requires `jetson-sipl-api`.
+* **`jetson-sipl-api`** — SIPL camera API library.
+* **`edk2-firmware-tegra-rcmboot-prebuilt`** — Optional prebuilt UEFI RCMBoot binary, for users
+  who cannot or do not wish to build the EDK2 sources. Set
+  `PREFERRED_PROVIDER_edk2-firmware-tegra-rcmboot = "edk2-firmware-tegra-rcmboot-prebuilt"` to
+  use it.
+* **`tegra-libraries-openwfd`** — OpenWFD display library.
+
+## Container support
+
+`nvidia-docker` has been replaced by `nvidia-container-toolkit`. Add `nvidia-container-toolkit`
+to your image instead of `nvidia-docker`. See [NVIDIA Container Runtime Support](../NVIDIA-Container-Runtime-support.md) for details.
+
+## DeepStream SDK
+
+No information is available yet on DeepStream SDK compatibility with JetPack 7.2.


### PR DESCRIPTION
Went through the updates between r36 and r38 to r39 and filled in a few gaps along the way. There's some improvements to the gstreamer plugins page, and an explanation of the updates to the virtualization support, as well as some release notes now. Also the secureboot documentation has been updated to add a section regarding build-time signing and to demonstrate EKB generation for Thor.