### PR TITLE
tegraflash: support encrypted initrd-flash partitions

### DIFF
--- a/classes-recipe/image_types_tegra.bbclass
+++ b/classes-recipe/image_types_tegra.bbclass
@@ -395,6 +395,9 @@ tegraflash_populate_package() {
         cp "${STAGING_DATADIR}/tegraflash/$f" .
     done
     sed -e "\$a\BOOTCONTROL_OVERLAYS=\"$bcoverlays\"" ${STAGING_DATADIR}/tegraflash/flashvars > ./flashvars
+    install -d ./tools/disk-encryption
+    install -m 0755 ${RECIPE_SYSROOT_NATIVE}/usr/bin/gen_ekb.py ./tools/disk-encryption/
+    install -m 0755 ${RECIPE_SYSROOT_NATIVE}/usr/bin/gen_luks_passphrase.py ./tools/disk-encryption/
     if [ "${SOC_FAMILY}" = "tegra234" ]; then
         cp ${STAGING_DATADIR}/tegraflash/bpmp_t234-*.bin .
         cp ${STAGING_DATADIR}/tegraflash/tegra234-*.dts* .
@@ -561,6 +564,7 @@ tegra_mksparse() {
 IMAGE_CMD:tegraflash-tar = "create_tegraflash_pkg"
 do_image_tegraflash_tar[depends] += "dtc-native:do_populate_sysroot coreutils-native:do_populate_sysroot \
                                  tegra-flashtools-native:do_populate_sysroot gptfdisk-native:do_populate_sysroot \
+                                 optee-nvsamples-native:do_populate_sysroot \
                                  tegra-bootfiles:do_populate_sysroot tegra-bootfiles:do_populate_lic \
                                  ${TEGRA_RCM_EDK2_DEPENDS} virtual/kernel:do_deploy \
                                  ${@'${INITRD_IMAGE}:do_image_complete' if d.getVar('INITRD_IMAGE') != '' else  ''} \

--- a/docs/Disk-Encryption-for-Jetson-Devices.md
+++ b/docs/Disk-Encryption-for-Jetson-Devices.md
@@ -1,34 +1,142 @@
-This page describes one mechanism for enabling disk encryption on meta-tegra, using the notes from Islam Hussein in [this thread](https://matrix.to/#/!qJMWWUfzttaurEBEqL:gitter.im/$nAwSFU_-nveUAnJ_ZwF7ftRX19UF0yRoHyvvkm_WPh8?via=gitter.im&via=matrix.org&via=3dvisionlabs.com) on matrix.
+# Disk encryption for Jetson devices
 
-The encryption happens as a post-process initiated manually after the build.
+This page describes disk-encryption workflows for meta-tegra. The automated
+`initrd-flash` workflow is supported on Jetson Orin (Tegra234) only. Jetson
+AGX Thor (Tegra264) continues to use the manual post-build workflow below.
 
-# Yocto changes
-1. Modify your partition xml to set 'encrypted' to true on the corresponding partition, as described in the [NVIDIA Disk Encryption Documentation](https://docs.nvidia.com/jetson/archives/r36.4/DeveloperGuide/SD/Security/DiskEncryption.html).
-```
-<partition name="data-partition" type="data" encrypted="true">
-```
-2. Choose a different init script to be used in initramfs which uses `luks-srv-app` and disable it totally after that to prevent further use. See code snippet below.  For the "context", refer to the build changes section below.
-```
-__l4t_enc_root_dm="l4t_enc_root";
-__l4t_enc_root_dm_dev="/dev/mapper/${__l4t_enc_root_dm}"
-eval nvluks-srv-app -g -c "<context>" | cryptsetup luksOpen /dev/nvme0n1p${current_rootfs} ${__l4t_enc_root_dm}
+Neither workflow manages production secrets. Generating fuse keys, the EKB,
+and per-device LUKS passphrase files belongs to the product flashing process.
+
+## Orin: encrypted `initrd-flash` partitions
+
+Mark every partition that must be encrypted in its partition layout XML:
+
+```xml
+<partition name="APP_ENC" type="data" encrypted="true">
 ```
 
-# Build changes
-Add a bash script to be called manually after finishing yocto build. The script will go to the path of the build, extract it in a temp directory. mount the rootfs and open it. Then it will make a luks-storage (And that’s why I couldn’t build it inside yocto) The problem is that when you want to open the luks using crypto you have to access device mapper which requires privileged access which yocto doesn’t have
+When `initrd-flash` exports the target storage as a block device, its host-side
+`make-sdcard` script detects this attribute. It formats that partition as LUKS2,
+opens it temporarily, and writes the partition image to the opened mapper. The
+script closes the mapper after writing it.
 
-* Store the size of rootfs which is written in xml it have to be the same and then create luks drive with the same size. 
-* To generate the password you’ll need to run `gen_ekb.py`
-* You’ll have to to write down dummy uuid which is the context used in the code snippet above. (context will be used in two places generating pass to encrypt rootfs and generating the pass access it.)
-* One way is to use a generic password which doesn’t need ecid. So the same key will be used for all of my devices.
+This applies only when flashing a block device via `initrd-flash`. Encrypted
+partitions are intentionally not supported when `make-sdcard` creates a regular
+`.sdcard` image file.
+
+### Host requirements
+
+The flashing host needs `cryptsetup`, in addition to the normal initrd-flash
+host tools. The tegraflash package includes these NVIDIA scripts:
 
 ```
+tools/disk-encryption/gen_ekb.py
+tools/disk-encryption/gen_luks_passphrase.py
+```
+
+The package does not include Python or Python's `cryptography` module. Those
+are host dependencies when either script is run.
+
+### Per-partition inputs
+
+Before running `initrd-flash`, export one key-file variable and one UUID
+variable for every encrypted partition. The variable suffix is the partition
+name uppercased with every non-alphanumeric character replaced by `_`.
+
+For example, `APP_ENC` uses:
+
+```sh
+export LUKS_KEYFILE_APP_ENC=/secure/per-device/app-enc.key
+export LUKS_UUID_APP_ENC=01234567-89ab-cdef-0123-456789abcdef
+./initrd-flash
+```
+
+`APP_ENC_b` would use `LUKS_KEYFILE_APP_ENC_B` and
+`LUKS_UUID_APP_ENC_B`. The key file must be readable and non-empty. The UUID
+must be a valid UUID and becomes the LUKS UUID. It should be unique for each
+flashed unit; it is also the passphrase-derivation context in the example
+below.
+
+The key file is a line-oriented derived LUKS passphrase, not the disk-encryption
+key itself. `make-sdcard` supplies it on standard input to `cryptsetup`, which
+matches the normal boot-time `nvluks-srv-app | cryptsetup luksOpen` use.
+
+### Generating EKB and passphrase files
+
+Use the tooling and key material appropriate to the product security process.
+For example, an Orin EKB containing the disk encryption key can be generated
+with:
+
+```sh
+python3 tools/disk-encryption/gen_ekb.py -chip t234 \
+    -oem_k1_key oem_k1.key \
+    -in_sym_key2 sym2_t234.key \
+    -in_auth_key auth_t234.key \
+    -out eks.img
+```
+
+To produce a generic passphrase file for the UUID/context above:
+
+```sh
+python3 tools/disk-encryption/gen_luks_passphrase.py \
+    -k sym2_t234.key -g -c 01234567-89ab-cdef-0123-456789abcdef \
+    > /secure/per-device/app-enc.key
+```
+
+Generic mode (`-g`) is the primary example: the boot-time unlock configuration
+must derive the same generic passphrase with the same context. ECID-specific
+mode is also possible, but the host-side derivation and the target's
+`nvluks-srv-app` invocation must use matching ECID-specific inputs.
+
+The target initramfs must be configured separately to use `nvluks-srv-app` and
+the same context to open the encrypted rootfs. That target runtime integration
+is product-specific and is not configured by this layer.
+
+### Image sizing
+
+`make-sdcard` writes the existing image with `dd` or `bmaptool` directly to the
+opened LUKS mapper; it does not resize or copy the filesystem. The rootfs image
+must therefore be smaller than the encrypted partition's LUKS payload. Reserve
+space for the LUKS2 header when choosing the image and partition sizes. Flashing
+fails before the image write if it does not fit in the mapper.
+
+The LUKS format parameters are LUKS2, `aes-xts-plain64`, and a 256-bit key.
+Temporary host mapper names include the flashing process ID and are closed after
+flashing; they do not determine the mapper name used on the Jetson at boot.
+
+## Thor: manual post-build workflow
+
+The automated workflow above does not apply to Thor's unified-flash path. The
+following manual post-build approach remains available for layouts requiring
+encrypted partitions on Thor.
+
+1. Modify the partition XML to set `encrypted` to true on the corresponding
+   partition, as described in the [NVIDIA Disk Encryption Documentation](https://docs.nvidia.com/jetson/archives/r36.4/DeveloperGuide/SD/Security/DiskEncryption.html).
+
+   ```xml
+   <partition name="data-partition" type="data" encrypted="true">
+   ```
+
+2. Choose an initramfs init script that uses `luks-srv-app` and disables it
+   after opening the rootfs. The context must match the context used when the
+   encrypted image was prepared.
+
+   ```sh
+   __l4t_enc_root_dm="l4t_enc_root"
+   __l4t_enc_root_dm_dev="/dev/mapper/${__l4t_enc_root_dm}"
+   eval nvluks-srv-app -g -c "<context>" | cryptsetup luksOpen /dev/nvme0n1p${current_rootfs} ${__l4t_enc_root_dm}
+   ```
+
+After the Yocto build, use a privileged host-side script to create a LUKS image,
+open it, create its filesystem, and copy the original rootfs into it. The LUKS
+image must be the same size as the partition configured in XML.
+
+```sh
 GEN_LUKS_PASS_CMD="tools/gen_luks_passphrase.py"
 genpass_opt=""
 genpass_opt+=" -k tools/ekb.key "
 genpass_opt+=" -g "
 genpass_opt+=" -c '${__rootfsuuid}' "
-
 GEN_LUKS_PASS_CMD+=" ${genpass_opt}"
 
 truncate --size ${__rootfs_size} ${__rootfs_name}
@@ -42,11 +150,10 @@ eval ${GEN_LUKS_PASS_CMD} | sudo cryptsetup \
 eval ${GEN_LUKS_PASS_CMD} | sudo cryptsetup luksOpen ${__rootfs_name} ${__l4t_enc}
 sudo mkfs.ext4 /dev/mapper/${__l4t_enc}
 sudo mount /dev/mapper/${__l4t_enc} ${__enc_rootfs_mountpoint}
-sudo mount  ${__original_rootfs} ${__rootfs_original_mountpoint}
+sudo mount ${__original_rootfs} ${__rootfs_original_mountpoint}
 sudo tar -cf - -C ${__rootfs_original_mountpoint} . | sudo tar -xpf - -C ${__enc_rootfs_mountpoint}
 sleep 5
 sudo umount ${__enc_rootfs_mountpoint}
 sudo cryptsetup luksClose ${__l4t_enc}
 sudo umount ${__rootfs_original_mountpoint}
 ```
-

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/make-sdcard.sh
@@ -10,6 +10,7 @@ DEVNAME=
 PARTSEP=
 OUTSYSBLK=
 HAVEBMAPTOOL=
+declare -a LUKS_MAPPERS
 
 SUDO=
 [ $(id -u) -eq 0 ] || SUDO="sudo"
@@ -142,21 +143,153 @@ make_partitions() {
     return 0
 }
 
+cleanup_luks_mappers() {
+    local mapper
+    for mapper in "${LUKS_MAPPERS[@]}"; do
+        [ ! -e "/dev/mapper/$mapper" ] || close_encrypted_partition "$mapper" || true
+    done
+    LUKS_MAPPERS=()
+}
+
+partition_var_suffix() {
+    echo "$1" | tr '[:lower:]' '[:upper:]' | sed 's/[^[:alnum:]]/_/g'
+}
+
+partition_mapper_name() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^[:alnum:]]/-/g'
+}
+
+validate_encrypted_partitions() {
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype encrypted partfilltoend
+    local pline suffix keyvar uuidvar keyfile luksuuid mapper
+    local have_encrypted=0
+
+    for pline in "${PARTS[@]}"; do
+        eval "$pline"
+        [ "$encrypted" -eq 1 ] || continue
+        have_encrypted=1
+        suffix=$(partition_var_suffix "$partname")
+        mapper=$(partition_mapper_name "$partname")
+        mapper="initrd-flash-$mapper-$$"
+        if [ -z "$suffix" ] || [ "$mapper" = "initrd-flash--$$" ] || [ ${#mapper} -gt 127 ]; then
+            echo "ERR: partition name $partname cannot be used for LUKS environment or mapper names" >&2
+            return 1
+        fi
+        if [ -e "/dev/mapper/$mapper" ]; then
+            echo "ERR: refusing to reuse existing LUKS mapper $mapper" >&2
+            return 1
+        fi
+        keyvar="LUKS_KEYFILE_$suffix"
+        uuidvar="LUKS_UUID_$suffix"
+        keyfile="${!keyvar}"
+        luksuuid="${!uuidvar}"
+        if [ -z "$keyfile" ] || [ ! -r "$keyfile" ] || [ ! -s "$keyfile" ]; then
+            echo "ERR: encrypted partition $partname requires readable non-empty \$$keyvar" >&2
+            return 1
+        fi
+        if ! [[ "$luksuuid" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]]; then
+            echo "ERR: encrypted partition $partname requires UUID \$$uuidvar" >&2
+            return 1
+        fi
+    done
+    if [ "$have_encrypted" -eq 1 ]; then
+        if [ ! -b "$output" ]; then
+            echo "ERR: encrypted partitions require a block-device output" >&2
+            return 1
+        fi
+        if ! command -v cryptsetup >/dev/null 2>&1; then
+            echo "ERR: encrypted partitions require the 'cryptsetup' command" >&2
+            return 1
+        fi
+    fi
+    return 0
+}
+
+open_encrypted_partition() {
+    local partname="$1"
+    local dest="$2"
+    local suffix=$(partition_var_suffix "$partname")
+    local keyvar="LUKS_KEYFILE_$suffix"
+    local uuidvar="LUKS_UUID_$suffix"
+    local keyfile="${!keyvar}"
+    local luksuuid="${!uuidvar}"
+    local mapper="initrd-flash-$(partition_mapper_name "$partname")-$$"
+
+    if [ -e "/dev/mapper/$mapper" ]; then
+        echo "ERR: refusing to reuse existing LUKS mapper $mapper" >&2
+        return 1
+    fi
+    echo "  Formatting $dest as LUKS2 (UUID=$luksuuid)..." >&2
+    if ! $SUDO cryptsetup luksFormat --batch-mode --type luks2 --cipher aes-xts-plain64 --key-size 256 --uuid "$luksuuid" "$dest" < "$keyfile"; then
+        echo "ERR: LUKS formatting failed for $dest" >&2
+        return 1
+    fi
+    if ! $SUDO cryptsetup luksOpen "$dest" "$mapper" < "$keyfile"; then
+        echo "ERR: LUKS open failed for $dest" >&2
+        return 1
+    fi
+    LUKS_MAPPERS+=("$mapper")
+    LUKS_DEVICE="/dev/mapper/$mapper"
+}
+
+close_encrypted_partition() {
+    local mapper="$1"
+    local mapperdev="/dev/mapper/$mapper"
+    local attempt errlog i
+    local max_attempts=5
+
+    for attempt in $(seq 1 $max_attempts); do
+        if command -v udevadm >/dev/null 2>&1; then
+            udevadm settle --timeout=2 >/dev/null 2>&1 || true
+        fi
+        unmount_device "$mapperdev" || return 1
+        errlog=$(mktemp)
+        if $SUDO cryptsetup close "$mapper" 2>"$errlog"; then
+            rm -f "$errlog"
+            for i in "${!LUKS_MAPPERS[@]}"; do
+                [ "${LUKS_MAPPERS[$i]}" != "$mapper" ] || unset 'LUKS_MAPPERS[i]'
+            done
+            return 0
+        fi
+        if [ "$attempt" -eq "$max_attempts" ]; then
+            echo "ERR: failed to close LUKS mapper $mapper after $max_attempts attempts" >&2
+            cat "$errlog" >&2
+            rm -f "$errlog"
+            return 1
+        fi
+        rm -f "$errlog"
+        echo "  LUKS mapper $mapper is busy; retrying close ($attempt/$max_attempts)..." >&2
+        sleep 0.2
+    done
+}
+
 create_filesystems() {
-    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
-    local pline mke2fscmd
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype encrypted partfilltoend
+    local pline mke2fscmd dest mapper
     local errlog=$(mktemp)
     for pline in "${PARTS[@]}"; do
 	eval "$pline"
-	if [ -z "$partfile" ] && [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
+	if [ -z "$partfile" ] && { [ "$encrypted" -eq 1 ] || { [ -n "$fstype" ] && [ "$fstype" != "basic" ]; }; }; then
 	    printf "Creating $fstype filesystem to /dev/$DEVNAME$PARTSEP$partnumber\n"
-	    mke2fscmd="mkfs.$fstype /dev/$DEVNAME$PARTSEP$partnumber"
-	    if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
+            dest="/dev/$DEVNAME$PARTSEP$partnumber"
+            if [ "$encrypted" -eq 1 ]; then
+                open_encrypted_partition "$partname" "$dest" || return 1
+                dest="$LUKS_DEVICE"
+                mapper=$(basename "$dest")
+            fi
+            if [ -n "$fstype" ] && [ "$fstype" != "basic" ]; then
+	        mke2fscmd="$SUDO mkfs.$fstype $dest"
+	        if ! eval "$mke2fscmd" >/dev/null 2>"$errlog"; then
 		    echo "ERR: filesystem failed" >&2
 		    cat "$errlog" >&2
 		    rm -f "$errlog"
 		    return 1
-	    fi
+	        fi
+            fi
+            if [ "$encrypted" -eq 1 ] && ! close_encrypted_partition "$mapper"; then
+                echo "ERR: failed to close LUKS mapper $mapper" >&2
+                return 1
+            fi
 	fi
     done
     rm -f "$errlog"
@@ -167,7 +300,7 @@ copy_to_device() {
     local src="$1"
     local dst="$2"
     if [ -z "$HAVEBMAPTOOL" -o -n "$ignore_bmap" ]; then
-	dd if="$src" of="$dst" bs=1M conv=fsync status=none >/dev/null 2>&1 || return 1
+	$SUDO dd if="$src" of="$dst" bs=1M conv=fsync status=none >/dev/null 2>&1 || return 1
 	return 0
     fi
     local bmap=$(mktemp)
@@ -182,20 +315,31 @@ copy_to_device() {
 
 unmount_device() {
     local dev="$1"
-    local mnt=$(cat /proc/mounts | grep "^$dev " | cut -d' ' -f2)
-    local m
-    for m in $mnt; do
-        if ! umount "$m" > /dev/null 2>&1; then
-            echo "ERR: unmount $m on device $dev failed" >&2
-            return 1
-        fi
-    done
+    local realdev mounteddev realmounteddev mnt rest
+
+    realdev=$(readlink -f "$dev" 2>/dev/null) || realdev="$dev"
+    while read -r mounteddev mnt rest; do
+        case "$mounteddev" in
+            /dev/*)
+                realmounteddev=$(readlink -f "$mounteddev" 2>/dev/null) || realmounteddev="$mounteddev"
+                ;;
+            *)
+                continue
+                ;;
+        esac
+        [ "$realmounteddev" != "$realdev" ] || {
+            if ! $SUDO umount "$mnt" >/dev/null 2>&1; then
+                echo "ERR: unmount $mnt on device $dev failed" >&2
+                return 1
+            fi
+        }
+    done < /proc/mounts
     return 0
 }
 
 write_partitions_to_device() {
-    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
-    local i dest pline destsize filesize n_written
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype encrypted partfilltoend
+    local i dest rawdest pline destsize filesize n_written mapper
     n_written=0
     i=0
     for pline in "${PARTS[@]}"; do
@@ -229,11 +373,30 @@ write_partitions_to_device() {
 	    sleep 1
 	    destsize=$(blockdev --getsize64 "$dest" 2>/dev/null)
 	fi
-	echo "  Writing $partfile (size=$filesize) to $dest (size=$destsize)..."
+        rawdest="$dest"
+        if [ "$encrypted" -eq 1 ]; then
+            open_encrypted_partition "$partname" "$rawdest" || return 1
+            dest="$LUKS_DEVICE"
+            mapper=$(basename "$dest")
+        fi
+        destsize=$(blockdev --getsize64 "$dest" 2>/dev/null)
+        if [ "$encrypted" -eq 1 ]; then
+            echo "  Writing $partfile (size=$filesize) through encrypted mapper $dest (payload size=$destsize; raw partition=$rawdest)..."
+        else
+            echo "  Writing $partfile (size=$filesize) to $dest (size=$destsize)..."
+        fi
+        if [ "$filesize" -gt "$destsize" ]; then
+            echo "ERR: $partfile does not fit in $dest; leave room for the LUKS header" >&2
+            return 1
+        fi
 	if ! copy_to_device "$partfile" "$dest"; then
 	    echo "ERR: failed to write $partfile to $dest" >&2
 	    return 1
 	fi
+        if [ "$encrypted" -eq 1 ] && ! close_encrypted_partition "$mapper"; then
+            echo "ERR: failed to close LUKS mapper $mapper" >&2
+            return 1
+        fi
 	n_written=$(expr $n_written + 1)
 	i=$(expr $i + 1)
     done
@@ -261,17 +424,36 @@ write_partitions_to_device() {
 	    sleep 1
 	    destsize=$(blockdev --getsize64 "$dest" 2>/dev/null)
 	fi
-	echo "  Writing $partfile (size=$filesize) to $dest (size=$destsize)..."
+        rawdest="$dest"
+        if [ "$encrypted" -eq 1 ]; then
+            open_encrypted_partition "$partname" "$rawdest" || return 1
+            dest="$LUKS_DEVICE"
+            mapper=$(basename "$dest")
+        fi
+        destsize=$(blockdev --getsize64 "$dest" 2>/dev/null)
+        if [ "$encrypted" -eq 1 ]; then
+            echo "  Writing $partfile (size=$filesize) through encrypted mapper $dest (payload size=$destsize; raw partition=$rawdest)..."
+        else
+            echo "  Writing $partfile (size=$filesize) to $dest (size=$destsize)..."
+        fi
+        if [ "$filesize" -gt "$destsize" ]; then
+            echo "ERR: $partfile does not fit in $dest; leave room for the LUKS header" >&2
+            return 1
+        fi
 	if ! copy_to_device "$partfile" "$dest"; then
 	    echo "ERR: failed to write $partfile to $dest" >&2
 	    return 1
 	fi
+        if [ "$encrypted" -eq 1 ] && ! close_encrypted_partition "$mapper"; then
+            echo "ERR: failed to close LUKS mapper $mapper" >&2
+            return 1
+        fi
     fi
 }
 
 write_partitions_to_image() {
     local -a partstart
-    local blksize partnumber partname start_location partsize partfile partguid parttype fstype partfilltoend
+    local blksize partnumber partname start_location partsize partfile partguid parttype fstype encrypted partfilltoend
     local i s e stuff partstart partend pline
 
     while read partnumber s e stuff; do
@@ -446,7 +628,6 @@ if [ -b "$output" ]; then
 else
     if [ -e "$output" ]; then
 	[ -n "$preconfirmed" ] || confirm "$output"
-	rm "$output"
     fi
     if [ -z "$outsize" ]; then
 	echo "ERR: no size specified for SDcard image $output" >&2
@@ -458,6 +639,14 @@ mapfile PARTS < <("$here/nvflashxmlparse" -t rootfs "$cfgfile")
 if [ ${#PARTS[@]} -eq 0 ]; then
     echo "No partition definitions found in $cfgfile" >&2
     exit 1
+fi
+if ! validate_encrypted_partitions; then
+    exit 1
+fi
+trap cleanup_luks_mappers EXIT INT TERM
+
+if [ ! -b "$output" ] && [ -e "$output" ]; then
+    rm "$output"
 fi
 
 echo  "Creating partitions"

--- a/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
+++ b/recipes-bsp/tegra-binaries/tegra-helper-scripts/nvflashxmlparse.py
@@ -54,6 +54,7 @@ class Partition(object):
         default_id = None if self.is_partition_table() else partnum
         self.id = default_id if ignore_id else element.get('id', default_id)
         self.oem_sign = element.get('oemsign', 'false') == 'true'
+        self.encrypted = element.get('encrypted', 'false') == 'true'
         guid = element.find('unique_guid')
         self.partguid = "" if guid is None else validate_guid(guid.text.strip())
 
@@ -469,7 +470,7 @@ Extracts/manipulates partition information in an NVIDIA flash layout XML file
     blksize = layout.devices[args.type].sector_size
     for n, part in enumerate(partitions):
         print("blksize={};partnumber={};partname=\"{}\";start_location={};partsize={};"
-              "partfile=\"{}\";partguid=\"{}\";parttype=\"{}\";fstype=\"{}\";partfilltoend={}".format(blksize,
+              "partfile=\"{}\";partguid=\"{}\";parttype=\"{}\";fstype=\"{}\";encrypted={};partfilltoend={}".format(blksize,
                                                                                         part.id,
                                                                                         part.name,
                                                                                         part.start_location,
@@ -478,6 +479,7 @@ Extracts/manipulates partition information in an NVIDIA flash layout XML file
                                                                                         part.partguid,
                                                                                         part.parttype,
                                                                                         part.fstype,
+                                                                                        1 if part.encrypted else 0,
                                                                                         1 if part.filltoend() else 0),
               file=outf)
     outf.close()

--- a/recipes-bsp/uefi/tegra-uefi-capsules_39.2.1.bb
+++ b/recipes-bsp/uefi/tegra-uefi-capsules_39.2.1.bb
@@ -15,6 +15,8 @@ COMPATIBLE_MACHINE = "(tegra)"
 
 TEGRA_SIGNING_EXTRA_DEPS ??= ""
 
+DEPENDS += "optee-nvsamples-native"
+
 do_compile() {
     # Older versions of this recipe use GUID
     if [ -n "${GUID}" ]; then

--- a/recipes-security/optee/optee-nvsamples-native_39.2.1.bb
+++ b/recipes-security/optee/optee-nvsamples-native_39.2.1.bb
@@ -21,6 +21,7 @@ do_compile[noexec] = "1"
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${S}/hwkey-agent/host/tool/gen_ekb/gen_ekb.py ${D}${bindir}
+    install -m 0755 ${S}/luks-srv/host/tool/gen_luks_passphrase/gen_luks_passphrase.py ${D}${bindir}
 }
 
 INHIBIT_SYSROOT_STRIP = "1"


### PR DESCRIPTION
Allow Orin flashing workflows to prepare encrypted partitions directly on their target block device, so the LUKS container, passphrase derivation, and payload write align with the boot-time unlock path.

Bundle the required host-side NVIDIA tools and document the required per-device inputs and security boundary; production key management remains outside the layer.