### PR TITLE
Minor Orin Nano storage fixes

### DIFF
--- a/conf/machine/jetson-orin-nano-devkit-nvme.conf
+++ b/conf/machine/jetson-orin-nano-devkit-nvme.conf
@@ -7,6 +7,7 @@ TNSPEC_BOOTDEV ?= "nvme0n1p1"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi.xml"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT_SUPPORTS_REDUNDANT ?= "1"
 PARTITION_LAYOUT_EXTERNAL_DEFAULT ?= "flash_l4t_t234_nvme.xml"
+TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
 
 require conf/machine/include/orin-nano.inc
 require conf/machine/include/p3768.inc

--- a/conf/machine/jetson-orin-nano-devkit.conf
+++ b/conf/machine/jetson-orin-nano-devkit.conf
@@ -5,6 +5,5 @@
 require conf/machine/include/orin-nano.inc
 require conf/machine/include/p3768.inc
 
-TNSPEC_BOOTDEV_DEFAULT ?= "mmcblk1p1"
 TEGRAFLASH_SDCARD_SIZE ?= "32G"
 PARTITION_LAYOUT_TEMPLATE_DEFAULT ?= "flash_t234_qspi_sd.xml"


### PR DESCRIPTION
Two minor fixes related to uSD/eMMC handling on an Orin Nano.

d218b2a700d41e3ba2efa7425fa7bcb35cee02a0 saves the uSD card content in the corner case situation that the card is present while flashing the NVME through `tegraflash`
a043d29f12e6ee646ca95ee4197f9a083d1eb06f is just an inert default variable assignment cleanup.