### PR TITLE
Update TensorRT recipes

### DIFF
--- a/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.16.bb
+++ b/external/meta-python/recipes-devtools/python3-tensorrt/python3-tensorrt_10.16.bb
@@ -7,7 +7,7 @@ DEPENDS = "python3-pybind11 tensorrt-core tensorrt-plugins"
 
 COMPATIBLE_MACHINE = "(tegra)"
 
-inherit setuptools3 cmake cuda
+inherit cmake cuda python3-dir python3targetconfig
 
 SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
 SRCBRANCH = "release/${PV}"
@@ -16,10 +16,9 @@ SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
     "
 
 # v${PV} tag
-SRCREV = "94e2b9ef6d2cce74c76cdad499cca36cc4949197"
+SRCREV = "52399f555c2f80cb690a4a558b604e1a5f227e7c"
 
 OECMAKE_SOURCEPATH = "${S}/python"
-SETUPTOOLS_SETUP_PATH = "${B}"
 
 EXTRA_OECMAKE = "-DTENSORRT_ROOT=${S} -DTENSORRT_LIBPATH=${STAGING_LIBDIR} -DTENSORRT_MODULE=tensorrt \
                  -DCUDA_INCLUDE_DIRS=${CUDA_PATH}/include \
@@ -35,32 +34,30 @@ do_configure() {
     TRT_MAJOR=$(awk '/^#define TRT_MAJOR_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
     TRT_MINOR=$(awk '/^#define TRT_MINOR_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
     TRT_PATCH=$(awk '/^#define TRT_PATCH_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
-    TRT_BUILD=$(awk '/^#define TRT_BUILD_ENTERPRISE/ {print $3}' ${STAGING_INCDIR}/NvInferVersion.h)
-    TRT_VERSION=${TRT_MAJOR}.${TRT_MINOR}.${TRT_PATCH}.${TRT_BUILD}
     TRT_MAJMINPATCH=${TRT_MAJOR}.${TRT_MINOR}.${TRT_PATCH}
     varsubst() {
-        sed -e "s|\#\#TENSORRT_VERSION\#\#|${TRT_VERSION}|g" \
-	    -e "s|\#\#TENSORRT_MAJMINPATCH\#\#|${TRT_MAJMINPATCH}|g" \
-	    -e "s|\#\#TENSORRT_PYTHON_VERSION\#\#|${TRT_MAJMINPATCH}|g" \
-	    -e "s|\#\#TENSORRT_PLUGIN_DISABLED\#\#|\"0\"|g" \
+        sed -e "s|\#\#TENSORRT_PYTHON_VERSION\#\#|${TRT_MAJMINPATCH}|g" \
+	    -e "s|\#\#TENSORRT_PLUGIN_DISABLED\#\#|False|g" \
+	    -e "s|\#\#TENSORRT_NVINFER_NAME\#\#|nvinfer|g" \
+	    -e "s|\#\#TENSORRT_ONNXPARSER_NAME\#\#|nvonnxparser|g" \
+	    -e "s|\#\#TENSORRT_MAJOR\#\#|${TRT_MAJOR}|g" \
+	    -e "s|\#\#TENSORRT_MINOR\#\#|${TRT_MINOR}|g" \
 	    -e "s|\#\#TENSORRT_MODULE\#\#|tensorrt|g" $1 >$2
     }
 
     rm -rf ${B}/tensorrt
     mkdir ${B}/tensorrt
-    varsubst ${S}/python/packaging/bindings_wheel/setup.cfg ${B}/setup.cfg
-    varsubst ${S}/python/packaging/bindings_wheel/setup.py ${B}/setup.py
     varsubst ${S}/python/packaging/bindings_wheel/tensorrt/__init__.py ${B}/tensorrt/__init__.py
-    cp ${S}/python/packaging/bindings_wheel/LICENSE.txt ${B}/
-}
-
-do_compile() {
-    cmake_do_compile
-    setuptools3_do_compile
+    cp -R --preserve=mode,timestamps ${S}/python/packaging/bindings_wheel/tensorrt/plugin ${B}/tensorrt/
 }
 
 do_install() {
-    setuptools3_do_install
+    install -d ${D}${PYTHON_SITEPACKAGES_DIR}/tensorrt
+    install -m 0644 ${B}/tensorrt/__init__.py ${D}${PYTHON_SITEPACKAGES_DIR}/tensorrt/
+    install -m 0755 ${B}/tensorrt/tensorrt.so ${D}${PYTHON_SITEPACKAGES_DIR}/tensorrt/
+    cp -R --preserve=mode,timestamps ${B}/tensorrt/plugin ${D}${PYTHON_SITEPACKAGES_DIR}/tensorrt/
 }
 
-RDEPENDS:${PN} = "python3-ctypes python3-numpy tensorrt-plugins"
+FILES:${PN} += "${PYTHON_SITEPACKAGES_DIR}"
+
+RDEPENDS:${PN} = "python3-core python3-ctypes python3-numpy tensorrt-plugins"

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins/0001-CMakeLists.txt-fix-cross-compilation-issues.patch
@@ -3,30 +3,38 @@ From: Ilies CHERGUI <ilies.chergui@gmail.com>
 Date: Mon, 14 Oct 2024 04:13:16 -0700
 Subject: [PATCH] CMakeLists.txt: fix cross compilation issues
 
+ * Use the protobuf from the target sysroot instead of building and
+   installing an internal copy (new BUILD_PROTOBUF option, off by
+   default).
+ * Pull in GNUInstallDirs, otherwise the install directories are empty.
+ * Link against the shared CUDA runtime from the target sysroot
+   (CUDA_TOOLKIT_TARGET_DIR) rather than the static one from the native
+   toolkit.
+ * Drop SOURCE_LENGTH, which bakes the build path into the objects.
+
 Upstream-Status: Pending
 Signed-off-by: Ilies CHERGUI <ilies.chergui@gmail.com>
 Signed-off-by: Matt Madison <matt@madison.systems>
 Signed-off-by: Kurt Kiefer <kekiefer@gmail.com>
 ---
- CMakeLists.txt             | 17 ++++++++++++++---
- parsers/CMakeLists.txt     |  9 ++++++---
- plugin/CMakeLists.txt      | 14 ++++++++++----
- third_party/protobuf.cmake |  2 +-
- 4 files changed, 31 insertions(+), 11 deletions(-)
+ CMakeLists.txt              | 24 +++++++++++++-----------
+ parsers/CMakeLists.txt      |  7 +++++--
+ parsers/onnx/CMakeLists.txt |  4 ----
+ 3 files changed, 18 insertions(+), 17 deletions(-)
 
 Index: git/CMakeLists.txt
 ===================================================================
 --- git.orig/CMakeLists.txt
 +++ git/CMakeLists.txt
-@@ -78,6 +78,7 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_T
- option(BUILD_PLUGINS "Build TensorRT plugin" ON)
- option(BUILD_PARSERS "Build TensorRT parsers" ON)
+@@ -124,6 +124,7 @@
  option(BUILD_SAMPLES "Build TensorRT samples" ON)
+ option(BUILD_SAFE_SAMPLES "Build TensorRT safety samples" OFF)
+ option(TRT_SAFETY_INFERENCE_ONLY "Build only the safety inference components (no safety builders)" OFF)
 +option(BUILD_PROTOBUF "Build internal copy of protobuf" OFF)
  
- # C++14
- set(CMAKE_CXX_STANDARD 14)
-@@ -90,6 +91,9 @@ else()
+ ############################################################################################
+ # Early dependency discovery
+@@ -261,6 +262,9 @@
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DBUILD_SYSTEM=cmake_oss")
  endif()
  
@@ -36,19 +44,19 @@ Index: git/CMakeLists.txt
  ############################################################################################
  # Cross-compilation settings
  
-@@ -122,7 +126,7 @@ message(STATUS "Protobuf version set to
+@@ -287,7 +291,7 @@
+ set_ifndef(PROTOBUF_VERSION ${DEFAULT_PROTOBUF_VERSION})
+ message(STATUS "Protobuf version set to ${PROTOBUF_VERSION}")
  
- set(THREADS_PREFER_PTHREAD_FLAG ON)
- find_package(Threads REQUIRED)
 -if (BUILD_PLUGINS OR BUILD_PARSERS)
 +if (BUILD_PROTOBUF)
      include(third_party/protobuf.cmake)
  endif()
  if(NOT CUB_ROOT_DIR)
-@@ -139,8 +143,10 @@ endif()
- include_directories(
-     ${CUDA_INCLUDE_DIRS}
- )
+@@ -296,8 +300,10 @@
+   endif()
+ endif()
+ 
 -if(BUILD_PARSERS)
 +if(BUILD_PROTOBUF)
      configure_protobuf(${PROTOBUF_VERSION})
@@ -56,119 +64,65 @@ Index: git/CMakeLists.txt
 +    find_package(Protobuf REQUIRED)
  endif()
  
- # Windows library names have major version appended.
-@@ -158,7 +164,7 @@ endif()
+ # Define library names
+@@ -323,14 +329,10 @@
+ if (DEFINED USE_CUGFX)
+     find_library(CUDART_LIB cugfx_dll HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib/x64 lib64)
+ else()
+-    # DriveOS platforms use cudart.so instead of cudart_static. This isn't the most sophisticated check, but it's correct.
+-    if(CUDA_VERSION VERSION_GREATER_EQUAL 12.0)
+-        set(CUDART_LIB_NAME cudart_static)
+-        set(CMAKE_CUDA_RUNTIME_LIBRARY "static")
+-    else()
+-        set(CUDART_LIB_NAME cudart)
+-        set(CMAKE_CUDA_RUNTIME_LIBRARY "shared")
+-    endif()
++    # Cross-compiled builds link against the shared CUDA runtime from the target
++    # sysroot rather than the static one.
++    set(CUDART_LIB_NAME cudart)
++    set(CMAKE_CUDA_RUNTIME_LIBRARY "shared")
  
- find_library_create_target(nvinfer ${nvinfer_lib_name} SHARED ${TRT_LIB_DIR})
+     # SafeCUDA (QNX-Safe) does not ship libcudadevrt. When CMAKE_CUDA_RUNTIME_LIBRARY
+     # is "shared" or "static", CMake automatically links -lcudadevrt for targets with
+@@ -341,7 +343,7 @@
+         set(CMAKE_CUDA_RUNTIME_LIBRARY "None")
+     endif()
  
--find_library(CUDART_LIB cudart_static HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib/x64 lib64)
-+find_library(CUDART_LIB cudart HINTS ${CUDA_TOOLKIT_TARGET_DIR} PATH_SUFFIXES lib lib64)
+-    find_library(CUDART_LIB ${CUDART_LIB_NAME} HINTS ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib/x64 lib64)
++    find_library(CUDART_LIB ${CUDART_LIB_NAME} HINTS ${CUDA_TOOLKIT_TARGET_DIR} ${CUDA_TOOLKIT_ROOT_DIR} PATH_SUFFIXES lib lib/x64 lib64)
+ endif()
  
  if (NOT MSVC)
-     find_library(RT_LIB rt)
-@@ -169,6 +175,10 @@ set(CUDA_LIBRARIES ${CUDART_LIB})
- ############################################################################################
- # CUDA targets
- 
-+if (SKIP_GPU_ARCHS)
-+  set(GENCODES "")
-+  set(BERT_GENCODES "")
-+else()
- if (DEFINED GPU_ARCHS)
-   message(STATUS "GPU_ARCHS defined as ${GPU_ARCHS}. Generating CUDA code for SM ${GPU_ARCHS}")
-   separate_arguments(GPU_ARCHS)
-@@ -214,6 +224,7 @@ set(GENCODES "${GENCODES} -gencode arch=
- if (${LATEST_SM} GREATER_EQUAL 70)
-     set(BERT_GENCODES "${BERT_GENCODES} -gencode arch=compute_${LATEST_SM},code=compute_${LATEST_SM}")
- endif()
-+endif()
- 
- if(NOT MSVC)
-     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr -Xcompiler -Wno-deprecated-declarations")
 Index: git/parsers/CMakeLists.txt
 ===================================================================
 --- git.orig/parsers/CMakeLists.txt
 +++ git/parsers/CMakeLists.txt
-@@ -19,14 +19,17 @@
- add_custom_target(parsers DEPENDS
-     nvonnxparser)
+@@ -18,8 +18,10 @@
+ ############################# GENERATE C++ PROTO FILES ###################################
+ add_custom_target(parsers DEPENDS nvonnxparser)
  
 -add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
--add_compile_options("-Dgoogle=google_private")
+-add_compile_options("-Dgoogle=google_trtrepack")
 +if(BUILD_PROTOBUF)
 +    add_definitions("-D_PROTOBUF_INSTALL_DIR=${Protobuf_INSTALL_DIR}")
-+    add_compile_options("-Dgoogle=google_private")
++    add_compile_options("-Dgoogle=google_trtrepack")
 +endif()
  set(TENSORRT_ROOT ${PROJECT_SOURCE_DIR})
- set(TENSORRT_BUILD ${TRT_OUT_DIR} ${TRT_LIB_DIR})
- set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TRT_OUT_DIR})
+ set(TENSORRT_BUILD ${TRT_OUT_DIR})
+ 
+@@ -33,6 +35,7 @@
  
  include_directories(
     ${Protobuf_INCLUDE_DIR}
--)
 +   ${PROJECT_SOURCE_DIR}/include
-+ )
- 
- add_subdirectory(onnx)
-Index: git/plugin/CMakeLists.txt
-===================================================================
---- git.orig/plugin/CMakeLists.txt
-+++ git/plugin/CMakeLists.txt
-@@ -29,7 +29,8 @@ set(VFC_PLUGIN_EXPORT_MAP ${TARGET_DIR}/
- if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
- endif()
--set(ENABLED_SMS "-DENABLE_SM72 -DENABLE_SM75 -DENABLE_SM80 -DENABLE_SM86 -DENABLE_SM87 -DENABLE_SM89 -DENABLE_SM90")
-+
-+message(STATUS "Enabled SM: ${ENABLED_SMS}")
- set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ENABLED_SMS}")
- set(PLUGIN_SOURCES)
- set(PLUGIN_CU_SOURCES)
-@@ -75,7 +76,7 @@ set(PLUGIN_LISTS
  )
  
- # Add BERT sources if ${BERT_GENCODES} was populated
--if(BERT_GENCODES)
-+if(DEFINED BERT_GENCODES)
-     set(BERT_CU_SOURCES)
-     set(PLUGIN_LISTS
-         ${PLUGIN_LISTS}
-@@ -99,10 +100,15 @@ endforeach(PLUGIN_ITER)
- add_subdirectory(common)
- 
- # Set gencodes
--set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS "${GENCODES} ${ENABLED_SMS}")
-+if(GENCODES)
-+    set_source_files_properties(${PLUGIN_CU_SOURCES} PROPERTIES COMPILE_FLAGS "${GENCODES} ${ENABLED_SMS}")
-+endif()
-+
- list(APPEND PLUGIN_SOURCES "${PLUGIN_CU_SOURCES}")
- if (BERT_CU_SOURCES)
--    set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS "${BERT_GENCODES} ${ENABLED_SMS}")
-+    if(BERT_GENCODES)
-+        set_source_files_properties(${BERT_CU_SOURCES} PROPERTIES COMPILE_FLAGS "${BERT_GENCODES} ${ENABLED_SMS}")
-+    endif()
-     list(APPEND PLUGIN_SOURCES "${BERT_CU_SOURCES}")
- endif()
- 
-Index: git/third_party/protobuf.cmake
-===================================================================
---- git.orig/third_party/protobuf.cmake
-+++ git/third_party/protobuf.cmake
-@@ -209,7 +209,7 @@ function(protobuf_generate_cpp SRCS HDRS
-             COMMAND ${Protobuf_PROTOC_EXECUTABLE}
-             ARGS --cpp_out ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_DIR} -I${CMAKE_CURRENT_SOURCE_DIR}/${PROTO_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${proto}
-             WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
--            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${proto}" protobuf::libprotobuf Protobuf protobuf::protoc
-+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${proto}" protobuf::libprotobuf
-             COMMENT "${proto} -> ${PROTO_DIR}/${PROTO_SRC} ${PROTO_DIR}/${PROTO_HEADER}"
-         )
- 
+ add_subdirectory(onnx)
 Index: git/parsers/onnx/CMakeLists.txt
 ===================================================================
 --- git.orig/parsers/onnx/CMakeLists.txt
 +++ git/parsers/onnx/CMakeLists.txt
