### PR TITLE
arm-trusted-firmware: use timezone.utc so recipes parse on Python 3.10

### DIFF
--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.13.0-l4t-r39.2.1.bb
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.13.0-l4t-r39.2.1.bb
@@ -47,10 +47,10 @@ def generate_build_string(d):
         return 'BUILD_STRING={}'.format('-'.join(pv[1:]))
 
 def generate_build_timestamp(d):
-    from datetime import datetime, UTC
+    from datetime import datetime, timezone
     sde = d.getVar('SOURCE_DATE_EPOCH')
     if sde:
-        return 'BUILD_MESSAGE_TIMESTAMP="\\\"{}\\\""'.format(datetime.fromtimestamp(int(sde), UTC).strftime('%Y-%m-%d %H:%M:%S'))
+        return 'BUILD_MESSAGE_TIMESTAMP="\\\"{}\\\""'.format(datetime.fromtimestamp(int(sde), timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return ''
 
 BUILD_STRING ?= "${@generate_build_string(d)}"

--- a/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.8.16-l4t-r39.2.1.bb
+++ b/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_2.8.16-l4t-r39.2.1.bb
@@ -28,10 +28,10 @@ def generate_build_string(d):
         return 'BUILD_STRING={}'.format('-'.join(pv[1:]))
 
 def generate_build_timestamp(d):
-    from datetime import datetime, UTC
+    from datetime import datetime, timezone
     sde = d.getVar('SOURCE_DATE_EPOCH')
     if sde:
-        return 'BUILD_MESSAGE_TIMESTAMP="\\\"{}\\\""'.format(datetime.fromtimestamp(int(sde), UTC).strftime('%Y-%m-%d %H:%M:%S'))
+        return 'BUILD_MESSAGE_TIMESTAMP="\\\"{}\\\""'.format(datetime.fromtimestamp(int(sde), timezone.utc).strftime('%Y-%m-%d %H:%M:%S'))
     return ''
 
 BUILD_STRING ?= "${@generate_build_string(d)}"


### PR DESCRIPTION
`datetime.UTC` was added in Python 3.11. On a build host running Python 3.10 (e.g. Ubuntu 22.04), the `L4T R39.2.1` recipes fail at parse time, before any task runs:

```
  ExpansionError: Failure expanding variable BUILDTIMESTAMP,
    expression was ${@generate_build_timestamp(d)} which triggered
    exception ImportError: cannot import name 'UTC' from 'datetime'
```

`BUILDTIMESTAMP` is set from an inline `${@...}` expression, so the helper runs while bitbake is parsing the recipe, and the `ImportError` takes the whole parse down rather than a single task.

`timezone.utc` is the same object (`datetime.UTC` is an alias for it) and has been available since Python 3.2, so this keeps the recipes working on every Python that bitbake and oe-core still accept (3.9 or newer), while still avoiding the deprecated `utcfromtimestamp()` that 6f72612d ("arm-trusted-firmware: update build timestamp generation function (t234)") moved away from. No behaviour change on 3.11 and later.
