### PR TITLE
nvidia-kernel-oot: fix host1x_fence crash on module unload and tegra_camera kmemleak false positive

### DIFF
--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -80,6 +80,7 @@ COMMON_PATCHES = "\
     file://0064-nvdisplay-nvidia-drm-support-fbdev-on-Linux-6.11-ker.patch;patchdir=nvdisplay \
     file://0065-nvdisplay-nvidia-drm-trigger-connector-detect-on-hot.patch;patchdir=nvdisplay \
     file://0066-nvdisplay-nvidia-drm-update-legacy-modeset-state-on-.patch;patchdir=nvdisplay \
+    file://0067-host1x-fence-fix-NULL-deref-and-add-module-exit-cleanup.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -81,6 +81,7 @@ COMMON_PATCHES = "\
     file://0065-nvdisplay-nvidia-drm-trigger-connector-detect-on-hot.patch;patchdir=nvdisplay \
     file://0066-nvdisplay-nvidia-drm-update-legacy-modeset-state-on-.patch;patchdir=nvdisplay \
     file://0067-host1x-fence-fix-NULL-deref-and-add-module-exit-cleanup.patch;patchdir=nvidia-oot \
+    file://0068-tegra-camera-suppress-kmemleak-false-positive.patch;patchdir=nvidia-oot \
 "
 EXTRA_PATCHES ??= ""
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0067-host1x-fence-fix-NULL-deref-and-add-module-exit-cleanup.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0067-host1x-fence-fix-NULL-deref-and-add-module-exit-cleanup.patch
@@ -1,0 +1,55 @@
+From: Wei Gao <wei.gao@windriver.com>
+Date: Sat, 6 Jun 2026 12:00:00 +0800
+Subject: [PATCH] gpu: host1x-fence: fix NULL deref in devnode and add module
+ exit cleanup
+
+The host1x_fence module has two bugs:
+
+1. host1x_fence_devnode() unconditionally dereferences the mode pointer,
+   but device_destroy -> devtmpfs_delete_node calls device_get_devnode
+   with mode=NULL, causing a NULL pointer dereference kernel panic on
+   module unload.
+
+2. tegra_host1x_exit() is empty - no cleanup of the sysfs class, cdev,
+   or device on module unload. This leaves dangling sysfs entries whose
+   devnode callback points to freed module memory. Any subsequent access
+   to /sys/class/host1x-fence/host1x-fence/uevent triggers an Undefined
+   instruction kernel panic. Reloading the module fails with -EEXIST.
+
+Fix by adding a NULL guard for mode, and implementing proper reverse-order
+teardown in the module exit function.
+
+Upstream-Status: Pending
+Signed-off-by: Wei Gao <wei.gao@windriver.com>
+---
+ drivers/gpu/host1x-fence/dev.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/host1x-fence/dev.c b/drivers/gpu/host1x-fence/dev.c
+index 2229978..39b6295 100644
+--- a/drivers/gpu/host1x-fence/dev.c
++++ b/drivers/gpu/host1x-fence/dev.c
+@@ -449,7 +449,8 @@ static char *host1x_fence_devnode(const struct device *dev, umode_t *mode)
+ static char *host1x_fence_devnode(struct device *dev, umode_t *mode)
+ #endif
+ {
+-	*mode = 0666;
++	if (mode)
++		*mode = 0666;
+ 	return NULL;
+ }
+ 
+@@ -515,6 +516,10 @@ module_init(tegra_host1x_init);
+ 
+ static void __exit tegra_host1x_exit(void)
+ {
++	device_destroy(uapi_data.class, uapi_data.dev_num);
++	cdev_del(&uapi_data.cdev);
++	class_destroy(uapi_data.class);
++	unregister_chrdev_region(uapi_data.dev_num, 1);
+ }
+ module_exit(tegra_host1x_exit);
+ 
+-- 
+2.39.2
+

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0068-tegra-camera-suppress-kmemleak-false-positive.patch
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot/0068-tegra-camera-suppress-kmemleak-false-positive.patch
@@ -1,0 +1,43 @@
+From: Wei Gao <wei.gao@windriver.com>
+Date: Sat, 6 Jun 2026 12:00:00 +0800
+Subject: [PATCH] media: tegra_camera: suppress kmemleak false positive for
+ video_device_alloc
+
+kmemleak reports unreferenced video_device objects allocated in
+tegra_channel_init_video(). These are long-lived V4L2 video device
+structures referenced through OOT module data structures that kmemleak
+cannot scan. The objects are properly freed in tegra_channel_cleanup_video()
+on module unload.
+
+Mark them with kmemleak_not_leak() to suppress the false positives.
+
+Upstream-Status: Pending
+
+Signed-off-by: Wei Gao <wei.gao@windriver.com>
+---
+ drivers/media/platform/tegra/camera/vi/channel.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/media/platform/tegra/camera/vi/channel.c b/drivers/media/platform/tegra/camera/vi/channel.c
+index 37c5383..c74e612 100644
+--- a/drivers/media/platform/tegra/camera/vi/channel.c
++++ b/drivers/media/platform/tegra/camera/vi/channel.c
+@@ -38,6 +38,7 @@
+ #include <linux/clk/tegra.h>
+ #define CREATE_TRACE_POINTS
+ #include <trace/events/camera_common.h>
++#include <linux/kmemleak.h>
+ 
+ #include "mipical/mipi_cal.h"
+ 
+@@ -2563,6 +2564,7 @@ int tegra_channel_init_video(struct tegra_channel *chan)
+ 	}
+ 
+ 	chan->video = video_device_alloc();
++	kmemleak_not_leak(chan->video);
+ 
+ 	/* Initialize the media entity... */
+ 	chan->pad.flags = MEDIA_PAD_FL_SINK;
+-- 
+2.39.2
+


### PR DESCRIPTION
Fix two nvidia-kernel-oot issues:

### 1. host1x_fence: fix NULL deref and add module exit cleanup

`host1x_fence_devnode()` unconditionally dereferences the `mode` pointer, but
`device_destroy` calls `device_get_devnode` with `mode=NULL`, causing a kernel
panic on module unload.

Additionally, `tegra_host1x_exit()` was empty — no cleanup of the sysfs class,
cdev, or device. This leaves dangling sysfs entries whose devnode callback points
to freed module memory, triggering an undefined instruction panic on any subsequent
access to `/sys/class/host1x-fence/host1x-fence/uevent`. Reloading the module
fails with `-EEXIST`.

Fix: add a NULL guard for `mode`, and implement proper reverse-order teardown
(device_destroy → cdev_del → class_destroy → unregister_chrdev_region).

Related: https://github.com/OE4T/meta-tegra/issues/2270

### 2. tegra_camera: suppress kmemleak false positive

kmemleak reports unreferenced `video_device` objects allocated in
`tegra_channel_init_video()`. These are long-lived V4L2 structures referenced
through OOT module data that kmemleak cannot scan. They are properly freed in
`tegra_channel_cleanup_video()` on module unload.

Fix: mark with `kmemleak_not_leak()` to suppress false positives.

Signed-off-by: Wei Gao <wei.gao@windriver.com>