-@@ -20,10 +20,6 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+@@ -20,10 +20,6 @@
  
  set(PARSER_LINKER_SCRIPT  ${ONNX2TRT_ROOT}/libnvonnxparser.version)
  

--- a/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.16.bb
+++ b/external/openembedded-layer/recipes-devtools/gie/tensorrt-plugins_10.16.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "NVIDIA TensorRT Plugins for deep learning"
 HOMEPAGE = "http://developer.nvidia.com/tensorrt"
 LICENSE = "Apache-2.0 AND BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = " \
-  file://LICENSE;md5=5feff12211c5116f88277308f4b88a64 \
+  file://LICENSE;md5=99db4b09478f3c2b0a11901785687034 \
   file://third_party/cub/LICENSE.TXT;md5=20d1414b801e2a130d7d546685105508 \
   file://parsers/onnx/third_party/onnx/LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57 \
   file://parsers/onnx/LICENSE;md5=aa3e92f9f2b6da1568c23ceaec468692 \
@@ -11,13 +11,13 @@ LIC_FILES_CHKSUM = " \
 inherit cuda cmake pkgconfig
 
 SRC_REPO = "github.com/NVIDIA/TensorRT.git;protocol=https"
-SRCBRANCH = "release/10.3"
+SRCBRANCH = "release/10.16"
 SRC_URI = "gitsm://${SRC_REPO};branch=${SRCBRANCH} \
     file://0001-CMakeLists.txt-fix-cross-compilation-issues.patch \
 "
 
