### PR TITLE
L4T r39.2.0 dtb/dtbo build fixups

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -28,6 +28,8 @@ def tegra_dtb_extra_deps(d):
     deps = []
     if d.getVar('PREFERRED_PROVIDER_virtual/dtb'):
         deps.append('virtual/dtb:do_populate_sysroot')
+    if d.getVar('PREFERRED_PROVIDER_virtual/dtbo'):
+        deps.append('virtual/dtbo:do_populate_sysroot')
     if d.getVar('TEGRA_UEFI_USE_SIGNED_FILES') == "true":
         deps.append('tegra-uefi-keys-dtb:do_deploy')
     return ' '.join(deps)

--- a/classes-recipe/tegra-devicetree.bbclass
+++ b/classes-recipe/tegra-devicetree.bbclass
@@ -23,6 +23,7 @@ DT_INCLUDE:tegra234 ?= " \
     ${DT_NV_BASE}/t23x/nv-public/include/nvidia-oot \
     ${DT_NV_BASE}/t23x/nv-public/include/platforms \
     ${DT_NV_BASE}/t23x/nv-public \
+    ${DT_NV_BASE}/t23x/nv-public/nv-platform \
     ${DT_FILES_PATH} \
     ${KERNEL_INCLUDE} \
 "
@@ -32,6 +33,7 @@ DT_INCLUDE:tegra264 ?= " \
     ${DT_NV_BASE}/tegra/nv-public \
     ${DT_NV_BASE}/t264/nv-public/include/kernel-t264 \
     ${DT_NV_BASE}/t264/nv-public \
+    ${DT_NV_BASE}/t264/nv-public/nv-platform \
     ${DT_FILES_PATH} \
     ${KERNEL_INCLUDE} \
 "

--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -18,6 +18,7 @@ NVIDIA_BOARD ?= "generic"
 TEGRA_BOOTCONTROL_OVERLAYS ?= "L4TConfiguration.dtbo"
 TEGRA_BOOTCONTROL_OVERLAYS += "${@'L4TConfiguration-RootfsRedundancyLevelABEnable.dtbo' if bb.utils.to_boolean(d.getVar('USE_REDUNDANT_FLASH_LAYOUT')) else ''}"
 TEGRA_PLUGIN_MANAGER_OVERLAYS ??= ""
+PREFERRED_PROVIDER_virtual/dtbo ?= "nvidia-kernel-oot-dtbo"
 # The following variable is deprecated; add new overlays
 # to one of the above instead.
 OVERLAY_DTB_FILE ?= ""

--- a/recipes-bsp/uefi/l4t-launcher-extlinux.bb
+++ b/recipes-bsp/uefi/l4t-launcher-extlinux.bb
@@ -63,6 +63,7 @@ python do_copy_dtb_overlays() {
 do_copy_dtb_overlays[dirs] = "${B}"
 do_copy_dtb_overlays[depends] += "virtual/kernel:do_deploy"
 do_copy_dtb_overlays[depends] += "${@'virtual/dtb:do_populate_sysroot' if d.getVar('PREFERRED_PROVIDER_virtual/dtb') else ''}"
+do_copy_dtb_overlays[depends] += "${@'virtual/dtbo:do_populate_sysroot' if d.getVar('PREFERRED_PROVIDER_virtual/dtbo') else ''}"
 
 addtask copy_dtb_overlays after do_configure before do_sign_files
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_39.2.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtb_39.2.0.bb
@@ -12,18 +12,3 @@ DT_PADDING_SIZE = "0"
 
 DT_FILES_PATH:tegra234 = "${DT_NV_BASE}/t23x/nv-public/nv-platform"
 DT_FILES_PATH:tegra264 = "${DT_NV_BASE}/t264/nv-public/nv-platform"
-
-NV_OVERLAY_PATH:tegra234 = "${DT_NV_BASE}/t23x/nv-public/overlay"
-NV_OVERLAY_PATH:tegra264 = "${DT_NV_BASE}/t264/nv-public/overlay"
-
-python do_compile:append() {
-    import os
-    overlay_path = d.getVar("NV_OVERLAY_PATH") or ""
-    if not overlay_path or not os.path.isdir(overlay_path):
-        return
-    includes = expand_includes("DT_INCLUDE", d)
-    for dts in sorted(os.listdir(overlay_path)):
-        if not dts.endswith(".dts"):
-            continue
-        devicetree_compile(os.path.join(overlay_path, dts), includes, d)
-}

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtbo_39.2.0.bb
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot-dtbo_39.2.0.bb
@@ -1,0 +1,15 @@
+DESCRIPTION = "NVIDIA Jetson Linux device tree overlays"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0-only;md5=801f80980d171dd6425610833a22dbe6"
+
+inherit tegra-devicetree
+
+PROVIDES = "virtual/dtbo"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+DT_RESERVED_MAP = "0"
+DT_PADDING_SIZE = "0"
+
+DT_FILES_PATH:tegra234 = "${DT_NV_BASE}/t23x/nv-public/overlay"
+DT_FILES_PATH:tegra264 = "${DT_NV_BASE}/t264/nv-public/overlay"

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -83,6 +83,7 @@ do_install() {
     # include device-tree source for building external dtb
     install -d ${D}/usr/src/device-tree
     cp -R ${S}/hardware/nvidia/ ${D}/usr/src/device-tree
+    find ${D}/usr/src/device-tree -name '.git' -depth -type d -exec rm -rf '{}' ';'
 }
 
 SYSROOT_DIRS += "/usr/src/device-tree"


### PR DESCRIPTION
The changes here fix a few problems with the new format of devicetree builds. External builds weren't building overlays, so we need new handling for that, and the external builds were missing an include path that was taken for granted in the build here. Also fix up a QA tmpdir path check failure along the way.

* tegra-devicetree: move to classes-recipe and improve search path
* nvidia-kernel-oot: skip .git dirs staging dts for _git version of recipe
* plugin_manager_overlays: depend on virtual/dtbo and split a recipe

Addresses #2264