### PR TITLE
tegra-common, tegra264: make the essential PCIe modules SoC-specific

### DIFF
--- a/conf/machine/include/tegra-common.inc
+++ b/conf/machine/include/tegra-common.inc
@@ -83,8 +83,9 @@ UBOOT_EXTLINUX ?= "1"
 TEGRA_ESSENTIAL_EXTRA_RDEPENDS ?= "${@'l4t-launcher-extlinux' if d.getVar('UBOOT_EXTLINUX') == '1' else ''}"
 MACHINE_FEATURES = "alsa usbhost pci rtc cuda ext2"
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "tegra-firmware ${TEGRA_ESSENTIAL_EXTRA_RDEPENDS} nvidia-kernel-oot-base"
+TEGRA_ESSENTIAL_PCIE_RRECOMMENDS ?= "kernel-module-pcie-tegra194 kernel-module-phy-tegra194-p2u"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS = "kernel-module-ina3221 kernel-module-lm90 kernel-module-tegra-bpmp-thermal kernel-module-spi-tegra114 kernel-module-spidev kernel-module-pwm-fan \
-                                       kernel-module-ucsi-ccg kernel-module-pcie-tegra194 kernel-module-phy-tegra194-p2u \
+                                       kernel-module-ucsi-ccg ${TEGRA_ESSENTIAL_PCIE_RRECOMMENDS} \
                                        kernel-module-nvme kernel-module-pwm-tegra kernel-module-tegra-xudc"
 MACHINE_EXTRA_RDEPENDS = "tegra-nvsciipc tegra-configs-sysctl tegra-nvfancontrol tegra-configs-udev tegra-redundant-boot nvidia-kernel-oot-display tegra-configs-display-driver"
 MACHINE_EXTRA_RRECOMMENDS = " \

--- a/conf/machine/include/tegra264.inc
+++ b/conf/machine/include/tegra264.inc
@@ -27,6 +27,8 @@ TEGRA_CUDA_ARCHITECTURE ?= "110"
 TEGRA_FLASHVAR_BR_CMD_CONFIG ?= ""
 TEGRA_FLASHVAR_FSIFW ?= ""
 
+TEGRA_ESSENTIAL_PCIE_RRECOMMENDS ?= "nv-kernel-module-pcie-tegra264"
+
 require conf/machine/include/tegra-common.inc
 
 L4T_BSP_PREFIX = "Jetson"

--- a/recipes-core/images/tegra-initrd-flash-initramfs.bb
+++ b/recipes-core/images/tegra-initrd-flash-initramfs.bb
@@ -22,7 +22,6 @@ PACKAGE_INSTALL = "\
 # Thor (T264): unified flash via ADB
 PACKAGE_INSTALL:append:tegra264 = " \
     tegra-target-flash-scripts \
-    nv-kernel-module-pcie-tegra264 \
     nv-kernel-module-ufs-tegra \
 "
 

--- a/recipes-core/images/tegra-minimal-initramfs.bb
+++ b/recipes-core/images/tegra-minimal-initramfs.bb
@@ -12,8 +12,7 @@ PACKAGE_INSTALL = "\
     ${ROOTFS_BOOTSTRAP_INSTALL} \
     ${TEGRA_INITRD_INSTALL} \
     kernel-module-nvme \
-    kernel-module-pcie-tegra194 \
-    kernel-module-phy-tegra194-p2u \
+    ${TEGRA_ESSENTIAL_PCIE_RRECOMMENDS} \
     kernel-module-tegra-xudc \
     kernel-module-ucsi-ccg \
     kernel-module-dummy \
@@ -24,7 +23,6 @@ PACKAGE_INSTALL = "\
 "
 
 PACKAGE_INSTALL:append:tegra264 = "\
-    nv-kernel-module-pcie-tegra264 \
     nv-kernel-module-ufs-tegra \
 "
 


### PR DESCRIPTION
**Problem**

`tegra-common.inc` sets `MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS` for all Tegra SoCs, including `kernel-module-pcie-tegra194` and `kernel-module-phy-tegra194-p2u`. Neither can bind on t264:

```
$ strings pcie-tegra194.ko | grep ^alias=of:
alias=of:N*T*Cnvidia,tegra234-pcie-ep    alias=of:N*T*Cnvidia,tegra234-pcie
alias=of:N*T*Cnvidia,tegra194-pcie-ep    alias=of:N*T*Cnvidia,tegra194-pcie

$ strings phy-tegra194-p2u.ko | grep ^alias=of:
alias=of:N*T*Cnvidia,tegra234-p2u        alias=of:N*T*Cnvidia,tegra194-p2u
```

The shipped Thor device tree (`tegra264-p4071-0000+p3834-0008-nv.dtb`, JetPack 7.2.1 / L4T R39.2.1) uses `compatible = "nvidia,tegra264-pcie"` on all six controllers and contains zero p2u nodes. The driver that does bind is the out-of-tree `nv-kernel-module-pcie-tegra264`.

So, on t264, both `initramfs` images hard-install PCIe drivers that cannot bind. `tegra-minimal-initramfs` lists `kernel-module-pcie-tegra194` and `kernel-module-phy-tegra194-p2u` directly in `PACKAGE_INSTALL`, and `tegra-initrd-flash-initramfs` pulls the same two in by interpolating `${MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS}` into `PACKAGE_INSTALL`, so `NO_RECOMMENDATIONS` never applies there. Both then append `nv-kernel-module-pcie-tegra264` on top, because the shared list cannot vary per SoC.

**Change**

Introduce `TEGRA_ESSENTIAL_PCIE_RRECOMMENDS`, defaulting to the two t19x/t23x modules in `tegra-common.inc`, and override it in `tegra264.inc` with `nv-kernel-module-pcie-tegra264`. This follows the `TEGRA_ESSENTIAL_EXTRA_RDEPENDS` / `UBOOT_EXTLINUX` pattern three lines above, keeps the truth for each SoC in one place, and avoids a :remove against a literal string in another file. Machine configs can still override it.

The second commit drops the entry this makes redundant in `tegra-initrd-flash-initramfs.bb`.

**Impact**

No functional change to booting. NVMe root on Thor already works because `CONFIG_BLK_DEV_NVME=m` and the t264 host driver is out-of-tree, so an `initramfs` carrying the correct module is mandatory at boot and it stays loaded across `switch_root`. What changes is that a stock t264 `rootfs` stops carrying two modules that cannot probe, and starts carrying the one that does.

It matters more for downstream layers that set `NO_RECOMMENDATIONS = "1"` and promote this list to hard `RDEPENDS:` they currently inherit the wrong module as a mandatory dependency. That is how I ran into it.

**Testing**
`bitbake -e` on t264 and t234 machines, checking `MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS` before and after: t234 unchanged, t264 swaps the two entries for `nv-kernel-module-pcie-tegra264`.