### PR TITLE
New recipes + Fixes 

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -196,7 +196,7 @@ prepare_binaries_t234() {
             wait_for_rcm
         fi
         rm -rf rcmboot_blob
-        if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU serial_number=$serial_number \
+        if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU RAMCODE=$RAMCODE serial_number=$serial_number \
               "$here/$FLASH_HELPER" --no-flash --datafile "$DATAFILE" --sign -u "$keyfile" -v "$sbk_keyfile" $instance_args \
               flash.xml.in $LNXFILE $ROOTFS_IMAGE; then
             cp secureflash.xml internal-secureflash.xml
@@ -217,7 +217,7 @@ prepare_binaries_t234() {
         # Even if there are no signable entries in the external device layout, we need the script to
         # apply its sed rewrites to the the xxxFILE tokens.
         . ./boardvars.sh
-        if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU \
+        if MACHINE=$MACHINE BOARDID=$BOARDID FAB=$FAB BOARDSKU=$BOARDSKU BOARDREV=$BOARDREV CHIPREV=$CHIPREV CHIP_SKU=$CHIP_SKU RAMCODE=$RAMCODE \
                             "$here/$FLASH_HELPER" --no-flash --sign --external-device --datafile "$DATAFILE" -u "$keyfile" -v "$sbk_keyfile" $instance_args \
                             external-flash.xml.in $LNXFILE $ROOTFS_IMAGE; then
             mv secureflash.xml external-secureflash.xml

--- a/recipes-bsp/tegra-binaries/tegra-libraries-camera_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-camera_39.2.0.bb
@@ -71,6 +71,7 @@ do_install() {
     install -d ${D}${sbindir}
     install -m755 ${B}/usr/sbin/nvargus-daemon ${D}${sbindir}/
     install -m755 ${B}/usr/sbin/nvtunerd ${D}${sbindir}/
+    install -m755 ${B}/usr/sbin/nvargus_nvraw ${D}${sbindir}/
     install -d ${D}${libdir}/nvsipl_drv
     install -m 0644 ${S}/usr/lib/nvsipl_drv/libnvsipl_qry_vb1940.so ${D}${libdir}/nvsipl_drv/
     install -m 0644 ${S}/usr/lib/nvsipl_drv/libnvsipl_qry_nova0_hawk.so ${D}${libdir}/nvsipl_drv/
@@ -78,12 +79,13 @@ do_install() {
     install -m 0644 ${S}/usr/lib/nvsipl_drv/libnvsipl_qry_smart_imx623.so ${D}${libdir}/nvsipl_drv/
 }
 
-PACKAGES =+ "tegra-libraries-argus-daemon-base ${PN}-nvtunerd ${PN}-sipl-vb1940 ${PN}-sipl-nova0-hawk ${PN}-sipl-imx728 ${PN}-sipl-imx623"
+PACKAGES =+ "tegra-libraries-argus-daemon-base ${PN}-nvtunerd ${PN}-nvraw ${PN}-sipl-vb1940 ${PN}-sipl-nova0-hawk ${PN}-sipl-imx728 ${PN}-sipl-imx623"
 FILES_SOLIBSDEV = ""
 SOLIBS = ".so*"
 FILES:${PN} += "${libdir}/libv4l/plugins"
 FILES:tegra-libraries-argus-daemon-base = "${sbindir}/nvargus-daemon"
 FILES:${PN}-nvtunerd = "${sbindir}/nvtunerd"
+FILES:${PN}-nvraw = "${sbindir}/nvargus_nvraw"
 FILES:${PN}-sipl-vb1940 = "${libdir}/nvsipl_drv/libnvsipl_qry_vb1940.so"
 FILES:${PN}-sipl-nova0-hawk = "${libdir}/nvsipl_drv/libnvsipl_qry_nova0_hawk.so"
 FILES:${PN}-sipl-imx728 = "${libdir}/nvsipl_drv/libnvsipl_qry_smart_imx728.so"

--- a/recipes-bsp/tegra-binaries/tegra-libraries-nvsci_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-libraries-nvsci_39.2.0.bb
@@ -1,5 +1,5 @@
 L4T_DEB_COPYRIGHT_MD5 = "661953981b9ae6f275ad01c67b2e881e"
-DEPENDS = "tegra-libraries-core tegra-libraries-adaruntime"
+DEPENDS = "tegra-libraries-core tegra-libraries-adaruntime tegra-nvsci-headers"
 
 require tegra-debian-libraries-common.inc
 

--- a/recipes-bsp/tegra-binaries/tegra-nvsci-headers_39.2.0.bb
+++ b/recipes-bsp/tegra-binaries/tegra-nvsci-headers_39.2.0.bb
@@ -1,0 +1,25 @@
+SUMMARY = "NvSci header files (build-time only)"
+HOMEPAGE = "https://developer.nvidia.com/embedded/jetpack"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://usr/share/doc/jetson_sipl_api/Tegra_Software_License_Agreement-Tegra-Linux.txt;md5=376d20bd5275442226fcdf54e4844ddf"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit l4t_bsp
+
+SRC_URI = "${L4T_URI_BASE}/Jetson_SIPL_API_R${L4T_VERSION}_aarch64.tbz2"
+SRC_URI[sha256sum] = "42d95cd4fb90ba32e87c7055d5659d818aa09c739d671bf48d857cc29496720b"
+
+S = "${UNPACKDIR}"
+
+NVSCI_HEADER_SRC = "${S}/usr/src/jetson_sipl_api/sipl/include/nvsci"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${includedir}
+    install -m 0644 ${NVSCI_HEADER_SRC}/*.h ${D}${includedir}/
+}
+
+FILES:${PN} = "${includedir}/"

--- a/recipes-devtools/python/python3-jetson-io_39.2.0.bb
+++ b/recipes-devtools/python/python3-jetson-io_39.2.0.bb
@@ -10,6 +10,7 @@ inherit python3native
 
 JETSON_IO_BASE = "/opt/nvidia/jetson-io"
 
+MAINSUM = "70d8b48d9a120aa75574b9ebdc359f82c2a9ad68e532a7d3dcec18465dfff9b8"
 SRC_URI += "file://0001-Jetson-board.py-fix-block-device-check-for-standard-.patch"
 
 do_install() {

--- a/recipes-graphics/vulkan-sc/tegra-libraries-vulkan-sc-core_39.2.0.bb
+++ b/recipes-graphics/vulkan-sc/tegra-libraries-vulkan-sc-core_39.2.0.bb
@@ -1,0 +1,51 @@
+SUMMARY = "NVIDIA Vulkan Safety Critical core driver library"
+HOMEPAGE = "https://developer.nvidia.com/embedded/jetpack"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM:tegra234 = "file://usr/share/doc/nvidia-l4t-vulkan-sc-nvgpu/copyright;md5=2efa2b52d37f190602d403961e089024"
+LIC_FILES_CHKSUM:tegra264 = "file://usr/share/doc/nvidia-l4t-vulkan-sc-openrm/copyright;md5=bf057ebea50d20e3884056bebc851ce6"
+
+COMPATIBLE_MACHINE = "(tegra234|tegra264)"
+
+inherit l4t_deb_pkgfeed features_check
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+MAINSUM:tegra234 = "ede7af97e0c4fa4cac52f2ced6c56a8d66d6aff1f5f094d45db5e92ee4518899"
+MAINSUM:tegra264 = "7dfed757e808dd95c6b97a8f06c9b29458574faca2952cf23c40d264ce5722da"
+
+SRC_SOC_DEBS:tegra234 = "${@l4t_deb_pkgname(d, 'vulkan-sc-nvgpu')};subdir=${BP};name=main"
+SRC_SOC_DEBS:tegra264 = "${@l4t_deb_pkgname(d, 'vulkan-sc-openrm')};subdir=${BP};name=main"
+
+SRC_URI[main.sha256sum] = "${MAINSUM}"
+
+S = "${UNPACKDIR}/${BP}"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install:tegra234() {
+    install -d ${D}${libdir}
+    install -m 0644 ${S}/opt/nvidia/l4t-gpu-libs/nvgpu/libnvidia-vksc-core.so.${L4T_LIB_VERSION} ${D}${libdir}/
+    ln -sf libnvidia-vksc-core.so.${L4T_LIB_VERSION} ${D}${libdir}/libnvidia-vksc-core.so.1
+    ln -sf libnvidia-vksc-core.so.1 ${D}${libdir}/libnvidia-vksc-core.so
+}
+
+do_install:tegra264() {
+    install -d ${D}${libdir}
+    install -m 0644 ${S}/opt/nvidia/l4t-gpu-libs/openrm/libnvidia-vksc-openrm.so.${L4T_LIB_VERSION} ${D}${libdir}/
+    ln -sf libnvidia-vksc-openrm.so.${L4T_LIB_VERSION} ${D}${libdir}/libnvidia-vksc-openrm.so.1
+    ln -sf libnvidia-vksc-openrm.so.1 ${D}${libdir}/libnvidia-vksc-openrm.so
+    ln -sf libnvidia-vksc-openrm.so.${L4T_LIB_VERSION} ${D}${libdir}/libnvidia-vksc-core.so.1
+    ln -sf libnvidia-vksc-core.so.1 ${D}${libdir}/libnvidia-vksc-core.so
+}
+
+FILES_SOLIBSDEV = ""
+SOLIBS = ".so*"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+INSANE_SKIP = "dev-so ldflags"
+RDEPENDS:${PN} += "tegra-libraries-core tegra-libraries-eglcore tegra-libraries-nvsci"
+
+PACKAGE_ARCH = "${SOC_FAMILY_PKGARCH}"

--- a/recipes-graphics/vulkan-sc/tegra-libraries-vulkan-sc_39.2.0.bb
+++ b/recipes-graphics/vulkan-sc/tegra-libraries-vulkan-sc_39.2.0.bb
@@ -1,0 +1,70 @@
+SUMMARY = "NVIDIA Vulkan Safety Critical loader, validation layers, and dev headers"
+HOMEPAGE = "https://developer.nvidia.com/embedded/jetpack"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "\
+    file://usr/share/doc/nvidia-l4t-vulkan-sc-sdk/copyright;md5=fea1f6ae9b5b80f1b769ae7c6cd85882 \
+    file://usr/share/doc/nvidia-l4t-vulkan-sc-dev/copyright;md5=7b227641d976dcc6d473fb345610ac57 \
+"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit l4t_deb_pkgfeed features_check
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+# Both debs merge into the same subdir so S gives access to all contents.
+SRC_SOC_DEBS = "\
+    ${@l4t_deb_pkgname(d, 'vulkan-sc-sdk')};subdir=${BP};name=sdk \
+    ${@l4t_deb_pkgname(d, 'vulkan-sc-dev')};subdir=${BP};name=dev \
+"
+SRC_URI[sdk.sha256sum] = "c6fdc0068ecd8c2b2d111e3d299a8b361c46a940f74249e1b4044e93b712676d"
+SRC_URI[dev.sha256sum] = "5116179b14efadacccb6b7ada10cf2b6d5051c067155ad466615b0fb831cd303"
+
+S = "${UNPACKDIR}/${BP}"
+
+VKSC_SDK_VERSION = "1.0.10"
+
+INHIBIT_PACKAGE_STRIP = "1"
+INHIBIT_SYSROOT_STRIP = "1"
+INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
+PACKAGE_ARCH = "${L4T_BSP_PKGARCH}"
+
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+do_install() {
+    install -d ${D}${libdir}
+    install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/nvidia/libvulkansc.so.${VKSC_SDK_VERSION} ${D}${libdir}/
+    ln -sf libvulkansc.so.${VKSC_SDK_VERSION} ${D}${libdir}/libvulkansc.so.1
+    ln -sf libvulkansc.so.1 ${D}${libdir}/libvulkansc.so
+    install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/nvidia/libVkLayer_json_gen.so ${D}${libdir}/
+    install -m 0644 ${S}/usr/lib/aarch64-linux-gnu/nvidia/libVkSCLayer_khronos_validation.so ${D}${libdir}/
+
+    install -d ${D}${sysconfdir}/vulkansc/icd.d
+    install -m 0644 ${S}/etc/vulkansc/icd.d/*.json ${D}${sysconfdir}/vulkansc/icd.d/
+
+    # Headers from the dev deb, needed for cross-compile sysroot population
+    install -d ${D}${includedir}/VulkanSC/vulkan
+    install -m 0644 ${S}/usr/include/VulkanSC/vulkan/* ${D}${includedir}/VulkanSC/vulkan/
+
+    install -d ${D}${bindir}
+    install -m 0755 ${S}/usr/bin/pcc ${D}${bindir}/
+}
+
+FILES_SOLIBSDEV = ""
+SOLIBS = ".so*"
+
+FILES:${PN} = "\
+    ${libdir}/libvulkansc.so.* \
+    ${libdir}/libVkLayer_json_gen.so \
+    ${libdir}/libVkSCLayer_khronos_validation.so \
+    ${sysconfdir}/vulkansc/ \
+    ${bindir}/pcc \
+"
+FILES:${PN}-dev = "\
+    ${libdir}/libvulkansc.so \
+    ${includedir}/VulkanSC/ \
+"
+
+INSANE_SKIP = "dev-so ldflags"
+RDEPENDS:${PN} += "libssl libcrypto tegra-libraries-vulkan-sc-core"

--- a/recipes-graphics/vulkan-sc/tegra-vulkan-sc-samples/0001-fix-oe-cross-compile-paths.patch
+++ b/recipes-graphics/vulkan-sc/tegra-vulkan-sc-samples/0001-fix-oe-cross-compile-paths.patch
@@ -1,0 +1,49 @@
+From: Kurt Kiefer <kkiefer@nvidia.com>
+Subject: [PATCH] Fix include/lib paths for OE cross-compile
+
+When CMAKE_SYSROOT is set (OE cross-compile into a staging sysroot),
+absolute paths like "/usr/include" are NOT automatically prefixed by gcc
+--sysroot.  Prefix all include paths and library hint paths with
+${CMAKE_SYSROOT} so cmake's find_library() and target_include_directories()
+resolve against the OE staging sysroot rather than the host filesystem.
+
+Also set TARGET_LIB_PATH to ${_SYSROOT}/usr/lib/nvidia and ${_SYSROOT}/usr/lib
+so libvulkansc.so (installed by tegra-libraries-vulkan-sc to ${libdir}/nvidia/)
+is found. OE uses /usr/lib/ flat — not the Debian /usr/lib/aarch64-linux-gnu/
+multilib layout.
+
+Upstream-Status: Inappropriate (OE-specific)
+Signed-off-by: Kurt Kiefer <kkiefer@nvidia.com>
+---
+--- a/CMakeLists.txt	2026-07-17 08:49:02.666271983 -0700
++++ b/CMakeLists.txt	2026-07-17 08:49:02.666565017 -0700
+@@ -75,15 +75,24 @@
+     set(VULKANSC_LIB_PATH "${TARGET_LIB_PATH}")
+     message("VulkanSC lib DIR: ${VULKAN_LIB_PATH}")
+ else()
+-    # For target build, need to override header path and lib path
+-    # TODO: No vulkan headers packaged to target_rootfs
+-    set(VULKAN_HEADER_PATH "/usr/include")
++    # For target build (or OE cross-compile), override header and lib paths.
++    # When CMAKE_SYSROOT is set by the OE cmake class, prefix absolute paths
++    # so they resolve into the staging sysroot rather than the host.
++    if (CMAKE_SYSROOT)
++        set(_SYSROOT "${CMAKE_SYSROOT}")
++    else()
++        set(_SYSROOT "")
++    endif()
++
++    set(VULKAN_HEADER_PATH "${_SYSROOT}/usr/include")
+     message("Vulkan header DIR: ${VULKAN_HEADER_PATH}")
+ 
+-    set(VULKANSC_HEADER_PATH "/usr/include/VulkanSC")
++    set(VULKANSC_HEADER_PATH "${_SYSROOT}/usr/include/VulkanSC")
+     message("VulkanSC header DIR: ${VULKANSC_HEADER_PATH}")
+ 
+-    set(TARGET_LIB_PATH "/usr/lib/aarch64-linux-gnu;/usr/lib;/usr/lib/aarch64-linux-gnu/tegra")
++    set(TARGET_LIB_PATH
++        "${_SYSROOT}/usr/lib/nvidia"
++        "${_SYSROOT}/usr/lib")
+     set(VULKAN_LIB_PATH "${TARGET_LIB_PATH}")
+     message("Vulkan lib DIR: ${VULKAN_LIB_PATH}")
+ 

--- a/recipes-graphics/vulkan-sc/tegra-vulkan-sc-samples_39.2.0.bb
+++ b/recipes-graphics/vulkan-sc/tegra-vulkan-sc-samples_39.2.0.bb
@@ -1,0 +1,72 @@
+SUMMARY = "NVIDIA Vulkan Safety Critical sample applications (built from source)"
+HOMEPAGE = "https://developer.nvidia.com/embedded/jetpack"
+LICENSE = "Proprietary"
+LIC_FILES_CHKSUM = "file://license.txt;md5=dcf473723faabf17baa9b5f2207599d0"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+inherit l4t_deb_pkgfeed cmake features_check
+
+REQUIRED_DISTRO_FEATURES = "vulkan"
+
+SRC_SOC_DEBS = "${@l4t_deb_pkgname(d, 'vulkan-sc-samples')};subdir=${BP};name=main"
+SRC_URI[main.sha256sum] = "479fdb8594724b7c8a1fe30909d3d7e7f52bfddcfa5e0ae437d03e405a5ef59e"
+
+SRC_URI:append = " file://0001-fix-oe-cross-compile-paths.patch"
+
+# tegra-libraries-vulkan-sc provides: libvulkansc.so + VulkanSC headers for build
+# tegra-libraries-nvsci provides: libnvscibuf.so.1 and libnvscisync.so.1
+# tegra-libraries-openwfd provides: libtegrawfd.so
+# vulkan-loader provides: libvulkan.so (for the non-SC vk_01tri / vk_computeparticles targets)
+DEPENDS = "\
+    tegra-libraries-vulkan-sc \
+    tegra-libraries-nvsci \
+    tegra-libraries-openwfd \
+    vulkan-loader \
+    libglvnd \
+"
+
+S = "${UNPACKDIR}/${BP}/usr/src/nvidia/vulkan-sc/vulkan-sc-ecosystem/vulkan-sc-sample"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/bin/vksc_01tri ${D}${bindir}/
+    install -m 0755 ${B}/bin/vk_01tri ${D}${bindir}/
+    install -m 0755 ${B}/bin/vksc_computeparticles ${D}${bindir}/
+    install -m 0755 ${B}/bin/vk_computeparticles ${D}${bindir}/
+    install -m 0755 ${B}/bin/vulkanscinfo ${D}${bindir}/
+
+    # Pipeline cache, pre-compiled SPIR-V, and texture data referenced at runtime
+    install -d ${D}${datadir}/vulkan-sc/data
+    find ${B}/bin/data -mindepth 1 -type d | while read dir; do
+        install -d ${D}${datadir}/vulkan-sc/data/${dir#${B}/bin/data/}
+    done
+    find ${B}/bin/data -type f | while read f; do
+        install -m 0644 "$f" ${D}${datadir}/vulkan-sc/data/${f#${B}/bin/data/}
+    done
+}
+
+FILES:${PN} = "${bindir}/ ${datadir}/vulkan-sc/"
+
+RDEPENDS:${PN} = "\
+    tegra-libraries-vulkan-sc \
+    tegra-libraries-nvsci \
+    tegra-libraries-openwfd \
+    vulkan-loader \
+    libglvnd \
+"
+
+# Pipeline caches must be compiled on-target by pcc (provided by tegra-libraries-vulkan-sc)
+# since they encode GPU microarchitecture-specific binary.
+VKSC_PCC_CHIP ??= ""
+VKSC_PCC_CHIP:tegra234 = "ga10b"
+VKSC_PCC_CHIP:tegra264 = "gb10b"
+
+pkg_postinst_ontarget:${PN}() {
+    test -z "${VKSC_PCC_CHIP}" && exit 0
+    for pipeline_dir in ${datadir}/vulkan-sc/data/pipeline/*/; do
+        pcc -chip "${VKSC_PCC_CHIP}" \
+            -path "$pipeline_dir" \
+            -out "${pipeline_dir}pipeline_cache.bin" || true
+    done
+}

--- a/recipes-multimedia/gstreamer/nvgstapps_39.2.0.bb
+++ b/recipes-multimedia/gstreamer/nvgstapps_39.2.0.bb
@@ -3,6 +3,7 @@ SECTION = "multimedia"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://nvgst_sample_apps/nvgstcapture-1.0/nvgstcapture-1.0_README.txt;endline=21;md5=75e7c2d08d6618cb836cbef46b410515 \
                     file://nvgst_sample_apps/nvgstplayer-1.0/nvgstplayer-1.0_README.txt;endline=21;md5=694cc29d69c54345f88511643308aae5 \
+                    file://nvgst_sample_apps/nvgstipctestapp-1.0/LICENSE.nvgstipctestapp-1.0;md5=7a741546263d60716bc5f6a387e30ad9 \
 "
 
 TEGRA_SRC_SUBARCHIVE = "Linux_for_Tegra/source/nvgstapps_src.tbz2"
@@ -36,6 +37,19 @@ do_compile() {
             ${S}/nvgst_sample_apps/nvgstplayer-1.0/nvgst_asound_common.c ${S}/nvgst_sample_apps/nvgstplayer-1.0/nvgst_x11_common.c ${LDFLAGS} \
             $(pkg-config --cflags --libs gstreamer-1.0 gstreamer-plugins-base-1.0 gstreamer-pbutils-1.0 x11 xext gstreamer-video-1.0 alsa) -ldl
     fi
+    ${CC} ${CFLAGS} \
+        -o ${B}/nvgstipctestapp-1.0 \
+        ${S}/nvgst_sample_apps/nvgstipctestapp-1.0/nvgstipctestapp.c \
+        ${LDFLAGS} \
+        $(pkg-config --cflags --libs \
+            gstreamer-1.0 \
+            gstreamer-base-1.0 \
+            gstreamer-video-1.0 \
+            gstreamer-allocators-1.0 \
+            gstreamer-audio-1.0 \
+            gstreamer-app-1.0 \
+            glib-2.0 gobject-2.0) \
+        -ldl -lm -lpthread
 }
 
 do_install() {
@@ -45,13 +59,15 @@ do_install() {
     if [ "$WITH_NVGSTPLAYER" = "yes" ]; then
         install -m 0755 ${B}/nvgstplayer-1.0 ${D}${bindir}/
     fi
+    install -m 0755 ${B}/nvgstipctestapp-1.0 ${D}${bindir}/
 }
 
-PACKAGES =+ "nvgstcapture nvgstplayer"
+PACKAGES =+ "nvgstcapture nvgstplayer nvgstipctestapp"
 FILES:nvgstplayer = "${bindir}/nvgstplayer-1.0"
 FILES:nvgstcapture = "${bindir}/nvgstcapture-1.0"
+FILES:nvgstipctestapp = "${bindir}/nvgstipctestapp-1.0"
 ALLOW_EMPTY:nvgstplayer = "1"
 ALLOW_EMPTY:${PN} = "1"
-RDEPENDS:${PN} = "nvgstcapture nvgstplayer"
+RDEPENDS:${PN} = "nvgstcapture nvgstplayer nvgstipctestapp"
 RRECOMMENDS:nvgstcapture = "gstreamer1.0-plugins-nvarguscamerasrc gstreamer1.0-plugins-nvv4l2camerasrc gstreamer1.0-plugins-good-video4linux2 gstreamer1.0-plugins-tegra"
 RRECOMMENDS:nvgstplayer = "gstreamer1.0-plugins-nveglgles gstreamer1.0-plugins-nvvideo4linux2 gstreamer1.0-plugins-nvvideosinks gstreamer1.0-plugins-nvjpeg gstreamer1.0-plugins-tegra"

--- a/recipes-multimedia/jetson-sipl-api/jetson-sipl-api/0001-Updates-for-OE-cross-builds.patch
+++ b/recipes-multimedia/jetson-sipl-api/jetson-sipl-api/0001-Updates-for-OE-cross-builds.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 1/2] Updates for OE cross builds
 Upstream-Status: Inappropriate [oe-specific]
 Signed-off-by: Ilies CHERGUI <ichergui@nvidia.com>
 ---
- CMakeLists.txt | 56 ++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 56 insertions(+)
+ CMakeLists.txt | 57 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 57 insertions(+)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index aa64eac..c468703 100644
@@ -56,8 +56,8 @@ index aa64eac..c468703 100644
 +)
 +
 +# Collect all public headers recursively (includes nvsci/, nvmedia/, WF/, query/include/,
-+# and capture/include/ for the NvFusaCaptureExternal* interface) then filter out the three
-+# nvbufsurface* headers owned by a separate multimedia package.
++# and capture/include/ for the NvFusaCaptureExternal* interface) then filter out headers
++# owned by other packages: nvbufsurface* (multimedia) and nvsci* (tegra-nvsci-headers).
 +file(GLOB_RECURSE SIPL_HEADERS
 +    "${CMAKE_CURRENT_SOURCE_DIR}/include/*.hpp"
 +    "${CMAKE_CURRENT_SOURCE_DIR}/include/*.h"
@@ -65,7 +65,7 @@ index aa64eac..c468703 100644
 +    "${CMAKE_CURRENT_SOURCE_DIR}/capture/include/*.h"
 +)
 +list(FILTER SIPL_HEADERS EXCLUDE REGEX
-+    ".*(nvbufsurface_nvscibuf\\.h|nvbufsurface\\.h|nvbufsurftransform\\.h)$"
++    ".*(nvbufsurface_nvscibuf\\.h|nvbufsurface\\.h|nvbufsurftransform\\.h|nvsci[^/]*\\.h)$"
 +)
 +# Install all headers flat — no nvsci/, nvmedia/, WF/, or query/include/ subdirectories.
 +install(FILES ${SIPL_HEADERS}

--- a/recipes-multimedia/jetson-sipl-api/jetson-sipl-api_2.0.0-r39.2.0.bb
+++ b/recipes-multimedia/jetson-sipl-api/jetson-sipl-api_2.0.0-r39.2.0.bb
@@ -16,7 +16,7 @@ inherit l4t_bsp cmake cuda features_check
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-DEPENDS += "tegra-libraries-camera tegra-libraries-nvsci tegra-libraries-openwfd fmt virtual/egl virtual/libgles2 libx11"
+DEPENDS += "tegra-nvsci-headers tegra-libraries-camera tegra-libraries-nvsci tegra-libraries-openwfd fmt virtual/egl virtual/libgles2 libx11"
 
 REQUIRED_DISTRO_FEATURES = "x11"
 


### PR DESCRIPTION
* tegra-helper-scripts: forward RAMCODE to RCM-boot BCT generation on T234
* python3-jetson-io: set MAINSUM for the L4T debian package
* vulkan-sc: add tegra-libraries-vulkan-sc and tegra-vulkan-sc-samples
* vulkan-sc: add tegra-libraries-vulkan-sc-core
* jetson-sipl-api: add tegra-nvsci-headers dep, exclude nvsci headers from install
* tegra-libraries-nvsci: add build dependency on tegra-nvsci-headers
* tegra-nvsci-headers: add recipe for NvSci build-time headers
* nvgstapps: add nvgstipctestapp
* tegra-libraries-camera: package nvargus_nvraw binary