### PR TITLE
gcc-for-nvcc: isolate sstate swspec namespace

### DIFF
--- a/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-source-for-nvcc.inc
@@ -9,7 +9,9 @@ inherit nopackages
 
 PN = "gcc-source-for-nvcc-${PV}"
 WORKDIR = "${TMPDIR}/work-shared/gcc-for-nvcc-${PV}-${PR}"
-SSTATE_SWSPEC = "sstate:gcc::${PV}:${PR}::${SSTATE_VERSION}:"
+# Keep NVCC GCC source cache namespace separate from oe-core gcc-source.
+# Their patch sets can diverge, causing noisy cross-matches and hash churn.
+SSTATE_SWSPEC = "sstate:gcc-for-nvcc::${PV}:${PR}::${SSTATE_VERSION}:"
 
 STAMP = "${STAMPS_DIR}/work-shared/gcc-for-nvcc-${PV}-${PR}"
 STAMPCLEAN = "${STAMPS_DIR}/work-shared/gcc-${PV}-*"


### PR DESCRIPTION
The gcc-source-for-nvcc recipe currently uses the generic 'gcc' SSTATE_SWSPEC namespace. That overlaps with oe-core gcc-source and can cause unrelated cache matches when the two recipes diverge in patch content.

Switch the namespace token to 'gcc-for-nvcc' so shared-state objects are keyed independently for this recipe family. This avoids noisy cross-matches and reduces unnecessary hash churn in incremental builds nwhen either side updates its patch set.