### PR TITLE
Convert licenses to SPDX expressions

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.13.3.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Python bindings for TensorRT"
 HOMEPAGE = "http://developer.nvidia.com/tensorrt"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://python/packaging/bindings_wheel/LICENSE.txt;md5=0f58ca2991dd21e8f5c268a18ac2535b"
 
 DEPENDS = "python3-pybind11 tensorrt-core tensorrt-plugins"

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.3.0.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.3.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA TensorRT Plugins for deep learning"
 HOMEPAGE = "http://developer.nvidia.com/tensorrt"
-LICENSE = "Apache-2.0 & BSD-3-Clause & MIT"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = " \
   file://LICENSE;md5=5feff12211c5116f88277308f4b88a64 \
   file://third_party/cub/LICENSE.TXT;md5=20d1414b801e2a130d7d546685105508 \

--- a/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.19.1.bb
+++ b/external/virtualization-layer/recipes-containers/libnvidia-container/libnvidia-container_1.19.1.bb
@@ -19,7 +19,7 @@ DEPENDS = " \
     libtirpc \
     ldconfig-native \
 "
-LICENSE = "Apache-2.0 & MIT"
+LICENSE = "Apache-2.0 AND MIT"
 
 # Both source repositories include GPL COPYING (and for
 # libnvidia-container, COPYING.LESSER) files. However:

--- a/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.19.1.bb
+++ b/external/virtualization-layer/recipes-containers/nvidia-container-toolkit/nvidia-container-toolkit_1.19.1.bb
@@ -7,7 +7,7 @@ HOMEPAGE = "https://github.com/NVIDIA/nvidia-container-runtime"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-LICENSE = "Apache-2.0 & MIT & ISC & MPL-2.0 & (Apache-2.0 | MIT) & BSD-3-Clause"
+LICENSE = "Apache-2.0 AND MIT AND ISC AND MPL-2.0 AND (Apache-2.0 OR MIT) AND BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
                     file://src/${GO_IMPORT}/vendor/tags.cncf.io/container-device-interface/LICENSE;md5=86d3f3a95c324c9479bd8986968f4327 \
                     file://src/${GO_IMPORT}/vendor/github.com/davecgh/go-spew/LICENSE;md5=c06795ed54b2a35ebeeb543cd3a73e56 \

--- a/recipes-bsp/tegra-binaries/nvidia-l4t-optee_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/nvidia-l4t-optee_39.2.0.bb
@@ -18,10 +18,10 @@ LIC_FILES_CHKSUM += " \
     file://usr/share/doc/nvidia-l4t-optee/LICENSE.optee_client;md5=69663ab153298557a59c67a60a743e5b \
     file://usr/share/doc/nvidia-l4t-optee/LICENSE.82154947-c1bc-4bdf-b89d-04f93c0ea97c.ta;md5=6938d70d5e5d49d31049419e85bb82f8 \
 "
-LICENSE += "& BSD-2-Clause & BSD-3-Clause & GPL-2.0-only"
-LICENSE:${PN} = "BSD-2-Clause & BSD-3-Clause"
+LICENSE += "AND BSD-2-Clause AND BSD-3-Clause AND GPL-2.0-only"
+LICENSE:${PN} = "BSD-2-Clause AND BSD-3-Clause"
 LICENSE:${PN}-base-tas = "BSD-2-Clause"
-LICENSE:${PN}-test = "GPL-2.0-only & BSD-2-Clause"
+LICENSE:${PN}-test = "GPL-2.0-only AND BSD-2-Clause"
 LICENSE:${PN}-nvsamples = "BSD-2-Clause"
 
 PROVIDES += "optee-client optee-test optee-nvsamples"

--- a/recipes-bsp/tegra-binaries/tegra-binaries-39.2.0.inc
+++ b/recipes-bsp/tegra-binaries/tegra-binaries-39.2.0.inc
@@ -1,4 +1,4 @@
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=376d20bd5275442226fcdf54e4844ddf"
 
 SRC_URI = "\

--- a/recipes-bsp/tegra-binaries/tegra-debian-libraries-common.inc
+++ b/recipes-bsp/tegra-binaries/tegra-debian-libraries-common.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "https://developer.nvidia.com/embedded-computing"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 
 L4T_DEB_COPYRIGHT_MD5 ??= ""
 L4T_DEB_TRANSLATED_BPN ?= "${@d.getVar('BPN').replace('tegra-libraries-', 'nvidia-l4t-')}"