-# v10.3.0 tag
-SRCREV = "c5b9de37f7ef9034e2efc621c664145c7c12436e"
+# v10.16 tag
+SRCREV = "52399f555c2f80cb690a4a558b604e1a5f227e7c"
 
 DEPENDS += "zlib cuda-cudart cuda-nvrtc protobuf protobuf-native tensorrt-core"
 
@@ -30,11 +30,11 @@ PACKAGECONFIG ??= " \
 PACKAGECONFIG[plugin] = "-DBUILD_PLUGINS=ON,-DBUILD_PLUGINS=OFF,"
 PACKAGECONFIG[parsers] = "-DBUILD_PARSERS=ON,-DBUILD_PARSERS=OFF,"
 
-EXTRA_OECMAKE = '-DBUILD_SAMPLES=OFF -DSKIP_GPU_ARCHS=ON -DTRT_PLATFORM_ID="${TARGET_ARCH}" \
+EXTRA_OECMAKE = '-DBUILD_SAMPLES=OFF -DTRT_PLATFORM_ID="${TARGET_ARCH}" \
+  -DGPU_ARCHS="${TEGRA_CUDA_ARCHITECTURE}" \
   -DCUDA_VERSION="${CUDA_VERSION}" \
   -DCUDA_INCLUDE_DIRS="${STAGING_DIR_HOST}/usr/local/cuda-${CUDA_VERSION}/include" \
