### PR TITLE
agx-thor: fix r8168/r8169 typo in MACHINE_EXTRA_RRECOMMENDS

### DIFF
--- a/conf/machine/include/agx-thor-t4000.inc
+++ b/conf/machine/include/agx-thor-t4000.inc
@@ -46,7 +46,7 @@ TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0000-sdram-dfs.dts"
 
 require conf/machine/include/tegra264.inc
 
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-r8168 kernel-module-r8169 kernel-module-realtek kernel-module-ina238"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
 MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
 

--- a/conf/machine/include/agx-thor-t5000.inc
+++ b/conf/machine/include/agx-thor-t5000.inc
@@ -47,7 +47,7 @@ TEGRA_FLASHVAR_BPMP_MEM_CONFIG ?= "tegra264-p3834-0008-sdram-dfs.dts"
 
 require conf/machine/include/tegra264.inc
 
-MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-8168 kernel-module-8169 kernel-module-realtek kernel-module-ina238"
+MACHINE_EXTRA_RRECOMMENDS += "kernel-module-r8126 kernel-module-r8168 kernel-module-r8169 kernel-module-realtek kernel-module-ina238"
 MACHINE_EXTRA_RRECOMMENDS += "kernel-module-ramoops kernel-module-tsecriscv"
 MACHINE_EXTRA_RDEPENDS += "linux-firmware-rtl8168"
 


### PR DESCRIPTION
kernel-module-8168/8169 are missing the 'r' prefix used by the real package names, so RRECOMMENDS silently no-ops and the Realtek driver never installs on agx-thor-t4000/t5000 despite being built.