--- a/recipes-bsp/tegra-binaries/tegra-flashtools_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-flashtools_39.2.0.bb
@@ -1,4 +1,4 @@
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=376d20bd5275442226fcdf54e4844ddf"
 
 SRC_URI = "\

--- a/recipes-bsp/tegra-binaries/tegra-libraries-camera_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-camera_39.2.0.bb
@@ -3,7 +3,7 @@ DEPENDS = "tegra-libraries-core tegra-libraries-multimedia tegra-libraries-multi
 
 require tegra-debian-libraries-common.inc
 
-LICENSE += "& BSD-3-Clause"
+LICENSE += "AND BSD-3-Clause"
 LIC_FILES_CHKSUM += "\
     file://usr/share/doc/nvidia-l4t-camera/LICENSE.libnvargus;md5=271791ce6ff6f928d44a848145021687 \
     file://usr/share/doc/nvidia-l4t-camera/LICENSE.libnvcam_imageencoder;md5=059e39d33711ff9e6a76760cffcf0811 \

--- a/recipes-bsp/tegra-binaries/tegra-libraries-core_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-core_39.2.0.bb
@@ -2,7 +2,7 @@ L4T_DEB_COPYRIGHT_MD5 = "d9a8361f8068fc4e3b934118d1de9f3f"
 
 require tegra-debian-libraries-common.inc
 
-LICENSE += "& Apache-2.0"
+LICENSE += "AND Apache-2.0"
 LIC_FILES_CHKSUM += "file://usr/share/doc/nvidia-l4t-core/LICENSE.libnvidia-rmapi-tegra;md5=5c7c5200a29e873064f17b5bbf4d3c56"
 
 MAINSUM = "f364c7e11437e4137d29eb08bac965da7c6c39624088ebfa22f4342d9ad5bcf7"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-ds_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-multimedia-ds_39.2.0.bb
@@ -5,7 +5,7 @@ L4T_DEB_TRANSLATED_BPN = "nvidia-l4t-multimedia"
 
 require tegra-debian-libraries-common.inc
 
-LICENSE += "& MIT & BSD-3-Clause"
+LICENSE += "AND MIT AND BSD-3-Clause"
 
 MAINSUM = "ea71387feea6c60af41608084c82374596bced0258ac8c40e0de9e2642938ab5"
 

--- a/recipes-bsp/tegra-binaries/tegra-libraries-nvsci_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-nvsci_39.2.0.bb
@@ -3,7 +3,7 @@ DEPENDS = "tegra-libraries-core tegra-libraries-adaruntime"
 
 require tegra-debian-libraries-common.inc
 
-LICENSE += "& MIT"
+LICENSE += "AND MIT"
 LIC_FILES_CHKSUM += "file://usr/share/doc/nvidia-l4t-nvsci/LICENSE.libnvscibuf;md5=0cd5a346aecd6451e0224bf024e84756"
 
 MAINSUM = "35e31b63db4739040b036ef4a473743ced965c42c209c1cd8bd7e29b3c0408a0"

--- a/recipes-bsp/uefi/edk2-firmware-core-tegra-39.2.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-core-tegra-39.2.0.inc
@@ -1,4 +1,4 @@
-LICENSE .= " & Proprietary"
+LICENSE .= " AND LicenseRef-Proprietary"
 
 LIC_FILES_CHKSUM = "file://License.txt;md5=2b415520383f7964e96700ae12b4570a"
 

--- a/recipes-bsp/uefi/edk2-firmware-tegra-39.2.0.inc
+++ b/recipes-bsp/uefi/edk2-firmware-tegra-39.2.0.inc
@@ -2,7 +2,7 @@ require edk2-firmware.inc
 require edk2-firmware-core-tegra-39.2.0.inc
 require conf/image-uefi.conf
 
-LICENSE .= " & Proprietary"
+LICENSE .= " AND LicenseRef-Proprietary"
 
 LIC_FILES_CHKSUM += "file://../edk2-platforms/License.txt;md5=2b415520383f7964e96700ae12b4570a"
 LIC_FILES_CHKSUM += "file://../edk2-nvidia/LICENSE;md5=52d8683e3d65a77ef84cc863e3f24f25"

