### PR TITLE
l4t-graphics-demos: remove unneeded weston dependency

### DIFF
--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0005-Remove-unneeded-libweston-linkage.patch
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos/0005-Remove-unneeded-libweston-linkage.patch
@@ -1,0 +1,35 @@
+From ca973042df6e58574377a79599f333755167e00e Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Thu, 16 Jul 2026 13:26:18 -0700
+Subject: [PATCH] Remove unneeded libweston linkage
+
+The weston-dmabuf-formats makefile links against libweston,
+but the code makes no calls to the weston core. Remove this
+unwanted and unnecessary dependency.
+
+Upstream-Status: Pending
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ usr/src/nvidia/graphics_demos/weston-dmabuf-formats/Makefile | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/usr/src/nvidia/graphics_demos/weston-dmabuf-formats/Makefile b/usr/src/nvidia/graphics_demos/weston-dmabuf-formats/Makefile
+index 2c12dff..c33354e 100644
+--- a/usr/src/nvidia/graphics_demos/weston-dmabuf-formats/Makefile
++++ b/usr/src/nvidia/graphics_demos/weston-dmabuf-formats/Makefile
+@@ -37,7 +37,6 @@ INTERMEDIATES += $(PROTOCOLS)
+ CFLAGS += -I$(NV_WINSYS)/ -I=$(includedir)/libdrm/nvidia
+ 
+ PROTOCOLSDIR := $(shell pkg-config --variable=pkgdatadir wayland-protocols)
+-WESTON-VERSION := $(shell pkg-config --modversion weston | cut -d. -f1)
+ 
+ WESTON-DMABUF-FORMATS_OBJS += $(patsubst %.h,%.o,$(PROTOCOLS))
+ 
+@@ -47,7 +46,6 @@ WESTON-DMABUF-FORMATS_LDLIBS += -lrt
+ WESTON-DMABUF-FORMATS_LDLIBS += -lpthread
+ WESTON-DMABUF-FORMATS_LDLIBS += $(shell pkg-config --libs egl)
+ WESTON-DMABUF-FORMATS_LDLIBS += $(shell pkg-config --libs glesv2)
+-WESTON-DMABUF-FORMATS_LDLIBS += $(shell pkg-config --libs libweston-$(WESTON-VERSION))
+ WESTON-DMABUF-FORMATS_LDLIBS += $(shell pkg-config --libs libdrm)
+ WESTON-DMABUF-FORMATS_LDLIBS += $(shell pkg-config --libs gbm)
+ WESTON-DMABUF-FORMATS_LDLIBS += ${NV_PLATFORM_WINSYS_LIBS}

--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos_39.2.0.bb
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos_39.2.0.bb
@@ -10,6 +10,7 @@ SRC_URI += "\
     file://0002-weston-dmabuf-formats-cross-build-fixes.patch;patchdir=../../../.. \
     file://0003-Fix-use-of-wayland-protocols-in-nvgldemo-makefile.patch;patchdir=../../../.. \
     file://0004-weston-dmabuf-formats-Thor-compatibility-fixes.patch;patchdir=../../../.. \
+    file://0005-Remove-unneeded-libweston-linkage.patch;patchdir=../../../.. \
 "
 
 REQUIRED_DISTRO_FEATURES = "opengl"
@@ -20,7 +21,7 @@ inherit pkgconfig features_check
 
 PACKAGECONFIG ??= "${@bb.utils.filter('DISTRO_FEATURES', 'x11 wayland', d)}"
 PACKAGECONFIG[x11] = ",,libx11 virtual/libgbm"
-PACKAGECONFIG[wayland] = ",,libxkbcommon wayland wayland-native weston wayland-protocols libffi virtual/libgbm tegra-mmapi tegra-libraries-multimedia-utils"
+PACKAGECONFIG[wayland] = ",,libxkbcommon wayland wayland-native wayland-protocols libffi virtual/libgbm tegra-mmapi tegra-libraries-multimedia-utils"
 
 CONFIGURESTAMPFILE = "${WORKDIR}/configure.sstate"
 


### PR DESCRIPTION
The weston-dmabuf-formats makefile has, since time immemorial, linked directly against core weston libraries. It could be, that at some point in history, the code actually made direct calls to the weston core, but it certainly does not any longer.

Add a patch to remove the unnecessary linkage, and remove weston from the build dependencies.