### PR TITLE
tegra-helper-scripts: backport T264 partial flash fix to r38.4

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -321,9 +321,6 @@ mkdir out
 mkdir -p out/flash_workspace/flash-images out/flash_workspace/rcm-boot
 ./create_l4t_bsp_images.py $convargs --info --dest $PWD/out
 ./create_l4t_bsp_images.py $convargs --dest $PWD/out/flash_workspace/flash-images
-if [ -n "$partition_name" ]; then
-    ./create_l4t_bsp_images.py $convargs -k $partition_name --dest $PWD/out/flash_workspace/flash-images
-fi
 ./create_l4t_bsp_images.py $convargs --dest $PWD/out/flash_workspace/rcm-boot --rcm-boot
 cp -R out/flash_workspace/rcm-boot out/flash_workspace/rcm-flash
 cat > out/doflash.sh <<EOF


### PR DESCRIPTION
Backport the T264 partial-flash fix from:

fb04dfd1a96d63b0edeb52c8f800f37a5764d201

The r38.4 branch still invokes `create_l4t_bsp_images.py` twice when
`-k <partition>` is used:

1. full workspace translation
2. second translation with `-k`

The first translation moves staged partition images, so the second call
can fail with `FileNotFoundError`. The wrapper then proceeds with an
inconsistent workspace and bootburn reports `s_ERROR_PARSE_CONFIG`.

Per-partition selection is already passed to `flash_bsp_images.py` as
`-u <partition>`, so the second `create_l4t_bsp_images.py -k` call is
redundant.

Observed on T264 / L4T r38.4 with:

    initrd-flash -k APP_b

Failure sequence:

    FileNotFoundError:
    ./tools/kernel_flash/images/external/my-image.ext4.simg

followed by:

    s_ERROR_PARSE_CONFIG

This change matches the fix already present on master.