--- a/recipes-devtools/cuda/cuda-shared-binaries.inc
+++ b/recipes-devtools/cuda/cuda-shared-binaries.inc
@@ -22,7 +22,7 @@ CUDA_DL_CLASS = "l4t_deb_pkgfeed"
 inherit ${CUDA_DL_CLASS}
 
 DESCRIPTION = "CUDA package ${PN}"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM ?= "file://usr/local/cuda-${CUDA_VERSION}/EULA.txt;md5=adab0e709d8c3b4c5f151392d2ff3a72"
 
 DEPENDS ?= "cuda-cudart"

--- a/recipes-devtools/cudnn/cudnn_9.20.0.46-1.bb
+++ b/recipes-devtools/cudnn/cudnn_9.20.0.46-1.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NVIDIA CUDA Deep Neural Network library"
 HOMEPAGE = "https://developer.nvidia.com/cudnn"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://usr/include/aarch64-linux-gnu/cudnn_v9.h;endline=48;md5=11e690c2afb545fc389ff0637693b996"
 
 inherit l4t_deb_pkgfeed

--- a/recipes-devtools/cupva/pva-sdk_2.5.4.bb
+++ b/recipes-devtools/cupva/pva-sdk_2.5.4.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Compute Unified Programmable Vision Accelerator SDK"
 HOMEPAGE = "https://www.nvidia.com"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://usr/share/doc/pva-sdk-${BASEVER}/copyright;md5=bb46a5b9fba375d52481253b20200701"
 
 inherit l4t_deb_pkgfeed

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-13.2.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-13.2.inc
@@ -13,7 +13,7 @@ FILESEXTRAPATHS =. "${FILE_DIRNAME}/gcc-for-nvcc:${FILE_DIRNAME}/gcc/backport:"
 DEPENDS =+ "mpfr gmp libmpc zlib zstd flex-native"
 NATIVEDEPS = "mpfr-native gmp-native libmpc-native zlib-native flex-native zstd-native"
 
-LICENSE = "GPL-3.0-with-GCC-exception & GPL-3.0-only"
+LICENSE = "GPL-3.0-or-later WITH GCC-exception-3.1 AND GPL-3.0-only"
 
 LIC_FILES_CHKSUM = "\
     file://COPYING;md5=59530bdf33659b29e73d4adb9f9f6552 \

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-common.inc
@@ -2,7 +2,7 @@ SUMMARY = "GNU cc and gcc C compilers"
 HOMEPAGE = "http://www.gnu.org/software/gcc/"
 DESCRIPTION = "The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Ada, Go, and D, as well as libraries for these languages (libstdc++,...). GCC was originally written as the compiler for the GNU operating system."
 SECTION = "devel"
-LICENSE = "GPL"
+LICENSE = "LicenseRef-GPL"
 
 NATIVEDEPS = ""
 

--- a/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-runtime.inc
+++ b/recipes-devtools/gcc-for-nvcc/gcc-for-nvcc-runtime.inc
@@ -4,7 +4,7 @@ SUMMARY = "Runtime libraries from GCC"
 
 # Over-ride the LICENSE set by gcc-${PV}.inc to remove "& GPLv3"
 # All gcc-runtime packages are now covered by the runtime exception.
-LICENSE = "GPL-3.0-with-GCC-exception"
+LICENSE = "GPL-3.0-or-later WITH GCC-exception-3.1"
 
 CXXFLAGS:remove = "-fvisibility-inlines-hidden"
 

--- a/recipes-devtools/gcc-for-nvcc/libgcc-for-nvcc-initial.inc
+++ b/recipes-devtools/gcc-for-nvcc/libgcc-for-nvcc-initial.inc
@@ -31,7 +31,7 @@ require libgcc-for-nvcc-common.inc
 
 DEPENDS = "virtual/cross-cc"
 
-LICENSE = "GPL-3.0-with-GCC-exception"
+LICENSE = "GPL-3.0-or-later WITH GCC-exception-3.1"
 
 PACKAGES = ""
 

--- a/recipes-devtools/gcc-for-nvcc/libgcc-for-nvcc.inc
+++ b/recipes-devtools/gcc-for-nvcc/libgcc-for-nvcc.inc
@@ -33,9 +33,9 @@ PACKAGES = "\
 
 # All libgcc source is marked with the exception.
 #