-  -DENABLED_SMS="-DENABLE_SM${TEGRA_CUDA_ARCHITECTURE}" \
-  -DSTABLE_DIFFUSION_GENCODES="-gencode arch=compute_${TEGRA_CUDA_ARCHITECTURE},code=compute_${TEGRA_CUDA_ARCHITECTURE}" \
+  -DTENSORRT_PYTHON_INCLUDE_DIR="${S}/include/impl" \
   -DProtobuf_LIBRARY="${STAGING_LIBDIR}/libprotobuf.so" \
   -DProtobuf_PROTOC_EXECUTABLE="${STAGING_BINDIR_NATIVE}/protoc" \
   -DONNX_CUSTOM_PROTOC_EXECUTABLE="${STAGING_BINDIR_NATIVE}/protoc" \


### PR DESCRIPTION
## Validation: TensorRT on Tegra264 (Thor) and Tegra234 (Orin)

Tested the TensorRT C++ sample suite and the TensorRT Python bindings on two
Jetson devkits. **22 of 22 tests pass, no failures and no skips on either
board.**

### Platforms

Both boards ran the same image lineage, so results are directly comparable:

| | Tegra264 | Tegra234 |
|---|---|---|
| Board | NVIDIA Jetson AGX Thor Developer Kit | NVIDIA Jetson AGX Orin Developer Kit (p3737-0000+p3701-0005) |
| L4T | R39, REVISION 2.1, GCID 46758480 | R39, REVISION 2.1, GCID 46758480 |
| Kernel | 6.18.48-yocto-standard | 6.18.48-yocto-standard |
| TensorRT | 10.16.2 | 10.16.2 |
| CUDA runtime | 13.2 (`/usr/local/cuda-13.2/lib/libcudart.so.13`) | 13.2 (`/usr/local/cuda-13.2/lib/libcudart.so.13`) |
| Python / numpy | 3.14.7 / 2.5.2 | 3.14.7 / 2.5.2 |
| Display server | X11 (not required by either module) | X11 (not required by either module) |

