### PR TITLE
cuda.bbclass: forward DEBUG_PREFIX_MAP flags to nvcc host-compiler pass

### DIFF
--- a/classes-recipe/cuda.bbclass
+++ b/classes-recipe/cuda.bbclass
@@ -3,7 +3,7 @@ CUDA_ARCHITECTURES ??= ""
 CUDA_NVCC_COMPAT_FLAGS ??= ""
 CUDA_NVCC_PATH_FLAGS ??= "--include-path ${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}/include --library-path ${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}/${baselib} -Xcompiler -isystem,=${includedir}/cuda-compat-workarounds"
 CUDA_NVCC_EXTRA_FLAGS ??= ""
-CUDA_NVCC_FLAGS ?= "${CUDA_NVCC_ARCH_FLAGS} ${CUDA_NVCC_COMPAT_FLAGS} ${CUDA_NVCC_PATH_FLAGS} ${CUDA_NVCC_EXTRA_FLAGS}"
+CUDA_NVCC_FLAGS ?= "${CUDA_NVCC_ARCH_FLAGS} ${CUDA_NVCC_COMPAT_FLAGS} ${CUDA_NVCC_PATH_FLAGS} ${CUDA_NVCC_EXTRA_FLAGS} ${CUDA_NVCC_PREFIX_MAP_FLAGS}"
 
 CUDA_CXXFLAGS = "-I${STAGING_DIR_NATIVE}/usr/local/cuda-${CUDA_VERSION}/include -I=/usr/local/cuda-${CUDA_VERSION}/include"
 CUDA_LDFLAGS = "\
@@ -15,6 +15,16 @@ CUDA_LDFLAGS = "\
 LDFLAGS:prepend:cuda = "${TOOLCHAIN_OPTIONS} "
 LDFLAGS:append:cuda = " ${CUDA_LDFLAGS}"
 DEBUG_PREFIX_MAP:remove:cuda = "-fcanon-prefix-map"
+
+def cudify_flags(varname, d):
+    return ' '.join(['-Xcompiler {}'.format(flag) for flag in (d.getVar(varname) or '').split()])
+
+# nvcc compiles .cu sources through a host-compiler pass but does NOT receive the
+# C/C++ DEBUG_PREFIX_MAP flags, so __FILE__ (and debug paths) from .cu files bake
+# in the absolute build path (TMPDIR) and leak into packaged binaries. Forward the
+# prefix-map flags to the host compiler via -Xcompiler so .cu objects are
+# normalized just like .cpp objects.
+CUDA_NVCC_PREFIX_MAP_FLAGS ??= "${@cudify_flags('DEBUG_PREFIX_MAP', d)}"
 
 def cuda_extract_compiler(compiler, d, prefix='-Xcompiler='):
     args = d.getVar(compiler).split()

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.3.0.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.3.0.bb
@@ -43,10 +43,7 @@ EXTRA_OECMAKE = '-DBUILD_SAMPLES=OFF -DSKIP_GPU_ARCHS=ON -DTRT_PLATFORM_ID="${TA
   -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
 '
 
-def cudify_flags(varname, d):
-    return ' '.join(['-Xcompiler {}'.format(flag) for flag in (d.getVar(varname) or '').split()])
-
-CUDAFLAGS += "-Xcompiler -DENABLE_SM${TEGRA_CUDA_ARCHITECTURE} ${@cudify_flags('DEBUG_PREFIX_MAP', d)}"
+CUDAFLAGS += "-Xcompiler -DENABLE_SM${TEGRA_CUDA_ARCHITECTURE}"
 LDFLAGS += "-Wl,--no-undefined"
 
 do_install:append() {


### PR DESCRIPTION
nvcc compiles .cu sources through a host-compiler pass but does not receive the C/C++ DEBUG_PREFIX_MAP flags. As a result, __FILE__ and debug paths from .cu files bake in the absolute build path (TMPDIR) and leak into packaged binaries, breaking reproducibility.

Add a CUDA_NVCC_PREFIX_MAP_FLAGS variable that wraps DEBUG_PREFIX_MAP in -Xcompiler and append it to CUDA_NVCC_FLAGS, so .cu objects are normalized the same way as .cpp objects for every cuda-inheriting recipe.

Drop the now-redundant local cudify_flags helper and CUDAFLAGS override from tensorrt-plugins, which is superseded by the shared handling in cuda.bbclass.