### PR TITLE
Drop deprecated gptfdisk dependency

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -560,7 +560,7 @@ tegra_mksparse() {
 
 IMAGE_CMD:tegraflash-tar = "create_tegraflash_pkg"
 do_image_tegraflash_tar[depends] += "dtc-native:do_populate_sysroot coreutils-native:do_populate_sysroot \
-                                 tegra-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
+                                 tegra-flashtools-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
                                  ${TEGRA_RCM_EDK2_DEPENDS} virtual/kernel:do_deploy \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \

--- a/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
+++ b/recipes-core/initrdscripts/tegra-flash-init/init-flash.sh
@@ -201,8 +201,8 @@ else
 			if wait_for_connect 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log; then
 			    if wait_for_disconnect 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log; then
 				partprobe /dev/$dev 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
-				sgdisk /dev/$dev --verify 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
-				sgdisk /dev/$dev --print 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
+				sfdisk --verify /dev/$dev 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
+				sfdisk -l /dev/$dev 2>&1 >> /tmp/flashpkg/flashpkg/logs/export-$dev.log
 				continue
 			    fi
 			fi

--- a/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
+++ b/recipes-core/initrdscripts/tegra-flash-init_1.0.bb
@@ -39,7 +39,7 @@ do_install() {
 }
 
 FILES:${PN} = "/"
-RDEPENDS:${PN} = "util-linux-blkdiscard mtd-utils e2fsprogs-mke2fs libusbgx-tegra-initrd-flash gptfdisk tegra-firmware kmod parted"
+RDEPENDS:${PN} = "util-linux-blkdiscard mtd-utils e2fsprogs-mke2fs libusbgx-tegra-initrd-flash util-linux-sfdisk tegra-firmware kmod parted"
 RRECOMMENDS:${PN} = "kernel-module-libcomposite \
                      kernel-module-usb-f-mass-storage \
 "


### PR DESCRIPTION
`oe-core` removed the gptfdisk recipe ([commit](https://git.openembedded.org/openembedded-core/commit/?id=188d84bcc136e87d03736606fb8e49f35df47fae)), so this layer no longer builds on `master`.

- `image_types_tegra` declared `gptfdisk-native`, but nothing in the class
  runs sgdisk, except `make_sdcard`, which runs on the flashing host.
- `tegra-flash-init` used sgdisk, replaced by sfdisk now.

make-sdcard.sh still needs sgdisk on the flashing host, but I left this unchanged since this is a flashing host dependency.