### PR TITLE
tegra-helper-scripts/initrd-flash: drop redundant -k create_l4t_bsp_i…

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -798,9 +798,6 @@ elif [ "$CHIPID" = "0x26" ]; then
     mkdir -p out/flash_workspace/flash-images out/flash_workspace/rcm-boot
     ./create_l4t_bsp_images.py $convargs --info --dest $PWD/out
     ./create_l4t_bsp_images.py $convargs --dest $PWD/out/flash_workspace/flash-images
-    if [ -n "$partition_name" ]; then
-        ./create_l4t_bsp_images.py $convargs -k $partition_name --dest $PWD/out/flash_workspace/flash-images
-    fi
     ./create_l4t_bsp_images.py $convargs --dest $PWD/out/flash_workspace/rcm-boot --rcm-boot
     cp -R out/flash_workspace/rcm-boot out/flash_workspace/rcm-flash
     cat > out/doflash.sh <<EOF


### PR DESCRIPTION
…mages.py call

When -k <partition> is given, the wrapper called create_l4t_bsp_images.py twice: a full workspace translate, then again with -k to "update" the named partition. The second call is redundant (both operate on the same source files) and triggers a latent T264 failure:

  - translate_l4t_to_auto (first call) shutil.move's partition binaries out of tools/kernel_flash/images/internal/
  - replace_file_in_flash_packages (second call) can't find them and fails with FileNotFoundError mid-rewrite of FileToFlash.txt, leaving it truncated
  - the wrapper ignores the exit code and proceeds to bootburn, which then raises s_ERROR_PARSE_CONFIG (surfaced as OSError 122)

L4T's l4t_initrd_flash_internal.sh treats the two modes as mutually exclusive; OE4T's wrapper combined them. Per-partition selection is already handled at flash time by the -k -> bootburn -u <partition> filter, so the extra create_l4t_bsp_images.py call can simply be dropped.

Verified on Thor T264 (PKCSBK-fused): 'initrd-flash -k A_eks' succeeds and the EKS authenticates on next boot; 'initrd-flash -k A_atf' leaves the previously written A_eks bytes unchanged.