### PR TITLE
l4t-usb-device-mode: give ttyGS0 its own getty template

### DIFF
--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode.bb
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode.bb
@@ -7,6 +7,7 @@ SRC_URI = "\
     file://70-l4tbr0.network \
     file://l4tbr0.netdev \
     file://98-usb-gadget-tty.rules \
+    file://serial-getty@ttyGS0.service.d/no-tty-reset.conf \
 "
 
 COMPATIBLE_MACHINE = "(tegra)"
@@ -27,7 +28,11 @@ do_install() {
     install -m 0644 ${S}/70-l4t-usb-gadget.network ${D}${sysconfdir}/systemd/network/
     install -d ${D}${sysconfdir}/udev/rules.d
     install -m 0644 ${S}/98-usb-gadget-tty.rules ${D}${sysconfdir}/udev/rules.d/
+    install -d ${D}${systemd_system_unitdir}/serial-getty@ttyGS0.service.d
+    install -m 0644 ${S}/serial-getty@ttyGS0.service.d/no-tty-reset.conf ${D}${systemd_system_unitdir}/serial-getty@ttyGS0.service.d/
 }
+
+FILES:${PN} += "${systemd_system_unitdir}/serial-getty@ttyGS0.service.d/no-tty-reset.conf"
 
 L4T_USBGX_DEPENDS ?= "libusbgx-tegra"
 

--- a/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/serial-getty@ttyGS0.service.d/no-tty-reset.conf
+++ b/recipes-bsp/l4t-usb-device-mode/l4t-usb-device-mode/serial-getty@ttyGS0.service.d/no-tty-reset.conf
@@ -1,0 +1,2 @@
+[Service]
+TTYReset=no


### PR DESCRIPTION
agetty invoked with "-" (the serial-getty@ default) takes an exclusive flock() on /dev/console to arbitrate between redundant console= entries. Being an auxiliary virtual console that may not even be plugged in at startup, ttyGS0 shouldn't be competing for /dev/console. If it happens to win the race at startup and remain unenumerated, it will starve the real console getty forever, with no error or log output.

Added a usb-gadget-getty@.service template that invokes agetty with %I instead of "-", and pointed the udev rule at it instead of serial-getty@.