### PR TITLE
optee: use Type=notify for tee-supplicant.service

### DIFF
--- a/recipes-security/optee/optee-client/tee-supplicant.service.in
+++ b/recipes-security/optee/optee-client/tee-supplicant.service.in
@@ -2,7 +2,7 @@
 Description=TEE Supplicant
 
 [Service]
-Type=exec
+Type=notify
 User=root
 EnvironmentFile=-@sysconfdir@/default/tee-supplicant
 ExecStart=@sbindir@/tee-supplicant $OPTARGS


### PR DESCRIPTION
tee-supplicant sends READY=1 once it has opened the supplicant device and can serve the secure world (optee_client [a5b1ffcd](https://github.com/OP-TEE/optee_client/commit/a5b1ffcd26e328af0bbf18ab448a38ecd558e05c), v4.3.0), unlike Type=exec which only covers execve().