-LICENSE:${PN} = "GPL-3.0-with-GCC-exception"
-LICENSE:${PN}-dev = "GPL-3.0-with-GCC-exception"
-LICENSE:${PN}-dbg = "GPL-3.0-with-GCC-exception"
+LICENSE:${PN} = "GPL-3.0-or-later WITH GCC-exception-3.1"
+LICENSE:${PN}-dev = "GPL-3.0-or-later WITH GCC-exception-3.1"
+LICENSE:${PN}-dbg = "GPL-3.0-or-later WITH GCC-exception-3.1"
 
 
 FILES:${PN}-dev = "\

--- a/recipes-devtools/gie/tensorrt-trtexec-prebuilt_10.16.2.10-1.bb
+++ b/recipes-devtools/gie/tensorrt-trtexec-prebuilt_10.16.2.10-1.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "NVIDIA TensorRT Prebuilt Plugins for deep learning"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 
 inherit l4t_deb_pkgfeed features_check
 

--- a/recipes-devtools/nsight-systems/nsight-systems_2026.3.1.157-263138048394v0.bb
+++ b/recipes-devtools/nsight-systems/nsight-systems_2026.3.1.157-263138048394v0.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "NVIDIA Nsight Systems is a multi-core CPU sampling profiler that 
     provides an interactive view of captured profiling data, helping improve \
     overall application performance."
 HOMEPAGE = "https://developer.nvidia.com/nsight-systems"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 BASE_VERSION = "${@'.'.join(d.getVar('PV').split('.')[0:3])}"
 LIC_FILES_CHKSUM = "file://opt/nvidia/nsight-systems/${BASE_VERSION}/EULA.txt;md5=59a793e0da68faeaa65ccfa38d9408b4"
 

--- a/recipes-devtools/pva-sdk/pva-sdk_2.9.1.bb
+++ b/recipes-devtools/pva-sdk/pva-sdk_2.9.1.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "Compute Unified Programmable Vision Accelerator SDK"
 HOMEPAGE = "https://www.nvidia.com"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://usr/share/doc/pva-sdk-${BASEVER}/copyright;md5=bb46a5b9fba375d52481253b20200701"
 
 inherit l4t_deb_pkgfeed

--- a/recipes-devtools/vpi/libnvvpi4_4.1.3.bb
+++ b/recipes-devtools/vpi/libnvvpi4_4.1.3.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Vision Programming Interface(VPI) is an API for accelerated \
   computer vision and image processing for embedded systems."
 HOMEPAGE = "https://developer.nvidia.com/embedded/vpi"
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = " \
     file://opt/nvidia/vpi4/doc/LICENSE.Boost;md5=5babd6e46e208e82f5759113623a6059 \
     file://opt/nvidia/vpi4/doc/LICENSE.Ceres;md5=b25c1d0dcdc903abbcc42fc0d3c2bd7a \

--- a/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos_39.2.0.bb
+++ b/recipes-graphics/l4t-graphics-demos/l4t-graphics-demos_39.2.0.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "L4T graphics demo programs"
 require l4t-graphics-demos.inc
 
-LICENSE = "MIT & Proprietary"
+LICENSE = "MIT AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://README;endline=21;md5=050dd71cf7e1524e1c4047cde5d052d4 \
                     file://gears-cube/Makefile;endline=8;md5=a2d67caf4241d62192371ef03b193fea"
 

--- a/recipes-graphics/l4t-graphics-demos/l4t-nvidia-glheaders_39.2.0.bb
+++ b/recipes-graphics/l4t-graphics-demos/l4t-nvidia-glheaders_39.2.0.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://developer.nvidia.com/embedded"
 
 require l4t-graphics-demos.inc
 
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://include/GLES2/gl2ext_nv.h;endline=9;md5=fec8e0f064aa930eeb964b4149958073 \
                     file://include/EGL/eglext_nv.h;beginline=8;endline=16;md5=9f7d8800f2854b13b429ad32bd3ab7e1"
 

--- a/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
+++ b/recipes-kernel/nvidia-kernel-oot/nvidia-kernel-oot.inc
@@ -1,5 +1,5 @@
 DESCRIPTION = "Out-of-tree kernel modules and device trees for Jetson Linux platforms"
-LICENSE = "GPL-2.0-only & BSD-3-Clause & (MIT | GPL-2.0-only)"
+LICENSE = "GPL-2.0-only AND BSD-3-Clause AND (MIT OR GPL-2.0-only)"
 LIC_FILES_CHKSUM = "file://unifiedgpudisp/COPYING;md5=1d5fa2a493e937d5a4b96e5e03b90f7c \
                     file://Makefile;beginline=2;endline=2;md5=a670216ac93e92dc066b1a876610705f \
                     file://nvidia-oot/Makefile;endline=1;md5=829e563511c9a1d6d41f17a7a4989d6a"