Both runs were performed in **MAXN** power mode with `jetson_clocks` pinned.

### TensorRT C++ samples (`run-tensorrt-tests`) — 8/8 on both boards

| Test | Tegra264 | Tegra234 |
|---|---|---|
| dynamic_reshape | PASS | PASS |
| int8_api | PASS | PASS |
| onnx_mnist | PASS | PASS |
| io_formats | PASS | PASS |
| progress_monitor | PASS | PASS |
| editable_timing_cache | PASS | PASS |
| non_zero_plugin | PASS | PASS |
| trtexec | PASS | PASS |

`trtexec` is a real PASS on both, not a skip: `/usr/src/tensorrt/bin/trtexec`
is present and reports `TensorRT v101602`.

### TensorRT Python bindings — 3/3 on both boards

| Test | Tegra264 | Tegra234 |
|---|---|---|
| import/module | PASS | PASS |
| build/identity_engine | PASS (plan 12228 bytes) | PASS (plan 2580 bytes) |
| execute/identity_engine | PASS | PASS |

What these cover:

- **import** — `tensorrt` and `numpy` import and report versions, i.e. the
  native extension loads for this interpreter.
- **build** — `trt.Builder` / `create_network` / `add_identity` /
  `build_serialized_network`, then `deserialize_cuda_engine` and
  `create_execution_context`.
- **execute** — device buffers allocated via `libcudart` through `ctypes`
  (no pycuda/cupy/torch on these images), pointers bound with
  `set_tensor_address()`, inference launched with `execute_async_v3()`, result
  copied back and stream synchronized. The verdict is a value check
  (`assert_allclose(..., rtol=0, atol=0)`), so output must equal input exactly
  — this is what would catch a binding built for the wrong SM.

The differing serialized-plan size (12228 vs 2580 bytes) is the expected result
of building for different GPU architectures, not a discrepancy.
