### PR TITLE
39.2.0 CUDA sdk fixes

### DIFF
--- a/recipes-core/packagegroups/nativesdk-packagegroup-cuda-sdk-host.bb
+++ b/recipes-core/packagegroups/nativesdk-packagegroup-cuda-sdk-host.bb
@@ -7,4 +7,5 @@ PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 
 RDEPENDS:${PN} = "\
     nativesdk-cuda-compiler \
+    nativesdk-cuda-cccl \
 "

--- a/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
@@ -1,0 +1,2 @@
+RDEPENDS:${PN}:append:tegra = " libgcc-for-nvcc-dev gcc-for-nvcc-runtime-dev"
+PACKAGE_ARCH:tegra = "${TEGRA_PKGARCH}"

--- a/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
+++ b/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS:${PN}:append:tegra = " gcc-for-nvcc-cross-canadian-${TRANSLATED_TARGET_ARCH}"

--- a/recipes-devtools/cuda/cuda-shared-binaries.inc
+++ b/recipes-devtools/cuda/cuda-shared-binaries.inc
@@ -30,7 +30,20 @@ CUDA_VERSION_DASHED = "${@d.getVar('CUDA_VERSION').replace('.','-')}"
 
 CUDA_PKGNAMES ?= "${@' '.join(['%s-${CUDA_VERSION_DASHED}_${PV}_${CUDA_DEB_PKGARCH}.deb' % pkg for pkg in d.getVar('CUDA_PKG').split()])}"
 
-CUDA_INSTALL_ARCH ?= "${HOST_ARCH}"
+# CUDA 13.x arm64 debs lay their per-target files out under targets/sbsa-linux,
+# while amd64 debs use targets/x86_64-linux. The directory is purely a function
+# of HOST_ARCH (which selects CUDA_DEB_PKGARCH), so map it here for every class.
+# This default covers class-nativesdk (which has no per-recipe override); the
+# explicit class-native assignment below overrides the recipes' "${HOST_ARCH}"
+# so that native builds on aarch64 hosts also resolve to sbsa.
+def cuda_install_arch(d):
+    arch = d.getVar('HOST_ARCH')
+    if arch == 'aarch64':
+        return 'sbsa'
+    return arch
+
+CUDA_INSTALL_ARCH ?= "${@cuda_install_arch(d)}"
+CUDA_INSTALL_ARCH:class-native = "${@cuda_install_arch(d)}"
 
 do_compile() {
     rm -f ${B}/usr/local/cuda-${CUDA_VERSION}/lib64


### PR DESCRIPTION
This PR includes three fixes for SDK generation and CUDA cross-compilation. 

To pull the CUDA host tooling into the SDK I added this to my local layer:

```
TOOLCHAIN_HOST_TASK:append:tegra = " nativesdk-packagegroup-cuda-sdk-host"
```

Tested on aarch64 SDK host, and I confirmed that the SDK for x86_64 also builds.

Please look at the commit messages for detailed descriptions.