### PR TITLE
Add IGX Orin and IGX Thor developer kits

### DIFF
--- a/conf/machine/include/igx-orin.inc
+++ b/conf/machine/include/igx-orin.inc
@@ -1,0 +1,45 @@
+# Common settings for IGX Orin modules
+
+NVPMODEL ?= "nvpmodel_p3701_0008"
+NVFANCONTROL ?= "nvfancontrol_p3701_0008"
+TEGRA_EDK2_CONFIGURATION ?= "general_igx"
+
+require conf/machine/include/tegra234.inc
+
+KERNEL_ARGS ?= "mminit_loglevel=4 console=tty0 console=ttyTCU0,115200 firmware_class.path=/etc/firmware fbcon=map:0 video=efifb:off console=tty0 efi=runtime nvme.use_threaded_interrupts=1 pci=pcie_bus_safe"
+
+EMMC_DEVSECT_SIZE ?= "512"
+BOOTPART_SIZE ?= "8388608"
+BOOTPART_LIMIT ?= "10485760"
+ROOTFSPART_SIZE_DEFAULT ?= "55834574848"
+TEGRA_FLASHVAR_ODMDATA ?= "gbe-uphy-config-8,hsio-uphy-config-0,nvhs-uphy-config-0"
+EMC_BCT ?= "tegra234-p3701-0008-sdram-l4t.dts"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi_sdmmc_safety.xml"
+TEGRA_AUDIO_DEVICE ?= "tegra-hda-jetson-agx"
+
+OTABOOTDEV ?= "/dev/mtdblock0"
+OTAGPTDEV ?= "/dev/mtdblock0"
+
+TEGRA_PLUGIN_MANAGER_OVERLAYS ?= "tegra234-carveouts.dtbo tegra-optee.dtbo"
+
+TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra234-bpmp-3701-0008-3740-0002-c00.dtb"
+TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t234-TA990SA-A1_prod.bin"
+TEGRA_FLASHVAR_BR_CMD_CONFIG ?= "tegra234-mb1-bct-reset-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:D0"
+TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra234-mb1-bct-cprod-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra234-mb1-bct-device-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra234-br-bct-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_DEV_PARAMS_B ?= "tegra234-br-bct_b-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra234-br-bct-diag-boot.dts"
+TEGRA_FLASHVAR_FSIFW ?= "fsi-lk.bin"
+TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra234-mb1-bct-gpioint-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra234-mb2-bct-misc-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "--minratchet_config tegra234-mb1-bct-ratchet-p3701-0000.dts"
+TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra234-mb1-bct-misc-p3701-0008-flash.dts"
+TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra234-mb1-bct-pinmux-p3701-0008-p3740-0002-c01.dtsi"
+TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra234-mb1-bct-padvoltage-p3701-0002-p3740-0002.dtsi"
+TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra234-mb1-bct-pmic-p3701-0008-p3740-0002-c01.dts"
+TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra234-mb1-bct-prod-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra234-mb2-bct-firewall-si-p3701-0002-p3740-0002.dts"
+TEGRA_FLASHVAR_UPHY_CONFIG ?= ""
+TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra234-p3701-0008-wb0sdram-l4t.dts"

--- a/conf/machine/include/igx-thor-t5000.inc
+++ b/conf/machine/include/igx-thor-t5000.inc
@@ -1,0 +1,65 @@
+# Common settings for IGX Thor T5000 (p3834-0008) modules
+
+TEGRA_BOARDID ?= "3834"
+TEGRA_FAB ?= "400"
+TEGRA_BOARDSKU ?= "0008"
+TEGRA_BOARDREV ?= "G.5"
+TEGRA_CHIPREV ?= "1"
+NVPMODEL ?= "nvpmodel_p3834_0008"
+NVFANCONTROL ?= "nvfancontrol_p3834_0008_p3740_0002"
+
+TNSPEC_BOOTDEV ?= "nvme0n1p1"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_l4t_t264_qspi.xml"
+PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
+PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t264_nvme.xml"
+TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
+
+TEGRA_BUPGEN_SPECS ?= " \
+    fab=000;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
+    fab=401;boardsku=0008;boardrev=;chiprev=;chipsku=00:00:00:A0;bup_type=bl \
+"
+
+EMMC_SIZE ?= ""
+BOOTPART_SIZE ?= ""
+
+TEGRA_PLUGIN_MANAGER_OVERLAYS ?= ""
+TEGRA_FLASHVAR_BPFDTB_FILE ?= "tegra264-bpmp-3834-0008-3740-xxxx.dtb"
+TEGRA_FLASHVAR_BPF_FILE ?= "bpmp_t264-TA1090SA-A1_prod.bin"
+TEGRA_FLASHVAR_CHIP_SKU ?= "00:00:00:A0"
+TEGRA_FLASHVAR_DEVICEPROD_CONFIG ?= "tegra264-mb1-bct-cprod-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_DEVICE_CONFIG ?= "tegra264-mb1-bct-device-p3834-xxxx.dts"
+TEGRA_FLASHVAR_DEV_PARAMS ?= "tegra264-br-bct-common-l4t.dts"
+TEGRA_FLASHVAR_DEV_PARAMS_B ?= ""
+TEGRA_FLASHVAR_EMC_FUSE_DEV_PARAMS ?= "tegra264-br-bct-diag-boot.dts"
+TEGRA_FLASHVAR_FSIFW ?= "fsi-fw-t264.bin"
+TEGRA_FLASHVAR_GPIOINT_CONFIG ?= "tegra264-mb1-bct-gpioint-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_MB2BCT_CFG ?= "tegra264-mb2-bct-misc-p3834-0008-p3740-0002.dts"
+TEGRA_FLASHVAR_MINRATCHET_CONFIG ?= "tegra264-mb1-bct-ratchet-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_MISC_CONFIG ?= "tegra264-mb1-bct-misc-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_PINMUX_CONFIG ?= "tegra264-mb1-bct-pinmux-p3834-0008-p3740-0002.dts"
+TEGRA_FLASHVAR_PMC_CONFIG ?= "tegra264-mb1-bct-padvoltage-p3834-0008-p3740-0002.dts"
+TEGRA_FLASHVAR_PMIC_CONFIG ?= "tegra264-mb1-bct-pmic-p3834-0008-p3740-0002.dts"
+TEGRA_FLASHVAR_PROD_CONFIG ?= "tegra264-mb1-bct-prod-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_RAMCODE ?= "12"
+TEGRA_FLASHVAR_SCR_CONFIG ?= "tegra264-mb2-bct-firewall-p3834-xxxx-p3971-0000.dts"
+TEGRA_FLASHVAR_UPHY_CONFIG ?= ""
+TEGRA_FLASHVAR_WB0SDRAM_BCT ?= "tegra264-p3834-0008-sdram-bct-warmboot-l4t.dts"
+TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0008-sdram-dfs.dts"
+
+TEGRA_EDK2_CONFIGURATION ?= "general_igx"
+
+require conf/machine/include/tegra264.inc
+
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
+MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
+
+KERNEL_DEVICETREE ?= "tegra264-p3740-0002+p3834-0008-qspi-nvme.dtb"
+# 50GiB default rootfs size
+ROOTFSPART_SIZE_DEFAULT ?= "53687091200"
+TEGRA_FLASHVAR_ODMDATA ?= "uphy0-config-6,pcie@3_status=okay"
+EMC_BCT ?= "tegra264-p3834-0008-sdram-bct-l4t.dts"
+TEGRA_AUDIO_DEVICE ?= "tegra-hda-p3767-p3509"
+
+OTABOOTDEV ?= "/dev/mtdblock0"
+OTAGPTDEV ?= "/dev/mtdblock0"

