### PR TITLE
cuda-target-environment: make host compiler extraction ccache-aware

### DIFF
--- a/recipes-devtools/cuda/cuda-target-environment_1.0.bb
+++ b/recipes-devtools/cuda/cuda-target-environment_1.0.bb
@@ -6,11 +6,11 @@ SRC_URI = "file://cuda_target.sh.in"
 
 COMPATIBLE_MACHINE = "(cuda)"
 
-inherit cuda-gcc
+inherit cuda
 
 S = "${UNPACKDIR}"
 
-COMPILER_CMD  = "${@d.getVar('CXX_FOR_CUDA').split()[0]}"
+COMPILER_CMD  = "${@cuda_extract_compiler('CXX_FOR_CUDA', d)[0]}"
 CMAKE_CUDA_ARCHITECTURES = "${@d.getVar('CUDA_ARCHITECTURES') if d.getVar('CUDA_ARCHITECTURES') else 'OFF'}"
 CUDA_EXTRA_CXXFLAGS ??= "-isystem=${includedir}/cuda-compat-workarounds"
 


### PR DESCRIPTION
The recipe extracted COMPILER_CMD directly from the first element of CXX_FOR_CUDA, so when ccache is enabled (e.g. INHERIT += "ccache") the CUDAHOSTCXX variable in the generated SDK environment ended up being "ccache" instead of the actual host compiler.

Inherit cuda.bbclass instead of cuda-gcc.bbclass and use its cuda_extract_compiler() helper, which already skips the ccache wrapper, so the correct compiler is used consistently.

Fixes: OE4T/meta-tegra#2288