--- a/recipes-multimedia/argus/tegra-mmapi-39.2.0.inc
+++ b/recipes-multimedia/argus/tegra-mmapi-39.2.0.inc
@@ -1,5 +1,5 @@
 HOMEPAGE = "http://developer.nvidia.com"
-LICENSE = "Proprietary & BSD-3-Clause"
+LICENSE = "LicenseRef-Proprietary AND BSD-3-Clause"
 
 SRC_COMMON_DEBS = "${@l4t_deb_pkgname(d, 'jetson-multimedia-api')};subdir=tegra-mmapi"
 PV .= "${@l4t_bsp_debian_version_suffix(d, pkgname='nvidia-l4t-jetson-multimedia-api')}"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvarguscamerasrc_1.0.0-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA nvarguscamerasrc GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://nvbufsurface.h;endline=9;md5=e8476dbd605c7006d494fc5383d994d3 \
                     file://README.txt;endline=25;md5=364434949752edc42711344c8401d55b \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor_1.20.5-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvcompositor_1.20.5-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA compositor GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://gstnvcompositor.h;beginline=64;endline=64;md5=4bc2fab8a765b0fc125c88f3b3c38d2f \
                     file://README.txt;endline=26;md5=d4da79f8cebc6b73ce481b090afa99ae \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nveglgles_1.2.3-r39.2.0.bb
@@ -1,6 +1,6 @@
 SUMMARY = "NVIDIA EGL/GLES GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "LGPL-2.0-or-later & MIT"
+LICENSE = "LGPL-2.0-or-later AND MIT"
 LIC_FILES_CHKSUM = "file://gst-libs/gst/egl/LICENSE.libgstnvegl-1.0;md5=de0f9dfa389a77a904a5a2919a9e6b08 \
                     file://LICENSE.libgstnveglglessink;md5=5cf2b0235eb3cb8f4073a66ecb29212a"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvipcpipeline_1.20.1-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvipcpipeline_1.20.1-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA-modified IPC pipeline GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "LGPL-2.1-only & BSD-3-Clause & Proprietary"
+LICENSE = "LGPL-2.1-only AND BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=aba133faf68bf941bf17b32a0b50f699 \
                     file://gstnvipcbufferpool.h;endline=27;md5=a3cdb0b800f9fb8ddbc7169f4254febc \
                     file://gstnvipcbufferpool.c;endline=10;md5=3f7bca09d7dd300b39cb2536807de1be"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc_1.0.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvsiplcamerasrc_1.0.0-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA nvsiplcamera GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://gstnvsipl.h;endline=29;md5=a94fb30f9bc256e10bfed0615bba9756 \
                     file://README.txt;endline=32;md5=06e37147d5873f2584371719d9887f89 \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvunixfd_1.20.1-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvunixfd_1.20.1-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA-modified unixfd GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "LGPL-2.1-only & Proprietary"
+LICENSE = "LGPL-2.1-only AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.gst-nvunixfd;md5=9625f2513c71cc788cdb110c47a3d9ca \
                     file://gstnvipcbufferpool.h;endline=10;md5=d9dae5d6e4678fa3c11acc234577e28c"
 

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc_1.14.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvv4l2camerasrc_1.14.0-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA v4l2camerasrc GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://nvbufsurface.h;endline=9;md5=e8476dbd605c7006d494fc5383d994d3 \
                     file://README.txt;endline=25;md5=afc286435ccd143c9a10b5d7a8c1dee1 \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv_1.20.5-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvidconv_1.20.5-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA video converter GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://nvbufsurface.h;endline=9;md5=e8476dbd605c7006d494fc5383d994d3 \
                     file://README.txt;endline=26;md5=d4da79f8cebc6b73ce481b090afa99ae \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideo4linux2_1.14.0-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA v4l2 GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "LGPL-2.0-only & BSD-3-Clause & Proprietary"
+LICENSE = "BSD-3-Clause AND LGPL-2.0-only AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.gst-nvvideo4linux2;md5=457fb5d7ae2d8cd8cabcc21789a37e5c \
                     file://README.txt;endline=11;md5=c5bf1833f4b7ed06fc647441eafc8f82 \
 "

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideosinks_1.14.0-r39.2.0.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-nvvideosinks_1.14.0-r39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA video sinks GStreamer plugin"
 SECTION = "multimedia"
