### PR TITLE
cuda-binaries-common-defs: update fallback default version

### DIFF
--- a/recipes-devtools/cuda/cuda-binaries-common-defs.inc
+++ b/recipes-devtools/cuda/cuda-binaries-common-defs.inc
@@ -1,6 +1,6 @@
 COMPATIBLE_MACHINE:class-target = "(cuda)"
 COMPATIBLE_HOST = "(x86_64|aarch64)"
-CUDA_VERSION ??= "13.0"
+CUDA_VERSION ??= "13.2"
 
 S = "${UNPACKDIR}/${BP}"
 B = "${S}"


### PR DESCRIPTION
Need to update CUDA_VERSION default to match what
we set in the tegra machine configurations.

Fixes #2300 