--- a/conf/machine/jetson-igx-orin-devkit.conf
+++ b/conf/machine/jetson-igx-orin-devkit.conf
@@ -1,0 +1,11 @@
+#@TYPE: Machine
+#@NAME: Nvidia Jetson IGX Orin dev kit
+#@DESCRIPTION: Nvidia Jetson IGX Orin dev kit (P3701-0008 module in P3740-0002 carrier)
+
+TEGRA_BUPGEN_SPECS ?= "fab=300;boardsku=0008;boardrev=;chipsku=00:00:00:D0;bup_type=bl \
+                       fab=300;boardsku=0008;boardrev=;bup_type=kernel"
+KERNEL_DEVICETREE ?= "tegra234-p3740-0002+p3701-0008-nv.dtb"
+
+require conf/machine/include/igx-orin.inc
+require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/devkit-audio.inc

--- a/conf/machine/jetson-igx-thor-devkit.conf
+++ b/conf/machine/jetson-igx-thor-devkit.conf
@@ -1,0 +1,9 @@
+#@TYPE: Machine
+#@NAME: Nvidia IGX Thor dev kit
+#@DESCRIPTION: Nvidia IGX Thor dev kit (P3834-0008 module in P3740-0002 carrier with NVMe)
+
+require conf/machine/include/igx-thor-t5000.inc
+
+NVIDIA_WIFI ?= "kernel-module-rtk-btusb kernel-module-rtl8852ce"
+require conf/machine/include/devkit-wifi.inc
+require conf/machine/include/devkit-audio.inc


### PR DESCRIPTION
## Summary

Adds machine support for the NVIDIA IGX Orin and IGX Thor developer kits on L4T R39.2.0 / JetPack 7.2, built on the existing `tegra234` and `tegra264` SoC includes. Both kits seem to use the p3740-0002 carrier.

| Machine | Module | Boot | FSI firmware | UEFI |
|---|---|---|---|---|
| `jetson-igx-orin-devkit` | p3701-0008 | eMMC (safety layout) | `fsi-lk.bin` | `general_igx` |
| `jetson-igx-thor-devkit` | p3834-0008 | NVMe | `fsi-fw-t264.bin` | `general_igx` |

## AGX/IGX differences

The IGX parts ship with the Functional Safety Island populated and run the IGX UEFI build. They are close to their AGX counterparts but not identical: IGX Thor is the same p3834-0008 module, while IGX Orin uses the p3701-0008 module (the AGX Orin devkit uses p3701-0000). The deltas versus the AGX siblings are:

- `TEGRA_FLASHVAR_FSIFW` set, so the FSI firmware is written to the fsi-fw partition (`tegra-storage-layout` already plumbs this when FSIFW is non-empty).
- `TEGRA_EDK2_CONFIGURATION = "general_igx"`, selecting the IGX platform UEFI (`uefi_t23x_general_igx` / `uefi_t26x_general_igx`), set before the SoC `require` so it overrides the `general` default.
- p3740-0002 / p3971-0000 carrier BCTs in place of the AGX devkit carrier.
- IGX-specific `nvpmodel` / `nvfancontrol` profiles (p3701-0008 for Orin, p3834-0008-p3740-0002 for Thor), and for Orin the safety partition layout and `pci=pcie_bus_safe`.

## Verification

I only have IGX Thor T5000 modules on hand, not the developer kits themselves, so I have not flashed or booted these machines on real dev-kit hardware yet. The values are taken directly from the L4T R39.2.0 board configs and packages and cross-checked against them value-by-value, so I am fairly confident they are correct, but a build and on-hardware boot pass on real dev-kit hardware is still wanted before relying on them.