-LICENSE = "LGPL-2.0-only & Proprietary"
+LICENSE = "LGPL-2.0-only AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.libgstnvvideosinks;md5=86ed1f32df3aaa376956e408540c024b \
                     file://README.txt;endline=11;md5=3670d068ae876bb6ea4c18beae2397ff \
 "

--- a/recipes-multimedia/gstreamer/libgstnvcustomhelper_39.2.0.bb
+++ b/recipes-multimedia/gstreamer/libgstnvcustomhelper_39.2.0.bb
@@ -1,6 +1,6 @@
 DESCRIPTION = "NVIDIA custom gstreamer events helper library"
 SECTION = "multimedia"
-LICENSE = "MIT & Proprietary"
+LICENSE = "MIT AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.libgstnvcustomhelper;md5=9e0fe9cd844e2cba9b43e7a16ad5d431 \
                     file://README;endline=11;md5=8a55074f13f4cdb3c9966343177e1f9e \
 "

--- a/recipes-multimedia/jetson-sipl-api/jetson-sipl-api_2.0.0-r39.2.0.bb
+++ b/recipes-multimedia/jetson-sipl-api/jetson-sipl-api_2.0.0-r39.2.0.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "The Safe Image Processing Library (SIPL) is NVIDIA modular, \
     extensible framework for camera and image sensor integration, image \
     processing, and control, which supports continuous streaming of image data from camera sensors. \
 "
-LICENSE = "Proprietary"
+LICENSE = "LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = "file://../../../share/doc/jetson_sipl_api/Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=376d20bd5275442226fcdf54e4844ddf"
 
 SRC_URI = "\

--- a/recipes-security/optee/optee-os-l4t.inc
+++ b/recipes-security/optee/optee-os-l4t.inc
@@ -1,7 +1,7 @@
 require optee-l4t.inc
 TEGRA_SRC_SUBARCHIVE_OPTS = "--strip-components=1 optee/optee_os"
 
-LICENSE = "BSD-2-Clause & Proprietary"
+LICENSE = "BSD-2-Clause AND LicenseRef-Proprietary"
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=2f6a2cb48b5cc5cd0bd3f87a836cb407 \
     file://LICENSE.NVIDIA;md5=ba16bc74328d76e24af960ba01c937dc \

--- a/recipes-security/optee/optee-test_4.6-l4t-r39.2.0.bb
+++ b/recipes-security/optee/optee-test_4.6-l4t-r39.2.0.bb
@@ -2,7 +2,7 @@ SUMMARY = "OP-TEE sanity testsuite"
 DESCRIPTION = "Open Portable Trusted Execution Environment - Test suite"
 HOMEPAGE = "https://www.op-tee.org/"
 
-LICENSE = "BSD-2-Clause & GPL-2.0-only"
+LICENSE = "BSD-2-Clause AND GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE.md;md5=a8fa504109e4cd7ea575bc49ea4be560"
 
 require optee-l4t.inc

--- a/recipes-support/libusbgx/libusbgx-tegra-initrd-flash_git.bb
+++ b/recipes-support/libusbgx/libusbgx-tegra-initrd-flash_git.bb
@@ -1,5 +1,5 @@
 SUMMARY = "USB Gadget neXt Configfs Library build for Tegra initrd flashing"
-LICENSE = "GPL-2.0-only & LGPL-2.1-only"
+LICENSE = "GPL-2.0-only AND LGPL-2.1-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
                     file://COPYING.LGPL;md5=4fbd65380cdd255951079008b364516c"
 

--- a/recipes-support/sbsigntool/sbsigntool_git.bb
+++ b/recipes-support/sbsigntool/sbsigntool_git.bb
@@ -1,5 +1,5 @@
 DESCRIPTION = "Utility for signing and verifying files for UEFI Secure Boot"
-LICENSE = "GPL-3.0-only & LGPL-2.1-only & LGPL-3.0-only & MIT"
+LICENSE = "GPL-3.0-only AND LGPL-2.1-only AND LGPL-3.0-only AND MIT"
 
 # sbsigntool statically links to libccan.a which is built with modules
 # passed to "create-ccan-tree" (and their dependencies). Therefore,


### PR DESCRIPTION
Recent changes in openembedded-core has made meta-tegra (and few other layers too) to produce a lot of license-related warnings. This PR chases the upstream and fixes them.