### PR TITLE
initrd-flash: fix unmounting of automounted partitions

### DIFF
--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/initrd-flash.sh
@@ -242,22 +242,20 @@ run_rcm_boot_t234() {
 
 mount_partition() {
     local dev="$1"
-    local mnt=$(cat /proc/mounts | grep "^$dev" | cut -d' ' -f2)
-    local i=$(echo $mnt|awk -F' ' '{print NF}')
+    local mnt=$(cat /proc/mounts | grep "^$dev " | cut -d' ' -f2)
     local j
-    while [ $i -ne 0 ]; do
-        local mnt=$(echo ${mnt} | cut -d' ' -f$i)
-        if ! umount "${mnt}" > /dev/null 2>&1; then
-            echo "ERR: unmount ${mnt} on device $dev failed" >&2
+    local m
+    for m in $mnt; do
+        if ! umount "$m" > /dev/null 2>&1; then
+            echo "ERR: unmount $m on device $dev failed" >&2
             return 1
         fi
-        i=$(expr $i - 1)
     done
 
     if udisksctl mount -b "$dev" > /dev/null 2>&1; then
         for j in 1 2 3 4 5; do
             sleep 1
-            mnt=$(cat /proc/mounts | grep "^$dev" | cut -d' ' -f2)
+            mnt=$(cat /proc/mounts | grep "^$dev " | cut -d' ' -f2)
             if [ -n "$mnt" ]; then
                 echo "$mnt"
                 return 0

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -181,13 +181,14 @@ copy_to_device() {
 
 unmount_device() {
     local dev="$1"
-    local mnt=$(cat /proc/mounts | grep "^$dev" | cut -d' ' -f2)
-    if [ -n "$mnt" ]; then
-        if ! umount "${mnt}" > /dev/null 2>&1; then
-            echo "ERR: unmount ${mnt} on device $dev failed" >&2
+    local mnt=$(cat /proc/mounts | grep "^$dev " | cut -d' ' -f2)
+    local m
+    for m in $mnt; do
+        if ! umount "$m" > /dev/null 2>&1; then
+            echo "ERR: unmount $m on device $dev failed" >&2
             return 1
         fi
-    fi
+    done
     return 0
 }
 


### PR DESCRIPTION
mount_partition() looks up the mountpoints of the target device with a prefix match on /proc/mounts, so for /dev/sdX1 it also picks up /dev/sdX10 and above when the desktop has automounted them. The unmount loop then trips over the extra entries: it reassigns mnt while indexing through the list, so the second iteration retries the mountpoint it just unmounted and bails out:

  ERR: unmount /media/user/4bafadc4-... on device /dev/sdf1 failed

Anchor the match on the whole device name and iterate over the list.

Seen on an Orin Nano with an 18-partition layout: after one flash the two-digit partitions carry filesystems, the desktop automounts them, and the next initrd-flash run fails to unmount /dev/sdf1.